### PR TITLE
feat: Phase 0 - Update action references for orchestrator fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
   claude-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: anthropics/claude-code-action@beta
+      - uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,7 +163,7 @@ on:
       - "src/api/**/*.ts"
 
 steps:
-  - uses: anthropics/claude-code-action@beta
+  - uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
     with:
       direct_prompt: |
         Update the API documentation in README.md to reflect
@@ -187,7 +187,7 @@ jobs:
       github.event.pull_request.user.login == 'developer1' ||
       github.event.pull_request.user.login == 'external-contributor'
     steps:
-      - uses: anthropics/claude-code-action@beta
+      - uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
         with:
           direct_prompt: |
             Please provide a thorough review of this pull request.
@@ -246,7 +246,7 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 **Note**: If your repository has a `.mcp.json` file in the root directory, Claude will automatically detect and use the MCP server tools defined there. However, these tools still need to be explicitly allowed via the `allowed_tools` configuration.
 
 ```yaml
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     allowed_tools: "Bash(npm install),Bash(npm run test),Edit,Replace,NotebookEditCell"
     disallowed_tools: "TaskOutput,KillTask"
@@ -260,7 +260,7 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 Use a specific Claude model:
 
 ```yaml
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     # model: "claude-3-5-sonnet-20241022"  # Optional: specify a different model
     # ... other inputs
@@ -288,20 +288,20 @@ Use provider-specific model names based on your chosen provider:
 
 ```yaml
 # For direct Anthropic API (default)
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     # ... other inputs
 
 # For Amazon Bedrock with OIDC
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     model: "anthropic.claude-3-7-sonnet-20250219-beta:0" # Cross-region inference
     use_bedrock: "true"
     # ... other inputs
 
 # For Google Vertex AI with OIDC
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
@@ -327,7 +327,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
@@ -352,7 +352,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-- uses: anthropics/claude-code-action@beta
+- uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"

--- a/examples/claude-auto-review.yml
+++ b/examples/claude-auto-review.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Automatic PR Review
-        uses: anthropics/claude-code-action@beta
+        uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"

--- a/examples/claude-pr-path-specific.yml
+++ b/examples/claude-pr-path-specific.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@beta
+        uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"

--- a/examples/claude-review-from-author.yml
+++ b/examples/claude-review-from-author.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Review PR from Specific Author
-        uses: anthropics/claude-code-action@beta
+        uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+        uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"

--- a/predev-docs/01-phase0-fork-update-design.md
+++ b/predev-docs/01-phase0-fork-update-design.md
@@ -5,6 +5,7 @@
 このフェーズでは、フォークしたリポジトリでオーケストレーション機能を開発するための基本的な参照更新を行います。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -18,10 +19,11 @@
 #### 対象ファイル
 
 1. **README.md**
+
    - アクション使用例の更新
    - インストール手順の更新
 
-2. **examples/*.yml**
+2. **examples/\*.yml**
    - claude.yml
    - claude-auto-review.yml
    - claude-pr-path-specific.yml
@@ -43,44 +45,48 @@ uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
 
 ```typescript
 // test/fork-update.test.ts
-import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 
-describe('Fork Update Validation', () => {
-  const rootDir = join(__dirname, '..');
+describe("Fork Update Validation", () => {
+  const rootDir = join(__dirname, "..");
 
-  test('README.md should reference forked action', () => {
-    const readme = readFileSync(join(rootDir, 'README.md'), 'utf-8');
-    expect(readme).not.toContain('anthropics/claude-code-action@beta');
-    expect(readme).toContain('MasashiFukuzawa/claude-code-action@orchestrator-alpha');
+  test("README.md should reference forked action", () => {
+    const readme = readFileSync(join(rootDir, "README.md"), "utf-8");
+    expect(readme).not.toContain("anthropics/claude-code-action@beta");
+    expect(readme).toContain(
+      "MasashiFukuzawa/claude-code-action@orchestrator-alpha",
+    );
   });
 
-  test('all example files should reference forked action', () => {
+  test("all example files should reference forked action", () => {
     const exampleFiles = [
-      'claude.yml',
-      'claude-auto-review.yml',
-      'claude-pr-path-specific.yml',
-      'claude-review-from-author.yml'
+      "claude.yml",
+      "claude-auto-review.yml",
+      "claude-pr-path-specific.yml",
+      "claude-review-from-author.yml",
     ];
 
-    exampleFiles.forEach(file => {
-      const content = readFileSync(join(rootDir, 'examples', file), 'utf-8');
-      expect(content).not.toContain('anthropics/claude-code-action@beta');
-      expect(content).toContain('MasashiFukuzawa/claude-code-action@orchestrator-alpha');
+    exampleFiles.forEach((file) => {
+      const content = readFileSync(join(rootDir, "examples", file), "utf-8");
+      expect(content).not.toContain("anthropics/claude-code-action@beta");
+      expect(content).toContain(
+        "MasashiFukuzawa/claude-code-action@orchestrator-alpha",
+      );
     });
   });
 
-  test('should maintain YAML structure integrity', () => {
+  test("should maintain YAML structure integrity", () => {
     const exampleFiles = [
-      'claude.yml',
-      'claude-auto-review.yml',
-      'claude-pr-path-specific.yml',
-      'claude-review-from-author.yml'
+      "claude.yml",
+      "claude-auto-review.yml",
+      "claude-pr-path-specific.yml",
+      "claude-review-from-author.yml",
     ];
 
-    exampleFiles.forEach(file => {
-      const content = readFileSync(join(rootDir, 'examples', file), 'utf-8');
+    exampleFiles.forEach((file) => {
+      const content = readFileSync(join(rootDir, "examples", file), "utf-8");
       // YAMLの基本構造が保たれていることを確認
       expect(content).toMatch(/^name:/m);
       expect(content).toMatch(/^\s+uses:/m);
@@ -94,19 +100,19 @@ describe('Fork Update Validation', () => {
 
 ```typescript
 // scripts/update-fork-references.ts
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { glob } from 'glob';
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { glob } from "glob";
 
-const OLD_REFERENCE = 'anthropics/claude-code-action@beta';
-const NEW_REFERENCE = 'MasashiFukuzawa/claude-code-action@orchestrator-alpha';
+const OLD_REFERENCE = "anthropics/claude-code-action@beta";
+const NEW_REFERENCE = "MasashiFukuzawa/claude-code-action@orchestrator-alpha";
 
 function updateFile(filePath: string): boolean {
-  const content = readFileSync(filePath, 'utf-8');
+  const content = readFileSync(filePath, "utf-8");
   if (content.includes(OLD_REFERENCE)) {
     const updatedContent = content.replace(
-      new RegExp(OLD_REFERENCE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
-      NEW_REFERENCE
+      new RegExp(OLD_REFERENCE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+      NEW_REFERENCE,
     );
     writeFileSync(filePath, updatedContent);
     console.log(`✅ Updated: ${filePath}`);
@@ -116,10 +122,7 @@ function updateFile(filePath: string): boolean {
 }
 
 async function main() {
-  const files = [
-    'README.md',
-    ...await glob('examples/*.yml')
-  ];
+  const files = ["README.md", ...(await glob("examples/*.yml"))];
 
   let updatedCount = 0;
   for (const file of files) {
@@ -137,6 +140,7 @@ main().catch(console.error);
 ## コミット計画
 
 ### コミット1: テストの追加
+
 ```bash
 # プリコミットチェック
 bun test
@@ -149,6 +153,7 @@ git commit -m "test: add tests for fork reference updates"
 ```
 
 ### コミット2: 更新スクリプトとREADME更新
+
 ```bash
 # プリコミットチェック
 bun test
@@ -161,6 +166,7 @@ git commit -m "feat: update README action references for orchestrator fork"
 ```
 
 ### コミット3: サンプルファイルの更新
+
 ```bash
 # プリコミットチェック
 bun test
@@ -175,6 +181,7 @@ git commit -m "feat: update example workflows for orchestrator fork"
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. feature/orchestrator-alpha から作業ブランチを作成
 git checkout feature/orchestrator-alpha
@@ -205,6 +212,7 @@ git branch -d phase0-fork-update # ローカルの作業ブランチを削除
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. feature/orchestrator-alpha から作業ブランチ作成
 git checkout feature/orchestrator-alpha
@@ -250,10 +258,12 @@ git branch -d phase0-fork-update
 ## 検証項目
 
 1. **参照の完全性**
+
    - すべての `anthropics/claude-code-action@beta` が置換されている
    - 新しい参照が正しい形式である
 
 2. **ファイルの整合性**
+
    - YAMLファイルの構文が正しい
    - Markdownのフォーマットが保たれている
 
@@ -264,12 +274,14 @@ git branch -d phase0-fork-update
 ## リスクと対策
 
 ### リスク1: 不完全な置換
+
 - **対策**: grepで確認
   ```bash
   grep -r "anthropics/claude-code-action" .
   ```
 
 ### リスク2: YAMLの破損
+
 - **対策**: YAML linterの使用
   ```bash
   # yamllintがインストールされている場合
@@ -286,5 +298,6 @@ git branch -d phase0-fork-update
 ## 次のステップ
 
 フェーズ0完了後、以下のフェーズを並列で開始可能：
+
 - フェーズ1.1: モードシステム（型定義）
 - フェーズ1.2: タスクシステム（型定義）

--- a/predev-docs/01-phase0-fork-update-design.md
+++ b/predev-docs/01-phase0-fork-update-design.md
@@ -1,0 +1,290 @@
+# フェーズ0: フォーク対応 - 詳細設計
+
+## 概要
+
+このフェーズでは、フォークしたリポジトリでオーケストレーション機能を開発するための基本的な参照更新を行います。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## 実装タスク
+
+### タスク0.1: アクション参照の更新
+
+#### 対象ファイル
+
+1. **README.md**
+   - アクション使用例の更新
+   - インストール手順の更新
+
+2. **examples/*.yml**
+   - claude.yml
+   - claude-auto-review.yml
+   - claude-pr-path-specific.yml
+   - claude-review-from-author.yml
+
+#### 変更内容
+
+```yaml
+# 変更前
+uses: anthropics/claude-code-action@beta
+
+# 変更後
+uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
+```
+
+## TDD実装計画
+
+### テストケース設計
+
+```typescript
+// test/fork-update.test.ts
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('Fork Update Validation', () => {
+  const rootDir = join(__dirname, '..');
+
+  test('README.md should reference forked action', () => {
+    const readme = readFileSync(join(rootDir, 'README.md'), 'utf-8');
+    expect(readme).not.toContain('anthropics/claude-code-action@beta');
+    expect(readme).toContain('MasashiFukuzawa/claude-code-action@orchestrator-alpha');
+  });
+
+  test('all example files should reference forked action', () => {
+    const exampleFiles = [
+      'claude.yml',
+      'claude-auto-review.yml',
+      'claude-pr-path-specific.yml',
+      'claude-review-from-author.yml'
+    ];
+
+    exampleFiles.forEach(file => {
+      const content = readFileSync(join(rootDir, 'examples', file), 'utf-8');
+      expect(content).not.toContain('anthropics/claude-code-action@beta');
+      expect(content).toContain('MasashiFukuzawa/claude-code-action@orchestrator-alpha');
+    });
+  });
+
+  test('should maintain YAML structure integrity', () => {
+    const exampleFiles = [
+      'claude.yml',
+      'claude-auto-review.yml',
+      'claude-pr-path-specific.yml',
+      'claude-review-from-author.yml'
+    ];
+
+    exampleFiles.forEach(file => {
+      const content = readFileSync(join(rootDir, 'examples', file), 'utf-8');
+      // YAMLの基本構造が保たれていることを確認
+      expect(content).toMatch(/^name:/m);
+      expect(content).toMatch(/^\s+uses:/m);
+      expect(content).toMatch(/^\s+with:/m);
+    });
+  });
+});
+```
+
+### 実装スクリプト
+
+```typescript
+// scripts/update-fork-references.ts
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { glob } from 'glob';
+
+const OLD_REFERENCE = 'anthropics/claude-code-action@beta';
+const NEW_REFERENCE = 'MasashiFukuzawa/claude-code-action@orchestrator-alpha';
+
+function updateFile(filePath: string): boolean {
+  const content = readFileSync(filePath, 'utf-8');
+  if (content.includes(OLD_REFERENCE)) {
+    const updatedContent = content.replace(
+      new RegExp(OLD_REFERENCE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+      NEW_REFERENCE
+    );
+    writeFileSync(filePath, updatedContent);
+    console.log(`✅ Updated: ${filePath}`);
+    return true;
+  }
+  return false;
+}
+
+async function main() {
+  const files = [
+    'README.md',
+    ...await glob('examples/*.yml')
+  ];
+
+  let updatedCount = 0;
+  for (const file of files) {
+    if (updateFile(file)) {
+      updatedCount++;
+    }
+  }
+
+  console.log(`\n✨ Updated ${updatedCount} files`);
+}
+
+main().catch(console.error);
+```
+
+## コミット計画
+
+### コミット1: テストの追加
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add test/fork-update.test.ts
+git commit -m "test: add tests for fork reference updates"
+```
+
+### コミット2: 更新スクリプトとREADME更新
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add scripts/update-fork-references.ts README.md
+git commit -m "feat: update README action references for orchestrator fork"
+```
+
+### コミット3: サンプルファイルの更新
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add examples/*.yml
+git commit -m "feat: update example workflows for orchestrator fork"
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. feature/orchestrator-alpha から作業ブランチを作成
+git checkout feature/orchestrator-alpha
+git pull origin feature/orchestrator-alpha # 念のため最新化
+git checkout -b phase0-fork-update feature/orchestrator-alpha
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat: update action references for fork"
+
+# 5. プッシュしてPR作成
+git push origin phase0-fork-update
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは feature/orchestrator-alpha とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout feature/orchestrator-alpha
+git pull origin feature/orchestrator-alpha # リモートの変更を取り込み最新化
+git branch -d phase0-fork-update # ローカルの作業ブランチを削除
+# git push origin --delete phase0-fork-update # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. feature/orchestrator-alpha から作業ブランチ作成
+git checkout feature/orchestrator-alpha
+git pull origin feature/orchestrator-alpha # 念のため最新化
+git checkout -b phase0-fork-update feature/orchestrator-alpha
+
+# プロジェクトルートで作業を進める
+
+# 2. テストファイル作成
+mkdir -p test
+# test/fork-update.test.ts を作成 (内容はドキュメントの「テストケース設計」を参照)
+
+# 3. テスト実行（失敗確認）
+bun test test/fork-update.test.ts
+
+# 4. 更新スクリプト作成
+mkdir -p scripts
+# scripts/update-fork-references.ts を作成 (内容はドキュメントの「実装スクリプト」を参照)
+
+# 5. スクリプト実行
+bun run scripts/update-fork-references.ts
+
+# 6. テスト再実行（成功確認）
+bun test test/fork-update.test.ts
+
+# 7. 全体チェック
+bun test && bun run format:check && bun run typecheck
+
+# 8. コミット
+git add .
+git commit -m "feat: update action references for fork"
+
+# 9. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase0-fork-update
+# GitHub上で feature/orchestrator-alpha をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout feature/orchestrator-alpha
+git pull origin feature/orchestrator-alpha
+git branch -d phase0-fork-update
+```
+
+## 検証項目
+
+1. **参照の完全性**
+   - すべての `anthropics/claude-code-action@beta` が置換されている
+   - 新しい参照が正しい形式である
+
+2. **ファイルの整合性**
+   - YAMLファイルの構文が正しい
+   - Markdownのフォーマットが保たれている
+
+3. **機能の維持**
+   - 既存の機能に影響がない
+   - ドキュメントの読みやすさが維持されている
+
+## リスクと対策
+
+### リスク1: 不完全な置換
+- **対策**: grepで確認
+  ```bash
+  grep -r "anthropics/claude-code-action" .
+  ```
+
+### リスク2: YAMLの破損
+- **対策**: YAML linterの使用
+  ```bash
+  # yamllintがインストールされている場合
+  yamllint examples/*.yml
+  ```
+
+## 完了基準
+
+- [ ] すべてのテストが通る
+- [ ] フォーマットチェックが通る
+- [ ] 旧参照が残っていない
+- [ ] PRがorchestrator-alphaブランチにマージされる
+
+## 次のステップ
+
+フェーズ0完了後、以下のフェーズを並列で開始可能：
+- フェーズ1.1: モードシステム（型定義）
+- フェーズ1.2: タスクシステム（型定義）

--- a/predev-docs/02-phase1-mode-system-design.md
+++ b/predev-docs/02-phase1-mode-system-design.md
@@ -1,0 +1,497 @@
+# フェーズ1.1: 組み込みモードシステム - 詳細設計
+
+## 概要
+
+組み込みモードシステムは、タスクの性質に応じて異なるAIの振る舞いを定義する基盤機能です。Code、Architect、Debug、Ask、Orchestratorの5つの組み込みモードを実装します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class Mode {
+        <<interface>>
+        +slug: string
+        +name: string
+        +roleDefinition: string
+        +groups: string[]
+        +customInstructions?: string
+        +defaultLLMProvider?: string
+    }
+
+    class ModeManager {
+        -modes: Map<string, Mode>
+        +getModeBySlug(slug: string): Mode
+        +getAllModes(): Mode[]
+        +getDefaultMode(): Mode
+    }
+
+    class BuiltInModes {
+        +CODE: Mode
+        +ARCHITECT: Mode
+        +DEBUG: Mode
+        +ASK: Mode
+        +ORCHESTRATOR: Mode
+    }
+
+    ModeManager --> Mode : manages
+    BuiltInModes ..> Mode : implements
+```
+
+## TDD実装計画
+
+### タスク1.1.1: モード定義の作成
+
+#### 実装: src/modes/types.ts
+
+```typescript
+export const VALID_GROUPS = [
+  'file_operations',
+  'git_operations',
+  'code_analysis',
+  'testing',
+  'read_operations',
+  'write_operations',
+  'documentation',
+  'analysis',
+  'diagnostic_tools',
+  'logging',
+  'search',
+  'task_management',
+  'mode_switching',
+  'context_optimization'
+] as const;
+
+export type ValidGroup = typeof VALID_GROUPS[number];
+
+export interface Mode {
+  slug: string;
+  name: string;
+  roleDefinition: string;
+  groups: ValidGroup[];
+  customInstructions?: string;
+  defaultLLMProvider?: string;
+}
+
+export interface ModeContext {
+  mode: Mode;
+  previousResults?: string[];
+  globalContext?: Record<string, any>;
+}
+
+export type ModeSlug = 'code' | 'architect' | 'debug' | 'ask' | 'orchestrator' | string;
+```
+
+### タスク1.1.2: 組み込みモードの実装
+
+#### テストファースト: src/modes/built-in-modes.ts
+
+```typescript
+// test/modes/built-in-modes.test.ts
+import { describe, test, expect } from 'bun:test';
+import { BUILT_IN_MODES } from '../../src/modes/built-in-modes';
+
+describe('Built-in Modes', () => {
+  test('should define CODE mode correctly', () => {
+    const codeMode = BUILT_IN_MODES.CODE;
+    expect(codeMode.slug).toBe('code');
+    expect(codeMode.name).toBe('Code');
+    expect(codeMode.roleDefinition).toContain('expert software developer');
+    expect(codeMode.groups).toContain('file_operations');
+    expect(codeMode.groups).toContain('git_operations');
+  });
+
+  test('should define ARCHITECT mode correctly', () => {
+    const architectMode = BUILT_IN_MODES.ARCHITECT;
+    expect(architectMode.slug).toBe('architect');
+    expect(architectMode.name).toBe('Architect');
+    expect(architectMode.roleDefinition).toContain('system architect');
+    expect(architectMode.groups).toContain('read_operations');
+    expect(architectMode.groups).not.toContain('write_operations');
+  });
+
+  test('should define DEBUG mode correctly', () => {
+    const debugMode = BUILT_IN_MODES.DEBUG;
+    expect(debugMode.slug).toBe('debug');
+    expect(debugMode.name).toBe('Debug');
+    expect(debugMode.roleDefinition).toContain('debugging expert');
+    expect(debugMode.groups).toContain('diagnostic_tools');
+  });
+
+  test('should define ASK mode correctly', () => {
+    const askMode = BUILT_IN_MODES.ASK;
+    expect(askMode.slug).toBe('ask');
+    expect(askMode.name).toBe('Ask');
+    expect(askMode.roleDefinition).toContain('knowledgeable assistant');
+    expect(askMode.groups).toContain('read_operations');
+  });
+
+  test('should define ORCHESTRATOR mode correctly', () => {
+    const orchestratorMode = BUILT_IN_MODES.ORCHESTRATOR;
+    expect(orchestratorMode.slug).toBe('orchestrator');
+    expect(orchestratorMode.name).toBe('Orchestrator');
+    expect(orchestratorMode.roleDefinition).toContain('task orchestrator');
+    expect(orchestratorMode.groups).toContain('task_management');
+  });
+
+  test('all modes should have required fields', () => {
+    Object.values(BUILT_IN_MODES).forEach(mode => {
+      expect(mode.slug).toBeTruthy();
+      expect(mode.name).toBeTruthy();
+      expect(mode.roleDefinition).toBeTruthy();
+      expect(Array.isArray(mode.groups)).toBe(true);
+      expect(mode.groups.length).toBeGreaterThan(0);
+    });
+  });
+});
+```
+
+#### 実装: src/modes/built-in-modes.ts
+
+```typescript
+import type { Mode } from './types';
+
+export const BUILT_IN_MODES = {
+  CODE: {
+    slug: 'code',
+    name: 'Code',
+    roleDefinition: `You are an expert software developer focused on implementation details.
+    Your primary goal is to write clean, efficient, and maintainable code.
+    You follow best practices and coding standards for the given language and framework.`,
+    groups: ['file_operations', 'git_operations', 'code_analysis', 'testing'],
+    customInstructions: `- Write idiomatic code for the target language
+- Include appropriate error handling
+- Follow existing code patterns in the repository
+- Write tests when implementing new functionality`
+  },
+
+  ARCHITECT: {
+    slug: 'architect',
+    name: 'Architect',
+    roleDefinition: `You are a system architect focused on high-level design and planning.
+    You analyze requirements, design system architectures, and make strategic technical decisions.
+    You prioritize scalability, maintainability, and alignment with business goals.`,
+    groups: ['read_operations', 'documentation', 'analysis'],
+    customInstructions: `- Focus on system design and architecture
+- Consider scalability and performance implications
+- Provide clear technical specifications
+- Document architectural decisions and trade-offs`
+  },
+
+  DEBUG: {
+    slug: 'debug',
+    name: 'Debug',
+    roleDefinition: `You are a debugging expert specialized in identifying and fixing issues.
+    You systematically analyze problems, use diagnostic tools effectively, and provide clear explanations of root causes.
+    You focus on not just fixing symptoms but addressing underlying issues.`,
+    groups: ['file_operations', 'diagnostic_tools', 'logging', 'testing'],
+    customInstructions: `- Systematically isolate the problem
+- Use appropriate debugging tools and techniques
+- Explain the root cause clearly
+- Implement fixes that prevent recurrence`
+  },
+
+  ASK: {
+    slug: 'ask',
+    name: 'Ask',
+    roleDefinition: `You are a knowledgeable assistant focused on providing clear, accurate information.
+    You explain concepts clearly, provide relevant examples, and ensure understanding.
+    You adapt your explanations to the user's level of expertise.`,
+    groups: ['read_operations', 'documentation', 'search'],
+    customInstructions: `- Provide clear, concise explanations
+- Use examples to illustrate concepts
+- Reference documentation when appropriate
+- Admit uncertainty rather than speculate`
+  },
+
+  ORCHESTRATOR: {
+    slug: 'orchestrator',
+    name: 'Orchestrator',
+    roleDefinition: `You are a task orchestrator responsible for breaking down complex tasks and delegating to appropriate modes.
+    You analyze task complexity, identify subtasks, and coordinate their execution.
+    You optimize for efficiency by providing each mode with focused, relevant context.`,
+    groups: ['task_management', 'mode_switching', 'context_optimization'],
+    customInstructions: `- Analyze task complexity and requirements
+- Break down tasks into appropriate subtasks
+- Select the optimal mode for each subtask
+- Minimize context size while maintaining effectiveness
+- Coordinate results between subtasks`
+  }
+} as const;
+
+export type BuiltInModeSlug = keyof typeof BUILT_IN_MODES;
+```
+
+### タスク1.1.3: モード管理システム
+
+#### テストファースト: src/modes/mode-manager.ts
+
+```typescript
+// test/modes/mode-manager.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { ModeManager } from '../../src/modes/mode-manager';
+import { BUILT_IN_MODES } from '../../src/modes/built-in-modes';
+import type { Mode } from '../../src/modes/types';
+
+describe('ModeManager', () => {
+  let manager: ModeManager;
+
+  beforeEach(() => {
+    manager = new ModeManager();
+  });
+
+  test('should initialize with built-in modes', () => {
+    const allModes = manager.getAllModes();
+    expect(allModes.length).toBe(5);
+
+    const slugs = allModes.map(m => m.slug);
+    expect(slugs).toContain('code');
+    expect(slugs).toContain('architect');
+    expect(slugs).toContain('debug');
+    expect(slugs).toContain('ask');
+    expect(slugs).toContain('orchestrator');
+  });
+
+  test('should get mode by slug', () => {
+    const codeMode = manager.getModeBySlug('code');
+    expect(codeMode).toEqual(BUILT_IN_MODES.CODE);
+
+    const architectMode = manager.getModeBySlug('architect');
+    expect(architectMode).toEqual(BUILT_IN_MODES.ARCHITECT);
+  });
+
+  test('should throw error for unknown mode', () => {
+    expect(() => manager.getModeBySlug('unknown')).toThrow('Mode not found: unknown');
+  });
+
+  test('should get default mode', () => {
+    const defaultMode = manager.getDefaultMode();
+    expect(defaultMode.slug).toBe('code');
+  });
+
+});
+```
+
+#### 実装: src/modes/mode-manager.ts
+
+```typescript
+import type { Mode, ValidGroup } from './types';
+import { BUILT_IN_MODES } from './built-in-modes';
+import { VALID_GROUPS } from './types';
+
+export class ModeManager {
+  private modes: Map<string, Mode>;
+
+  constructor() {
+    this.modes = new Map();
+    this.initializeBuiltInModes();
+  }
+
+  private initializeBuiltInModes(): void {
+    Object.values(BUILT_IN_MODES).forEach(mode => {
+      this.modes.set(mode.slug, mode);
+    });
+  }
+
+  getModeBySlug(slug: string): Mode {
+    const mode = this.modes.get(slug);
+    if (!mode) {
+      throw new Error(`Mode not found: ${slug}`);
+    }
+    return mode;
+  }
+
+  getAllModes(): Mode[] {
+    return Array.from(this.modes.values());
+  }
+
+  getDefaultMode(): Mode {
+    return this.getModeBySlug('code');
+  }
+
+  getBuiltInModes(): Mode[] {
+    return Object.values(BUILT_IN_MODES);
+  }
+}
+
+// Singleton instance
+export const modeManager = new ModeManager();
+```
+
+## コミット計画
+
+### コミット1: Mode型定義
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/modes/types.ts
+git commit -m "feat(modes): add Mode interface and type definitions"
+```
+
+### コミット2: 組み込みモード
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/modes/built-in-modes.ts test/modes/built-in-modes.test.ts
+git commit -m "feat(modes): implement built-in modes (Code, Architect, Debug, Ask, Orchestrator) with tests"
+```
+
+### コミット3: モードマネージャー
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/modes/mode-manager.ts test/modes/mode-manager.test.ts
+git commit -m "feat(modes): implement ModeManager for built-in mode retrieval with tests"
+```
+
+### コミット4: エクスポート設定
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/modes/index.ts
+git commit -m "feat(modes): add module exports for mode system"
+```
+
+## ディレクトリ構造
+
+```
+src/
+└── modes/
+    ├── types.ts           # Mode インターフェース定義
+    ├── built-in-modes.ts  # 組み込みモード定義
+    ├── mode-manager.ts    # モード管理システム
+    └── index.ts          # エクスポート
+
+test/
+└── modes/
+    ├── built-in-modes.test.ts
+    └── mode-manager.test.ts
+```
+
+## index.tsの実装
+
+```typescript
+// src/modes/index.ts
+export type { Mode, ModeContext, ModeSlug } from './types';
+export { BUILT_IN_MODES, type BuiltInModeSlug } from './built-in-modes';
+export { ModeManager, modeManager } from './mode-manager';
+```
+
+## 統合テスト
+
+```typescript
+// test/modes/integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { modeManager, type Mode } from '../../src/modes';
+
+describe('Mode System Integration', () => {
+  test('should handle mode switching workflow', () => {
+    // デフォルトモードから開始
+    const defaultMode = modeManager.getDefaultMode();
+    expect(defaultMode.slug).toBe('code');
+
+    // アーキテクトモードに切り替え
+    const architectMode = modeManager.getModeBySlug('architect');
+    expect(architectMode.groups).not.toContain('write_operations');
+
+    // デバッグモードに切り替え
+    const debugMode = modeManager.getModeBySlug('debug');
+    expect(debugMode.groups).toContain('diagnostic_tools');
+  });
+
+});
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase0-fork-update から作業ブランチを作成
+git checkout phase0-fork-update
+git pull origin phase0-fork-update # 念のため最新化
+git checkout -b phase1-mode-system phase0-fork-update
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(mode-system): implement mode system" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase1-mode-system
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase0-fork-update とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase0-fork-update
+git pull origin phase0-fork-update # リモートの変更を取り込み最新化
+git branch -d phase1-mode-system # ローカルの作業ブランチを削除
+# git push origin --delete phase1-mode-system # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase0-fork-update から作業ブランチ作成
+git checkout phase0-fork-update
+git pull origin phase0-fork-update # 念のため最新化
+git checkout -b phase1-mode-system phase0-fork-update
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(mode-system): implement mode system" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase1-mode-system
+# GitHub上で phase0-fork-update をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase0-fork-update
+git pull origin phase0-fork-update
+git branch -d phase1-mode-system
+```
+
+## 依存関係
+
+このフェーズは独立して実装可能です。以下のフェーズに必要となります：
+- フェーズ2.2: コンテキスト最適化（モード別の優先度設定）
+- フェーズ3.1: プロンプト生成の拡張（モード固有のプロンプト）
+
+## 次のステップ
+
+1. このモードシステムを基に、フェーズ2でタスク分析エンジンを実装
+2. フェーズ3でGitHub Actionsとの統合

--- a/predev-docs/02-phase1-mode-system-design.md
+++ b/predev-docs/02-phase1-mode-system-design.md
@@ -5,6 +5,7 @@
 組み込みモードシステムは、タスクの性質に応じて異なるAIの振る舞いを定義する基盤機能です。Code、Architect、Debug、Ask、Orchestratorの5つの組み込みモードを実装します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -52,23 +53,23 @@ classDiagram
 
 ```typescript
 export const VALID_GROUPS = [
-  'file_operations',
-  'git_operations',
-  'code_analysis',
-  'testing',
-  'read_operations',
-  'write_operations',
-  'documentation',
-  'analysis',
-  'diagnostic_tools',
-  'logging',
-  'search',
-  'task_management',
-  'mode_switching',
-  'context_optimization'
+  "file_operations",
+  "git_operations",
+  "code_analysis",
+  "testing",
+  "read_operations",
+  "write_operations",
+  "documentation",
+  "analysis",
+  "diagnostic_tools",
+  "logging",
+  "search",
+  "task_management",
+  "mode_switching",
+  "context_optimization",
 ] as const;
 
-export type ValidGroup = typeof VALID_GROUPS[number];
+export type ValidGroup = (typeof VALID_GROUPS)[number];
 
 export interface Mode {
   slug: string;
@@ -85,7 +86,13 @@ export interface ModeContext {
   globalContext?: Record<string, any>;
 }
 
-export type ModeSlug = 'code' | 'architect' | 'debug' | 'ask' | 'orchestrator' | string;
+export type ModeSlug =
+  | "code"
+  | "architect"
+  | "debug"
+  | "ask"
+  | "orchestrator"
+  | string;
 ```
 
 ### タスク1.1.2: 組み込みモードの実装
@@ -94,54 +101,54 @@ export type ModeSlug = 'code' | 'architect' | 'debug' | 'ask' | 'orchestrator' |
 
 ```typescript
 // test/modes/built-in-modes.test.ts
-import { describe, test, expect } from 'bun:test';
-import { BUILT_IN_MODES } from '../../src/modes/built-in-modes';
+import { describe, test, expect } from "bun:test";
+import { BUILT_IN_MODES } from "../../src/modes/built-in-modes";
 
-describe('Built-in Modes', () => {
-  test('should define CODE mode correctly', () => {
+describe("Built-in Modes", () => {
+  test("should define CODE mode correctly", () => {
     const codeMode = BUILT_IN_MODES.CODE;
-    expect(codeMode.slug).toBe('code');
-    expect(codeMode.name).toBe('Code');
-    expect(codeMode.roleDefinition).toContain('expert software developer');
-    expect(codeMode.groups).toContain('file_operations');
-    expect(codeMode.groups).toContain('git_operations');
+    expect(codeMode.slug).toBe("code");
+    expect(codeMode.name).toBe("Code");
+    expect(codeMode.roleDefinition).toContain("expert software developer");
+    expect(codeMode.groups).toContain("file_operations");
+    expect(codeMode.groups).toContain("git_operations");
   });
 
-  test('should define ARCHITECT mode correctly', () => {
+  test("should define ARCHITECT mode correctly", () => {
     const architectMode = BUILT_IN_MODES.ARCHITECT;
-    expect(architectMode.slug).toBe('architect');
-    expect(architectMode.name).toBe('Architect');
-    expect(architectMode.roleDefinition).toContain('system architect');
-    expect(architectMode.groups).toContain('read_operations');
-    expect(architectMode.groups).not.toContain('write_operations');
+    expect(architectMode.slug).toBe("architect");
+    expect(architectMode.name).toBe("Architect");
+    expect(architectMode.roleDefinition).toContain("system architect");
+    expect(architectMode.groups).toContain("read_operations");
+    expect(architectMode.groups).not.toContain("write_operations");
   });
 
-  test('should define DEBUG mode correctly', () => {
+  test("should define DEBUG mode correctly", () => {
     const debugMode = BUILT_IN_MODES.DEBUG;
-    expect(debugMode.slug).toBe('debug');
-    expect(debugMode.name).toBe('Debug');
-    expect(debugMode.roleDefinition).toContain('debugging expert');
-    expect(debugMode.groups).toContain('diagnostic_tools');
+    expect(debugMode.slug).toBe("debug");
+    expect(debugMode.name).toBe("Debug");
+    expect(debugMode.roleDefinition).toContain("debugging expert");
+    expect(debugMode.groups).toContain("diagnostic_tools");
   });
 
-  test('should define ASK mode correctly', () => {
+  test("should define ASK mode correctly", () => {
     const askMode = BUILT_IN_MODES.ASK;
-    expect(askMode.slug).toBe('ask');
-    expect(askMode.name).toBe('Ask');
-    expect(askMode.roleDefinition).toContain('knowledgeable assistant');
-    expect(askMode.groups).toContain('read_operations');
+    expect(askMode.slug).toBe("ask");
+    expect(askMode.name).toBe("Ask");
+    expect(askMode.roleDefinition).toContain("knowledgeable assistant");
+    expect(askMode.groups).toContain("read_operations");
   });
 
-  test('should define ORCHESTRATOR mode correctly', () => {
+  test("should define ORCHESTRATOR mode correctly", () => {
     const orchestratorMode = BUILT_IN_MODES.ORCHESTRATOR;
-    expect(orchestratorMode.slug).toBe('orchestrator');
-    expect(orchestratorMode.name).toBe('Orchestrator');
-    expect(orchestratorMode.roleDefinition).toContain('task orchestrator');
-    expect(orchestratorMode.groups).toContain('task_management');
+    expect(orchestratorMode.slug).toBe("orchestrator");
+    expect(orchestratorMode.name).toBe("Orchestrator");
+    expect(orchestratorMode.roleDefinition).toContain("task orchestrator");
+    expect(orchestratorMode.groups).toContain("task_management");
   });
 
-  test('all modes should have required fields', () => {
-    Object.values(BUILT_IN_MODES).forEach(mode => {
+  test("all modes should have required fields", () => {
+    Object.values(BUILT_IN_MODES).forEach((mode) => {
       expect(mode.slug).toBeTruthy();
       expect(mode.name).toBeTruthy();
       expect(mode.roleDefinition).toBeTruthy();
@@ -155,74 +162,74 @@ describe('Built-in Modes', () => {
 #### 実装: src/modes/built-in-modes.ts
 
 ```typescript
-import type { Mode } from './types';
+import type { Mode } from "./types";
 
 export const BUILT_IN_MODES = {
   CODE: {
-    slug: 'code',
-    name: 'Code',
+    slug: "code",
+    name: "Code",
     roleDefinition: `You are an expert software developer focused on implementation details.
     Your primary goal is to write clean, efficient, and maintainable code.
     You follow best practices and coding standards for the given language and framework.`,
-    groups: ['file_operations', 'git_operations', 'code_analysis', 'testing'],
+    groups: ["file_operations", "git_operations", "code_analysis", "testing"],
     customInstructions: `- Write idiomatic code for the target language
 - Include appropriate error handling
 - Follow existing code patterns in the repository
-- Write tests when implementing new functionality`
+- Write tests when implementing new functionality`,
   },
 
   ARCHITECT: {
-    slug: 'architect',
-    name: 'Architect',
+    slug: "architect",
+    name: "Architect",
     roleDefinition: `You are a system architect focused on high-level design and planning.
     You analyze requirements, design system architectures, and make strategic technical decisions.
     You prioritize scalability, maintainability, and alignment with business goals.`,
-    groups: ['read_operations', 'documentation', 'analysis'],
+    groups: ["read_operations", "documentation", "analysis"],
     customInstructions: `- Focus on system design and architecture
 - Consider scalability and performance implications
 - Provide clear technical specifications
-- Document architectural decisions and trade-offs`
+- Document architectural decisions and trade-offs`,
   },
 
   DEBUG: {
-    slug: 'debug',
-    name: 'Debug',
+    slug: "debug",
+    name: "Debug",
     roleDefinition: `You are a debugging expert specialized in identifying and fixing issues.
     You systematically analyze problems, use diagnostic tools effectively, and provide clear explanations of root causes.
     You focus on not just fixing symptoms but addressing underlying issues.`,
-    groups: ['file_operations', 'diagnostic_tools', 'logging', 'testing'],
+    groups: ["file_operations", "diagnostic_tools", "logging", "testing"],
     customInstructions: `- Systematically isolate the problem
 - Use appropriate debugging tools and techniques
 - Explain the root cause clearly
-- Implement fixes that prevent recurrence`
+- Implement fixes that prevent recurrence`,
   },
 
   ASK: {
-    slug: 'ask',
-    name: 'Ask',
+    slug: "ask",
+    name: "Ask",
     roleDefinition: `You are a knowledgeable assistant focused on providing clear, accurate information.
     You explain concepts clearly, provide relevant examples, and ensure understanding.
     You adapt your explanations to the user's level of expertise.`,
-    groups: ['read_operations', 'documentation', 'search'],
+    groups: ["read_operations", "documentation", "search"],
     customInstructions: `- Provide clear, concise explanations
 - Use examples to illustrate concepts
 - Reference documentation when appropriate
-- Admit uncertainty rather than speculate`
+- Admit uncertainty rather than speculate`,
   },
 
   ORCHESTRATOR: {
-    slug: 'orchestrator',
-    name: 'Orchestrator',
+    slug: "orchestrator",
+    name: "Orchestrator",
     roleDefinition: `You are a task orchestrator responsible for breaking down complex tasks and delegating to appropriate modes.
     You analyze task complexity, identify subtasks, and coordinate their execution.
     You optimize for efficiency by providing each mode with focused, relevant context.`,
-    groups: ['task_management', 'mode_switching', 'context_optimization'],
+    groups: ["task_management", "mode_switching", "context_optimization"],
     customInstructions: `- Analyze task complexity and requirements
 - Break down tasks into appropriate subtasks
 - Select the optimal mode for each subtask
 - Minimize context size while maintaining effectiveness
-- Coordinate results between subtasks`
-  }
+- Coordinate results between subtasks`,
+  },
 } as const;
 
 export type BuiltInModeSlug = keyof typeof BUILT_IN_MODES;
@@ -234,56 +241,57 @@ export type BuiltInModeSlug = keyof typeof BUILT_IN_MODES;
 
 ```typescript
 // test/modes/mode-manager.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { ModeManager } from '../../src/modes/mode-manager';
-import { BUILT_IN_MODES } from '../../src/modes/built-in-modes';
-import type { Mode } from '../../src/modes/types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { ModeManager } from "../../src/modes/mode-manager";
+import { BUILT_IN_MODES } from "../../src/modes/built-in-modes";
+import type { Mode } from "../../src/modes/types";
 
-describe('ModeManager', () => {
+describe("ModeManager", () => {
   let manager: ModeManager;
 
   beforeEach(() => {
     manager = new ModeManager();
   });
 
-  test('should initialize with built-in modes', () => {
+  test("should initialize with built-in modes", () => {
     const allModes = manager.getAllModes();
     expect(allModes.length).toBe(5);
 
-    const slugs = allModes.map(m => m.slug);
-    expect(slugs).toContain('code');
-    expect(slugs).toContain('architect');
-    expect(slugs).toContain('debug');
-    expect(slugs).toContain('ask');
-    expect(slugs).toContain('orchestrator');
+    const slugs = allModes.map((m) => m.slug);
+    expect(slugs).toContain("code");
+    expect(slugs).toContain("architect");
+    expect(slugs).toContain("debug");
+    expect(slugs).toContain("ask");
+    expect(slugs).toContain("orchestrator");
   });
 
-  test('should get mode by slug', () => {
-    const codeMode = manager.getModeBySlug('code');
+  test("should get mode by slug", () => {
+    const codeMode = manager.getModeBySlug("code");
     expect(codeMode).toEqual(BUILT_IN_MODES.CODE);
 
-    const architectMode = manager.getModeBySlug('architect');
+    const architectMode = manager.getModeBySlug("architect");
     expect(architectMode).toEqual(BUILT_IN_MODES.ARCHITECT);
   });
 
-  test('should throw error for unknown mode', () => {
-    expect(() => manager.getModeBySlug('unknown')).toThrow('Mode not found: unknown');
+  test("should throw error for unknown mode", () => {
+    expect(() => manager.getModeBySlug("unknown")).toThrow(
+      "Mode not found: unknown",
+    );
   });
 
-  test('should get default mode', () => {
+  test("should get default mode", () => {
     const defaultMode = manager.getDefaultMode();
-    expect(defaultMode.slug).toBe('code');
+    expect(defaultMode.slug).toBe("code");
   });
-
 });
 ```
 
 #### 実装: src/modes/mode-manager.ts
 
 ```typescript
-import type { Mode, ValidGroup } from './types';
-import { BUILT_IN_MODES } from './built-in-modes';
-import { VALID_GROUPS } from './types';
+import type { Mode, ValidGroup } from "./types";
+import { BUILT_IN_MODES } from "./built-in-modes";
+import { VALID_GROUPS } from "./types";
 
 export class ModeManager {
   private modes: Map<string, Mode>;
@@ -294,7 +302,7 @@ export class ModeManager {
   }
 
   private initializeBuiltInModes(): void {
-    Object.values(BUILT_IN_MODES).forEach(mode => {
+    Object.values(BUILT_IN_MODES).forEach((mode) => {
       this.modes.set(mode.slug, mode);
     });
   }
@@ -312,7 +320,7 @@ export class ModeManager {
   }
 
   getDefaultMode(): Mode {
-    return this.getModeBySlug('code');
+    return this.getModeBySlug("code");
   }
 
   getBuiltInModes(): Mode[] {
@@ -327,6 +335,7 @@ export const modeManager = new ModeManager();
 ## コミット計画
 
 ### コミット1: Mode型定義
+
 ```bash
 # プリコミットチェック
 bun test
@@ -339,6 +348,7 @@ git commit -m "feat(modes): add Mode interface and type definitions"
 ```
 
 ### コミット2: 組み込みモード
+
 ```bash
 # プリコミットチェック
 bun test
@@ -351,6 +361,7 @@ git commit -m "feat(modes): implement built-in modes (Code, Architect, Debug, As
 ```
 
 ### コミット3: モードマネージャー
+
 ```bash
 # プリコミットチェック
 bun test
@@ -363,6 +374,7 @@ git commit -m "feat(modes): implement ModeManager for built-in mode retrieval wi
 ```
 
 ### コミット4: エクスポート設定
+
 ```bash
 # プリコミットチェック
 bun test
@@ -394,39 +406,39 @@ test/
 
 ```typescript
 // src/modes/index.ts
-export type { Mode, ModeContext, ModeSlug } from './types';
-export { BUILT_IN_MODES, type BuiltInModeSlug } from './built-in-modes';
-export { ModeManager, modeManager } from './mode-manager';
+export type { Mode, ModeContext, ModeSlug } from "./types";
+export { BUILT_IN_MODES, type BuiltInModeSlug } from "./built-in-modes";
+export { ModeManager, modeManager } from "./mode-manager";
 ```
 
 ## 統合テスト
 
 ```typescript
 // test/modes/integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { modeManager, type Mode } from '../../src/modes';
+import { describe, test, expect } from "bun:test";
+import { modeManager, type Mode } from "../../src/modes";
 
-describe('Mode System Integration', () => {
-  test('should handle mode switching workflow', () => {
+describe("Mode System Integration", () => {
+  test("should handle mode switching workflow", () => {
     // デフォルトモードから開始
     const defaultMode = modeManager.getDefaultMode();
-    expect(defaultMode.slug).toBe('code');
+    expect(defaultMode.slug).toBe("code");
 
     // アーキテクトモードに切り替え
-    const architectMode = modeManager.getModeBySlug('architect');
-    expect(architectMode.groups).not.toContain('write_operations');
+    const architectMode = modeManager.getModeBySlug("architect");
+    expect(architectMode.groups).not.toContain("write_operations");
 
     // デバッグモードに切り替え
-    const debugMode = modeManager.getModeBySlug('debug');
-    expect(debugMode.groups).toContain('diagnostic_tools');
+    const debugMode = modeManager.getModeBySlug("debug");
+    expect(debugMode.groups).toContain("diagnostic_tools");
   });
-
 });
 ```
 
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase0-fork-update から作業ブランチを作成
 git checkout phase0-fork-update
@@ -457,6 +469,7 @@ git branch -d phase1-mode-system # ローカルの作業ブランチを削除
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase0-fork-update から作業ブランチ作成
 git checkout phase0-fork-update
@@ -488,6 +501,7 @@ git branch -d phase1-mode-system
 ## 依存関係
 
 このフェーズは独立して実装可能です。以下のフェーズに必要となります：
+
 - フェーズ2.2: コンテキスト最適化（モード別の優先度設定）
 - フェーズ3.1: プロンプト生成の拡張（モード固有のプロンプト）
 

--- a/predev-docs/03-phase1-task-system-design.md
+++ b/predev-docs/03-phase1-task-system-design.md
@@ -1,0 +1,685 @@
+# フェーズ1.2: タスクシステム - 詳細設計
+
+## 概要
+
+タスクシステムは、オーケストレーション機能の核となる部分で、複雑なタスクの管理、分解、実行制御を行います。タスクのライフサイクル管理と、サブタスクの依存関係を処理します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class Task {
+        <<interface>>
+        +id: string
+        +mode: string
+        +message: string
+        +parentTaskId?: string
+        +context: TaskContext
+        +status: TaskStatus
+        +result?: TaskResult
+    }
+
+    class TaskContext {
+        <<interface>>
+        +previousResults: string[]
+        +globalContext: Record<string, any>
+        +modeSpecificContext: Record<string, any>
+        +maxTokens: number
+    }
+
+    class TaskManager {
+        -tasks: Map<string, Task>
+        +createTask(params: CreateTaskParams): Task
+        +getTask(id: string): Task
+        +updateTaskStatus(id: string, status: TaskStatus): void
+        +updateTaskResult(id: string, result: TaskResult): void
+        +executeTask(id: string): Promise<TaskResult>
+        +getSubTasks(parentId: string): Task[]
+        +getAllTasks(): Task[]
+        +getTasksByStatus(status: TaskStatus): Task[]
+    }
+
+    class TaskResult {
+        <<interface>>
+        +taskId: string
+        +success: boolean
+        +output?: string
+        +error?: string
+        +createdFiles?: string[]
+        +modifiedFiles?: string[]
+    }
+
+    Task --> TaskContext : contains
+    TaskManager --> Task : manages
+    Task --> TaskResult : produces
+```
+
+## タスク処理シーケンス
+
+以下は、`TaskManager` を中心とした主要なタスク処理のフローを示すシーケンス図です。
+
+```mermaid
+sequenceDiagram
+    participant Caller as Caller / Orchestrator
+    participant TaskManager as TaskManager
+    participant TaskExecutor as TaskExecutor (executionFn)
+    participant Task as Task (Data Object)
+
+    Caller->>TaskManager: createTask(params: CreateTaskParams)
+    activate TaskManager
+    TaskManager->>TaskManager: generateTaskId()
+    TaskManager->>Task: new Task({id, mode, message, context, status='pending', createdAt, updatedAt})
+    TaskManager-->>Caller: task: Task (Initial State)
+    deactivate TaskManager
+
+    Note over Caller, TaskManager: Caller decides to execute the created task (or a subtask)
+
+    Caller->>TaskManager: executeTask(taskId, executionFn)
+    activate TaskManager
+    TaskManager->>TaskManager: getTask(taskId)
+    alt Task Not Found
+        TaskManager-->>Caller: Error: Task Not Found
+    else Task Found
+        TaskManager->>Task: Update status to 'in_progress', update 'updatedAt'
+        TaskManager->>TaskExecutor: await executionFn()
+        activate TaskExecutor
+        Note over TaskExecutor: Performs mode-specific processing (e.g., LLM call, tool use)
+        TaskExecutor-->>TaskManager: executionOutcome (Omit<TaskResult, 'taskId'>)
+        deactivate TaskExecutor
+
+        TaskManager->>TaskManager: Record duration
+        alt Execution Successful
+            TaskManager->>Task: Update status to 'completed', set result (success, output, etc.), update 'updatedAt'
+            TaskManager-->>Caller: taskResult: TaskResult (Success)
+        else Execution Failed (or error in executionFn)
+            TaskManager->>Task: Update status to 'failed', set result (error, etc.), update 'updatedAt'
+            TaskManager-->>Caller: taskResult: TaskResult (Failure)
+        end
+    end
+    deactivate TaskManager
+
+    Note over Caller, TaskManager: Caller may retrieve the updated task details
+
+    Caller->>TaskManager: getTask(taskId)
+    activate TaskManager
+    TaskManager->>Task: Retrieve Task data
+    TaskManager-->>Caller: task: Task (Updated State with Result)
+    deactivate TaskManager
+
+    Note over Caller, TaskManager: If the task was an orchestrator task, it might create subtasks
+
+    Caller->>TaskManager: createTask(params: CreateTaskParams with parentTaskId)
+    activate TaskManager
+    TaskManager->>TaskManager: generateTaskId()
+    TaskManager->>Task: new Task (Subtask with parentTaskId)
+    TaskManager-->>Caller: subtask: Task
+    deactivate TaskManager
+
+    Caller->>TaskManager: getSubTasks(parentTaskId)
+    activate TaskManager
+    TaskManager->>TaskManager: Filter tasks by parentTaskId
+    TaskManager-->>Caller: subtasks: Task[]
+    deactivate TaskManager
+```
+
+### シーケンス図の解説
+
+1.  **タスク作成 (`createTask`)**:
+    *   `Caller` (例: `AutoOrchestrator`) が `TaskManager` にタスク作成を要求します。
+    *   `TaskManager` は新しいタスクIDを生成し、初期状態 (`status: 'pending'`) の `Task` オブジェクトを作成して返します。この際、コンストラクタで設定されたデフォルトコンテキストと、`params.context` で提供されたコンテキストがマージされます。
+
+2.  **タスク実行 (`executeTask`)**:
+    *   `Caller` が特定のタスクの実行を `TaskManager` に要求します。このとき、具体的な処理ロジックである `executionFn` を渡します。
+    *   `TaskManager` は対象タスクを取得し、ステータスを `'in_progress'` に更新します。
+    *   `TaskManager` は提供された `executionFn` を呼び出し、その完了を待ちます。`executionFn` は、タスクID以外の `TaskResult` に必要な情報（成功フラグ、出力、エラーメッセージなど）を返します。
+    *   `executionFn` の結果に基づき、`TaskManager` は実行時間 (`duration`) を計算し、タスクのステータスを `'completed'` または `'failed'` に更新し、最終的な `TaskResult` をタスクオブジェクトに保存して `Caller` に返します。
+
+3.  **タスク情報取得 (`getTask`, `getSubTasks`)**:
+    *   `Caller` はいつでも `TaskManager` から最新のタスク情報や、特定の親タスクに紐づくサブタスクのリストを取得できます。
+
+## TDD実装計画
+
+### タスク1.2.1: タスク定義の作成
+
+#### 実装: src/tasks/types.ts
+
+```typescript
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+
+export interface TaskContext {
+  previousResults: string[];
+  globalContext: Record<string, any>;
+  modeSpecificContext: Record<string, any>;
+  maxTokens: number;
+}
+
+export interface TaskResult {
+  taskId: string;
+  success: boolean;
+  output?: string;
+  error?: string;
+  createdFiles?: string[];
+  modifiedFiles?: string[];
+  duration?: number;
+  tokensUsed?: number;
+}
+
+export interface Task {
+  id: string;
+  mode: string;
+  message: string;
+  parentTaskId?: string;
+  context: TaskContext;
+  status: TaskStatus;
+  result?: TaskResult;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateTaskParams {
+  mode: string;
+  message: string;
+  parentTaskId?: string;
+  context?: Partial<TaskContext>;
+}
+```
+
+### タスク1.2.2: タスクマネージャーの実装
+
+#### テストファースト: src/tasks/task-manager.ts
+
+```typescript
+// test/tasks/task-manager.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TaskManager } from '../../src/tasks/task-manager';
+import type { Task, CreateTaskParams } from '../../src/tasks/types';
+
+describe('TaskManager', () => {
+  let manager: TaskManager;
+
+  beforeEach(() => {
+    manager = new TaskManager();
+  });
+
+  test('should create a new task', () => {
+    const params: CreateTaskParams = {
+      mode: 'code',
+      message: 'Implement feature A'
+    };
+
+    const task = manager.createTask(params);
+
+    expect(task.id).toBeTruthy();
+    expect(task.mode).toBe('code');
+    expect(task.message).toBe('Implement feature A');
+    expect(task.status).toBe('pending');
+    expect(task.createdAt).toBeInstanceOf(Date);
+  });
+
+  test('should get task by id', () => {
+    const params: CreateTaskParams = {
+      mode: 'debug',
+      message: 'Fix critical bug'
+    };
+
+    const task = manager.createTask(params);
+    const retrieved = manager.getTask(task.id);
+
+    expect(retrieved).toEqual(task);
+  });
+
+  test('should throw error for unknown task', () => {
+    expect(() => manager.getTask('unknown-id')).toThrow('Task not found: unknown-id');
+  });
+
+  test('should update task status', () => {
+    const task = manager.createTask({
+      mode: 'code',
+      message: 'Test task'
+    });
+
+    manager.updateTaskStatus(task.id, 'in_progress');
+    const updated = manager.getTask(task.id);
+
+    expect(updated.status).toBe('in_progress');
+    expect(updated.updatedAt.getTime()).toBeGreaterThan(task.updatedAt.getTime());
+  });
+
+  test('should throw error when updating status of unknown task', () => {
+    expect(() => manager.updateTaskStatus('unknown-id', 'in_progress')).toThrow('Task not found: unknown-id');
+  });
+
+  test('should throw error when updating result of unknown task', () => {
+    expect(() => manager.updateTaskResult('unknown-id', { taskId: 'unknown-id', success: true })).toThrow('Task not found: unknown-id');
+  });
+
+  test('should create subtask with parent reference', () => {
+    const parentTask = manager.createTask({
+      mode: 'orchestrator',
+      message: 'Complex feature implementation'
+    });
+
+    const subTask = manager.createTask({
+      mode: 'code',
+      message: 'Implement component X',
+      parentTaskId: parentTask.id
+    });
+
+    expect(subTask.parentTaskId).toBe(parentTask.id);
+  });
+
+  test('should get subtasks by parent id', () => {
+    const parentTask = manager.createTask({
+      mode: 'orchestrator',
+      message: 'Main task'
+    });
+
+    const subTask1 = manager.createTask({
+      mode: 'code',
+      message: 'Subtask 1',
+      parentTaskId: parentTask.id
+    });
+
+    const subTask2 = manager.createTask({
+      mode: 'debug',
+      message: 'Subtask 2',
+      parentTaskId: parentTask.id
+    });
+
+    const subTasks = manager.getSubTasks(parentTask.id);
+
+    expect(subTasks.length).toBe(2);
+    expect(subTasks.map(t => t.id)).toContain(subTask1.id);
+    expect(subTasks.map(t => t.id)).toContain(subTask2.id);
+  });
+
+  test('should generate unique task ids', () => {
+    const task1 = manager.createTask({ mode: 'code', message: 'Task 1' });
+    const task2 = manager.createTask({ mode: 'code', message: 'Task 2' });
+
+    expect(task1.id).not.toBe(task2.id);
+  });
+
+  test('should allow overriding default context in constructor', () => {
+    const customManager = new TaskManager({ defaultMaxTokens: 5000 });
+    const task = customManager.createTask({ mode: 'code', message: 'Test' });
+    expect(task.context.maxTokens).toBe(5000);
+  });
+
+  test('should merge provided context with defaults', () => {
+    const task = manager.createTask({
+      mode: 'code',
+      message: 'Test',
+      context: { maxTokens: 3000, globalContext: { custom: 'value' } }
+    });
+    expect(task.context.maxTokens).toBe(3000);
+    expect(task.context.globalContext.custom).toBe('value');
+    expect(task.context.previousResults).toEqual([]); // デフォルトが維持される
+  });
+
+  // executeTaskのテスト (モックを使用)
+  describe('executeTask', () => {
+    // 実際のタスク実行ロジックはTaskManagerの責務外なので、
+    // ここでは状態遷移と結果の記録のみをテストする。
+    // 実際の実行は各Modeのエンジンが行う。
+
+    test('should update task status to in_progress then completed on successful execution', async () => {
+      const task = manager.createTask({ mode: 'code', message: 'Execute this' });
+      // 実際の実行処理はモックする
+      const mockExecution = async (): Promise<Omit<TaskResult, 'taskId'>> => {
+        return { success: true, output: 'Execution successful' };
+      };
+
+      const result = await manager.executeTask(task.id, mockExecution);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe('Execution successful');
+      const updatedTask = manager.getTask(task.id);
+      expect(updatedTask.status).toBe('completed');
+      expect(updatedTask.result).toEqual(result);
+    });
+
+    test('should update task status to in_progress then failed on unsuccessful execution', async () => {
+      const task = manager.createTask({ mode: 'code', message: 'Execute this' });
+      const mockExecution = async (): Promise<Omit<TaskResult, 'taskId'>> => {
+        return { success: false, error: 'Execution failed' };
+      };
+
+      const result = await manager.executeTask(task.id, mockExecution);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Execution failed');
+      const updatedTask = manager.getTask(task.id);
+      expect(updatedTask.status).toBe('failed');
+      expect(updatedTask.result).toEqual(result);
+    });
+
+    test('should throw error if task is not found', async () => {
+      const mockExecution = async (): Promise<Omit<TaskResult, 'taskId'>> => {
+        return { success: true };
+      };
+      await expect(manager.executeTask('unknown-id', mockExecution)).rejects.toThrow('Task not found: unknown-id');
+    });
+  });
+});
+```
+
+#### 実装: src/tasks/task-manager.ts
+
+```typescript
+import type { Task, CreateTaskParams, TaskStatus, TaskResult } from './types';
+import { v4 as uuidv4 } from 'uuid';
+
+export class TaskManager {
+  private tasks: Map<string, Task>;
+
+  constructor() {
+    this.tasks = new Map();
+  }
+
+  createTask(params: CreateTaskParams): Task {
+    const now = new Date();
+    const task: Task = {
+      id: this.generateTaskId(),
+      mode: params.mode,
+      message: params.message,
+      parentTaskId: params.parentTaskId,
+      status: 'pending',
+      context: {
+        previousResults: [],
+        globalContext: {},
+        modeSpecificContext: {},
+        maxTokens: 8000,
+        ...params.context
+      },
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.tasks.set(task.id, task);
+    return task;
+  }
+
+  getTask(id: string): Task {
+    const task = this.tasks.get(id);
+    if (!task) {
+      throw new Error(`Task not found: ${id}`);
+    }
+    return task;
+  }
+
+  updateTaskStatus(id: string, status: TaskStatus): void {
+    const task = this.getTask(id);
+    task.status = status;
+    task.updatedAt = new Date();
+    this.tasks.set(id, task);
+  }
+
+  updateTaskResult(id: string, result: TaskResult): void {
+    const task = this.getTask(id);
+    task.result = result;
+    task.status = result.success ? 'completed' : 'failed';
+    task.updatedAt = new Date();
+    this.tasks.set(id, task);
+  }
+
+  getSubTasks(parentId: string): Task[] {
+    return Array.from(this.tasks.values())
+      .filter(task => task.parentTaskId === parentId)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  getAllTasks(): Task[] {
+    return Array.from(this.tasks.values())
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  getTasksByStatus(status: TaskStatus): Task[] {
+    return Array.from(this.tasks.values())
+      .filter(task => task.status === status)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  private generateTaskId(): string {
+    return `task-${uuidv4()}`;
+  }
+}
+
+// Singleton instance
+export const taskManager = new TaskManager();
+```
+
+## コミット計画
+
+### コミット1: Task型定義
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/tasks/types.ts
+git commit -m "feat(tasks): add Task interface and type definitions"
+```
+
+### コミット2: タスクマネージャー
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/tasks/task-manager.ts test/tasks/task-manager.test.ts
+git commit -m "feat(tasks): implement TaskManager for task lifecycle management with tests"
+```
+
+### コミット3: エクスポート設定
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/tasks/index.ts
+git commit -m "feat(tasks): add module exports for task system"
+```
+
+## ディレクトリ構造
+
+```
+src/
+└── tasks/
+    ├── types.ts           # Task インターフェース定義
+    ├── task-manager.ts    # タスク管理システム
+    └── index.ts          # エクスポート
+
+test/
+└── tasks/
+    └── task-manager.test.ts
+```
+
+## index.tsの実装
+
+```typescript
+// src/tasks/index.ts
+export type {
+  Task,
+  TaskContext,
+  TaskResult,
+  TaskStatus,
+  CreateTaskParams,
+} from './types';
+export { TaskManager, taskManager } from './task-manager';
+```
+
+## 統合テスト
+
+```typescript
+// test/tasks/integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { taskManager, type Task } from '../../src/tasks';
+
+describe('Task System Integration', () => {
+  test('should handle task lifecycle workflow', () => {
+    // 親タスク作成
+    const parentTask = taskManager.createTask({
+      mode: 'orchestrator',
+      message: 'Implement user authentication system'
+    });
+
+    expect(parentTask.status).toBe('pending');
+
+    // サブタスク作成
+    const subTask1 = taskManager.createTask({
+      mode: 'code',
+      message: 'Create user model',
+      parentTaskId: parentTask.id
+    });
+
+    const subTask2 = taskManager.createTask({
+      mode: 'code',
+      message: 'Implement login endpoint',
+      parentTaskId: parentTask.id
+    });
+
+    // サブタスク取得
+    const subTasks = taskManager.getSubTasks(parentTask.id);
+    expect(subTasks.length).toBe(2);
+
+    // タスク実行シミュレーション (executeTaskを使用)
+    const subTask1FromManager = taskManager.getTask(subTask1.id); // 最新の状態を取得
+
+    // モックの実行関数
+    const mockExecutionFn = async (taskSuccess: boolean, outputMsg?: string, errorMsg?: string, files?: string[]): Promise<Omit<TaskResult, 'taskId'>> => {
+      await new Promise(resolve => setTimeout(resolve, 10)); // 非同期処理をシミュレート
+      if (taskSuccess) {
+        return { success: true, output: outputMsg, createdFiles: files };
+      } else {
+        return { success: false, error: errorMsg };
+      }
+    };
+
+    // subTask1 の実行 (成功ケース)
+    await taskManager.executeTask(
+      subTask1FromManager.id,
+      () => mockExecutionFn(true, 'User model created successfully', undefined, ['src/models/user.ts'])
+    );
+
+    const completedTask = taskManager.getTask(subTask1.id);
+    expect(completedTask.status).toBe('completed');
+    expect(completedTask.result?.success).toBe(true);
+    expect(completedTask.result?.createdFiles).toEqual(['src/models/user.ts']);
+    expect(completedTask.result?.duration).toBeGreaterThanOrEqual(10);
+
+    // subTask2 の実行 (失敗ケース)
+    await taskManager.executeTask(
+      subTask2.id,
+      () => mockExecutionFn(false, undefined, 'Endpoint implementation failed')
+    );
+    const failedTask = taskManager.getTask(subTask2.id);
+    expect(failedTask.status).toBe('failed');
+    expect(failedTask.result?.success).toBe(false);
+    expect(failedTask.result?.error).toBe('Endpoint implementation failed');
+  });
+
+  test('should support context passing between tasks', () => {
+    const task = taskManager.createTask({
+      mode: 'code',
+      message: 'Process user data',
+      context: {
+        globalContext: { userId: '123' },
+        modeSpecificContext: { validateInput: true },
+        maxTokens: 4000
+      }
+    });
+
+    expect(task.context.globalContext.userId).toBe('123');
+    expect(task.context.modeSpecificContext.validateInput).toBe(true);
+    expect(task.context.maxTokens).toBe(4000);
+  });
+});
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase1-mode-system から作業ブランチを作成
+git checkout phase1-mode-system
+git pull origin phase1-mode-system # 念のため最新化
+git checkout -b phase1-task-system phase1-mode-system
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(task-system): implement task system" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase1-task-system
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase1-mode-system とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase1-mode-system
+git pull origin phase1-mode-system # リモートの変更を取り込み最新化
+git branch -d phase1-task-system # ローカルの作業ブランチを削除
+# git push origin --delete phase1-task-system # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase1-mode-system から作業ブランチ作成
+git checkout phase1-mode-system
+git pull origin phase1-mode-system # 念のため最新化
+git checkout -b phase1-task-system phase1-mode-system
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(task-system): implement task system" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase1-task-system
+# GitHub上で phase1-mode-system をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase1-mode-system
+git pull origin phase1-mode-system
+git branch -d phase1-task-system
+```
+
+## 依存関係
+
+このフェーズはモードシステム（フェーズ1.1）完了後に実装してください。以下のフェーズに必要となります：
+- フェーズ2.1: タスク分析エンジン（タスクの複雑度分析）
+- フェーズ2.2: コンテキスト最適化（タスクコンテキストの管理）
+- フェーズ3: GitHub Actionsとの統合
+
+## 次のステップ
+
+1. フェーズ2.1でタスク分析エンジンを実装（このタスクシステムを基盤として）
+2. フェーズ2.2でコンテキスト最適化機能を追加
+3. フェーズ3でGitHub Actionsとの統合

--- a/predev-docs/03-phase1-task-system-design.md
+++ b/predev-docs/03-phase1-task-system-design.md
@@ -5,6 +5,7 @@
 タスクシステムは、オーケストレーション機能の核となる部分で、複雑なタスクの管理、分解、実行制御を行います。タスクのライフサイクル管理と、サブタスクの依存関係を処理します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -132,17 +133,19 @@ sequenceDiagram
 ### シーケンス図の解説
 
 1.  **タスク作成 (`createTask`)**:
-    *   `Caller` (例: `AutoOrchestrator`) が `TaskManager` にタスク作成を要求します。
-    *   `TaskManager` は新しいタスクIDを生成し、初期状態 (`status: 'pending'`) の `Task` オブジェクトを作成して返します。この際、コンストラクタで設定されたデフォルトコンテキストと、`params.context` で提供されたコンテキストがマージされます。
+
+    - `Caller` (例: `AutoOrchestrator`) が `TaskManager` にタスク作成を要求します。
+    - `TaskManager` は新しいタスクIDを生成し、初期状態 (`status: 'pending'`) の `Task` オブジェクトを作成して返します。この際、コンストラクタで設定されたデフォルトコンテキストと、`params.context` で提供されたコンテキストがマージされます。
 
 2.  **タスク実行 (`executeTask`)**:
-    *   `Caller` が特定のタスクの実行を `TaskManager` に要求します。このとき、具体的な処理ロジックである `executionFn` を渡します。
-    *   `TaskManager` は対象タスクを取得し、ステータスを `'in_progress'` に更新します。
-    *   `TaskManager` は提供された `executionFn` を呼び出し、その完了を待ちます。`executionFn` は、タスクID以外の `TaskResult` に必要な情報（成功フラグ、出力、エラーメッセージなど）を返します。
-    *   `executionFn` の結果に基づき、`TaskManager` は実行時間 (`duration`) を計算し、タスクのステータスを `'completed'` または `'failed'` に更新し、最終的な `TaskResult` をタスクオブジェクトに保存して `Caller` に返します。
+
+    - `Caller` が特定のタスクの実行を `TaskManager` に要求します。このとき、具体的な処理ロジックである `executionFn` を渡します。
+    - `TaskManager` は対象タスクを取得し、ステータスを `'in_progress'` に更新します。
+    - `TaskManager` は提供された `executionFn` を呼び出し、その完了を待ちます。`executionFn` は、タスクID以外の `TaskResult` に必要な情報（成功フラグ、出力、エラーメッセージなど）を返します。
+    - `executionFn` の結果に基づき、`TaskManager` は実行時間 (`duration`) を計算し、タスクのステータスを `'completed'` または `'failed'` に更新し、最終的な `TaskResult` をタスクオブジェクトに保存して `Caller` に返します。
 
 3.  **タスク情報取得 (`getTask`, `getSubTasks`)**:
-    *   `Caller` はいつでも `TaskManager` から最新のタスク情報や、特定の親タスクに紐づくサブタスクのリストを取得できます。
+    - `Caller` はいつでも `TaskManager` から最新のタスク情報や、特定の親タスクに紐づくサブタスクのリストを取得できます。
 
 ## TDD実装計画
 
@@ -151,7 +154,7 @@ sequenceDiagram
 #### 実装: src/tasks/types.ts
 
 ```typescript
-export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+export type TaskStatus = "pending" | "in_progress" | "completed" | "failed";
 
 export interface TaskContext {
   previousResults: string[];
@@ -197,36 +200,36 @@ export interface CreateTaskParams {
 
 ```typescript
 // test/tasks/task-manager.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { TaskManager } from '../../src/tasks/task-manager';
-import type { Task, CreateTaskParams } from '../../src/tasks/types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { TaskManager } from "../../src/tasks/task-manager";
+import type { Task, CreateTaskParams } from "../../src/tasks/types";
 
-describe('TaskManager', () => {
+describe("TaskManager", () => {
   let manager: TaskManager;
 
   beforeEach(() => {
     manager = new TaskManager();
   });
 
-  test('should create a new task', () => {
+  test("should create a new task", () => {
     const params: CreateTaskParams = {
-      mode: 'code',
-      message: 'Implement feature A'
+      mode: "code",
+      message: "Implement feature A",
     };
 
     const task = manager.createTask(params);
 
     expect(task.id).toBeTruthy();
-    expect(task.mode).toBe('code');
-    expect(task.message).toBe('Implement feature A');
-    expect(task.status).toBe('pending');
+    expect(task.mode).toBe("code");
+    expect(task.message).toBe("Implement feature A");
+    expect(task.status).toBe("pending");
     expect(task.createdAt).toBeInstanceOf(Date);
   });
 
-  test('should get task by id', () => {
+  test("should get task by id", () => {
     const params: CreateTaskParams = {
-      mode: 'debug',
-      message: 'Fix critical bug'
+      mode: "debug",
+      message: "Fix critical bug",
     };
 
     const task = manager.createTask(params);
@@ -235,137 +238,156 @@ describe('TaskManager', () => {
     expect(retrieved).toEqual(task);
   });
 
-  test('should throw error for unknown task', () => {
-    expect(() => manager.getTask('unknown-id')).toThrow('Task not found: unknown-id');
+  test("should throw error for unknown task", () => {
+    expect(() => manager.getTask("unknown-id")).toThrow(
+      "Task not found: unknown-id",
+    );
   });
 
-  test('should update task status', () => {
+  test("should update task status", () => {
     const task = manager.createTask({
-      mode: 'code',
-      message: 'Test task'
+      mode: "code",
+      message: "Test task",
     });
 
-    manager.updateTaskStatus(task.id, 'in_progress');
+    manager.updateTaskStatus(task.id, "in_progress");
     const updated = manager.getTask(task.id);
 
-    expect(updated.status).toBe('in_progress');
-    expect(updated.updatedAt.getTime()).toBeGreaterThan(task.updatedAt.getTime());
+    expect(updated.status).toBe("in_progress");
+    expect(updated.updatedAt.getTime()).toBeGreaterThan(
+      task.updatedAt.getTime(),
+    );
   });
 
-  test('should throw error when updating status of unknown task', () => {
-    expect(() => manager.updateTaskStatus('unknown-id', 'in_progress')).toThrow('Task not found: unknown-id');
+  test("should throw error when updating status of unknown task", () => {
+    expect(() => manager.updateTaskStatus("unknown-id", "in_progress")).toThrow(
+      "Task not found: unknown-id",
+    );
   });
 
-  test('should throw error when updating result of unknown task', () => {
-    expect(() => manager.updateTaskResult('unknown-id', { taskId: 'unknown-id', success: true })).toThrow('Task not found: unknown-id');
+  test("should throw error when updating result of unknown task", () => {
+    expect(() =>
+      manager.updateTaskResult("unknown-id", {
+        taskId: "unknown-id",
+        success: true,
+      }),
+    ).toThrow("Task not found: unknown-id");
   });
 
-  test('should create subtask with parent reference', () => {
+  test("should create subtask with parent reference", () => {
     const parentTask = manager.createTask({
-      mode: 'orchestrator',
-      message: 'Complex feature implementation'
+      mode: "orchestrator",
+      message: "Complex feature implementation",
     });
 
     const subTask = manager.createTask({
-      mode: 'code',
-      message: 'Implement component X',
-      parentTaskId: parentTask.id
+      mode: "code",
+      message: "Implement component X",
+      parentTaskId: parentTask.id,
     });
 
     expect(subTask.parentTaskId).toBe(parentTask.id);
   });
 
-  test('should get subtasks by parent id', () => {
+  test("should get subtasks by parent id", () => {
     const parentTask = manager.createTask({
-      mode: 'orchestrator',
-      message: 'Main task'
+      mode: "orchestrator",
+      message: "Main task",
     });
 
     const subTask1 = manager.createTask({
-      mode: 'code',
-      message: 'Subtask 1',
-      parentTaskId: parentTask.id
+      mode: "code",
+      message: "Subtask 1",
+      parentTaskId: parentTask.id,
     });
 
     const subTask2 = manager.createTask({
-      mode: 'debug',
-      message: 'Subtask 2',
-      parentTaskId: parentTask.id
+      mode: "debug",
+      message: "Subtask 2",
+      parentTaskId: parentTask.id,
     });
 
     const subTasks = manager.getSubTasks(parentTask.id);
 
     expect(subTasks.length).toBe(2);
-    expect(subTasks.map(t => t.id)).toContain(subTask1.id);
-    expect(subTasks.map(t => t.id)).toContain(subTask2.id);
+    expect(subTasks.map((t) => t.id)).toContain(subTask1.id);
+    expect(subTasks.map((t) => t.id)).toContain(subTask2.id);
   });
 
-  test('should generate unique task ids', () => {
-    const task1 = manager.createTask({ mode: 'code', message: 'Task 1' });
-    const task2 = manager.createTask({ mode: 'code', message: 'Task 2' });
+  test("should generate unique task ids", () => {
+    const task1 = manager.createTask({ mode: "code", message: "Task 1" });
+    const task2 = manager.createTask({ mode: "code", message: "Task 2" });
 
     expect(task1.id).not.toBe(task2.id);
   });
 
-  test('should allow overriding default context in constructor', () => {
+  test("should allow overriding default context in constructor", () => {
     const customManager = new TaskManager({ defaultMaxTokens: 5000 });
-    const task = customManager.createTask({ mode: 'code', message: 'Test' });
+    const task = customManager.createTask({ mode: "code", message: "Test" });
     expect(task.context.maxTokens).toBe(5000);
   });
 
-  test('should merge provided context with defaults', () => {
+  test("should merge provided context with defaults", () => {
     const task = manager.createTask({
-      mode: 'code',
-      message: 'Test',
-      context: { maxTokens: 3000, globalContext: { custom: 'value' } }
+      mode: "code",
+      message: "Test",
+      context: { maxTokens: 3000, globalContext: { custom: "value" } },
     });
     expect(task.context.maxTokens).toBe(3000);
-    expect(task.context.globalContext.custom).toBe('value');
+    expect(task.context.globalContext.custom).toBe("value");
     expect(task.context.previousResults).toEqual([]); // デフォルトが維持される
   });
 
   // executeTaskのテスト (モックを使用)
-  describe('executeTask', () => {
+  describe("executeTask", () => {
     // 実際のタスク実行ロジックはTaskManagerの責務外なので、
     // ここでは状態遷移と結果の記録のみをテストする。
     // 実際の実行は各Modeのエンジンが行う。
 
-    test('should update task status to in_progress then completed on successful execution', async () => {
-      const task = manager.createTask({ mode: 'code', message: 'Execute this' });
+    test("should update task status to in_progress then completed on successful execution", async () => {
+      const task = manager.createTask({
+        mode: "code",
+        message: "Execute this",
+      });
       // 実際の実行処理はモックする
-      const mockExecution = async (): Promise<Omit<TaskResult, 'taskId'>> => {
-        return { success: true, output: 'Execution successful' };
+      const mockExecution = async (): Promise<Omit<TaskResult, "taskId">> => {
+        return { success: true, output: "Execution successful" };
       };
 
       const result = await manager.executeTask(task.id, mockExecution);
 
       expect(result.success).toBe(true);
-      expect(result.output).toBe('Execution successful');
+      expect(result.output).toBe("Execution successful");
       const updatedTask = manager.getTask(task.id);
-      expect(updatedTask.status).toBe('completed');
+      expect(updatedTask.status).toBe("completed");
       expect(updatedTask.result).toEqual(result);
     });
 
-    test('should update task status to in_progress then failed on unsuccessful execution', async () => {
-      const task = manager.createTask({ mode: 'code', message: 'Execute this' });
-      const mockExecution = async (): Promise<Omit<TaskResult, 'taskId'>> => {
-        return { success: false, error: 'Execution failed' };
+    test("should update task status to in_progress then failed on unsuccessful execution", async () => {
+      const task = manager.createTask({
+        mode: "code",
+        message: "Execute this",
+      });
+      const mockExecution = async (): Promise<Omit<TaskResult, "taskId">> => {
+        return { success: false, error: "Execution failed" };
       };
 
       const result = await manager.executeTask(task.id, mockExecution);
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Execution failed');
+      expect(result.error).toBe("Execution failed");
       const updatedTask = manager.getTask(task.id);
-      expect(updatedTask.status).toBe('failed');
+      expect(updatedTask.status).toBe("failed");
       expect(updatedTask.result).toEqual(result);
     });
 
-    test('should throw error if task is not found', async () => {
-      const mockExecution = async (): Promise<Omit<TaskResult, 'taskId'>> => {
+    test("should throw error if task is not found", async () => {
+      const mockExecution = async (): Promise<Omit<TaskResult, "taskId">> => {
         return { success: true };
       };
-      await expect(manager.executeTask('unknown-id', mockExecution)).rejects.toThrow('Task not found: unknown-id');
+      await expect(
+        manager.executeTask("unknown-id", mockExecution),
+      ).rejects.toThrow("Task not found: unknown-id");
     });
   });
 });
@@ -374,8 +396,8 @@ describe('TaskManager', () => {
 #### 実装: src/tasks/task-manager.ts
 
 ```typescript
-import type { Task, CreateTaskParams, TaskStatus, TaskResult } from './types';
-import { v4 as uuidv4 } from 'uuid';
+import type { Task, CreateTaskParams, TaskStatus, TaskResult } from "./types";
+import { v4 as uuidv4 } from "uuid";
 
 export class TaskManager {
   private tasks: Map<string, Task>;
@@ -391,16 +413,16 @@ export class TaskManager {
       mode: params.mode,
       message: params.message,
       parentTaskId: params.parentTaskId,
-      status: 'pending',
+      status: "pending",
       context: {
         previousResults: [],
         globalContext: {},
         modeSpecificContext: {},
         maxTokens: 8000,
-        ...params.context
+        ...params.context,
       },
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
     };
 
     this.tasks.set(task.id, task);
@@ -425,25 +447,26 @@ export class TaskManager {
   updateTaskResult(id: string, result: TaskResult): void {
     const task = this.getTask(id);
     task.result = result;
-    task.status = result.success ? 'completed' : 'failed';
+    task.status = result.success ? "completed" : "failed";
     task.updatedAt = new Date();
     this.tasks.set(id, task);
   }
 
   getSubTasks(parentId: string): Task[] {
     return Array.from(this.tasks.values())
-      .filter(task => task.parentTaskId === parentId)
+      .filter((task) => task.parentTaskId === parentId)
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }
 
   getAllTasks(): Task[] {
-    return Array.from(this.tasks.values())
-      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    return Array.from(this.tasks.values()).sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    );
   }
 
   getTasksByStatus(status: TaskStatus): Task[] {
     return Array.from(this.tasks.values())
-      .filter(task => task.status === status)
+      .filter((task) => task.status === status)
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }
 
@@ -459,6 +482,7 @@ export const taskManager = new TaskManager();
 ## コミット計画
 
 ### コミット1: Task型定義
+
 ```bash
 # プリコミットチェック
 bun test
@@ -471,6 +495,7 @@ git commit -m "feat(tasks): add Task interface and type definitions"
 ```
 
 ### コミット2: タスクマネージャー
+
 ```bash
 # プリコミットチェック
 bun test
@@ -483,6 +508,7 @@ git commit -m "feat(tasks): implement TaskManager for task lifecycle management 
 ```
 
 ### コミット3: エクスポート設定
+
 ```bash
 # プリコミットチェック
 bun test
@@ -518,38 +544,38 @@ export type {
   TaskResult,
   TaskStatus,
   CreateTaskParams,
-} from './types';
-export { TaskManager, taskManager } from './task-manager';
+} from "./types";
+export { TaskManager, taskManager } from "./task-manager";
 ```
 
 ## 統合テスト
 
 ```typescript
 // test/tasks/integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { taskManager, type Task } from '../../src/tasks';
+import { describe, test, expect } from "bun:test";
+import { taskManager, type Task } from "../../src/tasks";
 
-describe('Task System Integration', () => {
-  test('should handle task lifecycle workflow', () => {
+describe("Task System Integration", () => {
+  test("should handle task lifecycle workflow", () => {
     // 親タスク作成
     const parentTask = taskManager.createTask({
-      mode: 'orchestrator',
-      message: 'Implement user authentication system'
+      mode: "orchestrator",
+      message: "Implement user authentication system",
     });
 
-    expect(parentTask.status).toBe('pending');
+    expect(parentTask.status).toBe("pending");
 
     // サブタスク作成
     const subTask1 = taskManager.createTask({
-      mode: 'code',
-      message: 'Create user model',
-      parentTaskId: parentTask.id
+      mode: "code",
+      message: "Create user model",
+      parentTaskId: parentTask.id,
     });
 
     const subTask2 = taskManager.createTask({
-      mode: 'code',
-      message: 'Implement login endpoint',
-      parentTaskId: parentTask.id
+      mode: "code",
+      message: "Implement login endpoint",
+      parentTaskId: parentTask.id,
     });
 
     // サブタスク取得
@@ -560,8 +586,13 @@ describe('Task System Integration', () => {
     const subTask1FromManager = taskManager.getTask(subTask1.id); // 最新の状態を取得
 
     // モックの実行関数
-    const mockExecutionFn = async (taskSuccess: boolean, outputMsg?: string, errorMsg?: string, files?: string[]): Promise<Omit<TaskResult, 'taskId'>> => {
-      await new Promise(resolve => setTimeout(resolve, 10)); // 非同期処理をシミュレート
+    const mockExecutionFn = async (
+      taskSuccess: boolean,
+      outputMsg?: string,
+      errorMsg?: string,
+      files?: string[],
+    ): Promise<Omit<TaskResult, "taskId">> => {
+      await new Promise((resolve) => setTimeout(resolve, 10)); // 非同期処理をシミュレート
       if (taskSuccess) {
         return { success: true, output: outputMsg, createdFiles: files };
       } else {
@@ -570,40 +601,40 @@ describe('Task System Integration', () => {
     };
 
     // subTask1 の実行 (成功ケース)
-    await taskManager.executeTask(
-      subTask1FromManager.id,
-      () => mockExecutionFn(true, 'User model created successfully', undefined, ['src/models/user.ts'])
+    await taskManager.executeTask(subTask1FromManager.id, () =>
+      mockExecutionFn(true, "User model created successfully", undefined, [
+        "src/models/user.ts",
+      ]),
     );
 
     const completedTask = taskManager.getTask(subTask1.id);
-    expect(completedTask.status).toBe('completed');
+    expect(completedTask.status).toBe("completed");
     expect(completedTask.result?.success).toBe(true);
-    expect(completedTask.result?.createdFiles).toEqual(['src/models/user.ts']);
+    expect(completedTask.result?.createdFiles).toEqual(["src/models/user.ts"]);
     expect(completedTask.result?.duration).toBeGreaterThanOrEqual(10);
 
     // subTask2 の実行 (失敗ケース)
-    await taskManager.executeTask(
-      subTask2.id,
-      () => mockExecutionFn(false, undefined, 'Endpoint implementation failed')
+    await taskManager.executeTask(subTask2.id, () =>
+      mockExecutionFn(false, undefined, "Endpoint implementation failed"),
     );
     const failedTask = taskManager.getTask(subTask2.id);
-    expect(failedTask.status).toBe('failed');
+    expect(failedTask.status).toBe("failed");
     expect(failedTask.result?.success).toBe(false);
-    expect(failedTask.result?.error).toBe('Endpoint implementation failed');
+    expect(failedTask.result?.error).toBe("Endpoint implementation failed");
   });
 
-  test('should support context passing between tasks', () => {
+  test("should support context passing between tasks", () => {
     const task = taskManager.createTask({
-      mode: 'code',
-      message: 'Process user data',
+      mode: "code",
+      message: "Process user data",
       context: {
-        globalContext: { userId: '123' },
+        globalContext: { userId: "123" },
         modeSpecificContext: { validateInput: true },
-        maxTokens: 4000
-      }
+        maxTokens: 4000,
+      },
     });
 
-    expect(task.context.globalContext.userId).toBe('123');
+    expect(task.context.globalContext.userId).toBe("123");
     expect(task.context.modeSpecificContext.validateInput).toBe(true);
     expect(task.context.maxTokens).toBe(4000);
   });
@@ -613,6 +644,7 @@ describe('Task System Integration', () => {
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase1-mode-system から作業ブランチを作成
 git checkout phase1-mode-system
@@ -643,6 +675,7 @@ git branch -d phase1-task-system # ローカルの作業ブランチを削除
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase1-mode-system から作業ブランチ作成
 git checkout phase1-mode-system
@@ -674,6 +707,7 @@ git branch -d phase1-task-system
 ## 依存関係
 
 このフェーズはモードシステム（フェーズ1.1）完了後に実装してください。以下のフェーズに必要となります：
+
 - フェーズ2.1: タスク分析エンジン（タスクの複雑度分析）
 - フェーズ2.2: コンテキスト最適化（タスクコンテキストの管理）
 - フェーズ3: GitHub Actionsとの統合

--- a/predev-docs/04-phase2-task-analyzer-design.md
+++ b/predev-docs/04-phase2-task-analyzer-design.md
@@ -5,6 +5,7 @@
 タスク分析エンジンは、複雑なタスクを適切なサブタスクに分解し、各サブタスクに最適なモードを割り当てるオーケストレーション機能の核心部分です。タスクの複雑度を分析し、分割が必要かを判定する機能を実装します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -74,9 +75,7 @@ classDiagram
     TaskAnalyzer --> ModeSelector : uses
 ```
 
-
 ## TDD実装計画
-
 
 ### タスク2.1.1: タスク分析型定義の作成
 
@@ -116,7 +115,7 @@ export interface DependencyGraph {
 export interface DependencyEdge {
   from: string;
   to: string;
-  type: 'sequential' | 'parallel' | 'conditional';
+  type: "sequential" | "parallel" | "conditional";
 }
 
 export interface ModeSelectionRule {
@@ -127,41 +126,40 @@ export interface ModeSelectionRule {
 }
 
 export type ComplexityFactorType =
-  | 'multi_step'
-  | 'cross_domain'
-  | 'file_complexity'
-  | 'integration_required'
-  | 'performance_critical'
-  | 'security_sensitive'
-  | 'legacy_code'
-  | 'external_dependencies';
+  | "multi_step"
+  | "cross_domain"
+  | "file_complexity"
+  | "integration_required"
+  | "performance_critical"
+  | "security_sensitive"
+  | "legacy_code"
+  | "external_dependencies";
 ```
 
 ### タスク2.1.2: 複雑度計算エンジンの実装
-
 
 #### テストファースト: src/orchestration/complexity-calculator.ts
 
 ```typescript
 // test/orchestration/complexity-calculator.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { ComplexityCalculator } from '../../src/orchestration/complexity-calculator';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { ComplexityCalculator } from "../../src/orchestration/complexity-calculator";
 
-describe('ComplexityCalculator', () => {
+describe("ComplexityCalculator", () => {
   let calculator: ComplexityCalculator;
 
   beforeEach(() => {
     calculator = new ComplexityCalculator();
   });
 
-  test('should calculate low complexity for simple tasks', () => {
+  test("should calculate low complexity for simple tasks", () => {
     const simpleTask = "Fix typo in README.md";
     const complexity = calculator.calculateComplexity(simpleTask);
 
     expect(complexity).toBeLessThan(3.0);
   });
 
-  test('should calculate high complexity for multi-step tasks', () => {
+  test("should calculate high complexity for multi-step tasks", () => {
     const complexTask = `
       Implement a complete user authentication system with:
       - User registration and login
@@ -177,28 +175,29 @@ describe('ComplexityCalculator', () => {
     expect(complexity).toBeGreaterThan(7.0);
   });
 
-  test('should identify complexity factors correctly', () => {
-    const task = "Refactor legacy payment processing system to support new payment methods";
+  test("should identify complexity factors correctly", () => {
+    const task =
+      "Refactor legacy payment processing system to support new payment methods";
     const factors = calculator.identifyComplexityFactors(task);
 
-    const factorTypes = factors.map(f => f.type);
-    expect(factorTypes).toContain('legacy_code');
-    expect(factorTypes).toContain('integration_required');
+    const factorTypes = factors.map((f) => f.type);
+    expect(factorTypes).toContain("legacy_code");
+    expect(factorTypes).toContain("integration_required");
   });
 
-  test('should use appropriate complexity threshold', () => {
+  test("should use appropriate complexity threshold", () => {
     const threshold = calculator.getComplexityThreshold();
     expect(threshold).toBeGreaterThan(0);
     expect(threshold).toBeLessThan(10);
   });
 
-  test('should handle edge cases gracefully', () => {
+  test("should handle edge cases gracefully", () => {
     expect(() => calculator.calculateComplexity("")).not.toThrow();
     expect(() => calculator.calculateComplexity("   ")).not.toThrow();
     expect(calculator.calculateComplexity("")).toBe(0);
   });
 
-  test('should assign higher complexity to security-sensitive tasks', () => {
+  test("should assign higher complexity to security-sensitive tasks", () => {
     const securityTask = "Implement OAuth2 authentication with PKCE flow";
     const regularTask = "Add logging to user service";
 
@@ -213,14 +212,17 @@ describe('ComplexityCalculator', () => {
 #### 実装: src/orchestration/complexity-calculator.ts
 
 ```typescript
-import type { ComplexityFactor, ComplexityPattern, ComplexityFactorType } from './types';
+import type {
+  ComplexityFactor,
+  ComplexityPattern,
+  ComplexityFactorType,
+} from "./types";
 
 export class ComplexityCalculator {
   private readonly BASE_COMPLEXITY = 1.0;
   private readonly COMPLEXITY_THRESHOLD = 5.0;
 
-  constructor() {
-  }
+  constructor() {}
 
   calculateComplexity(description: string): number {
     if (!description || description.trim().length === 0) {
@@ -248,72 +250,72 @@ export class ComplexityCalculator {
     // Multi-step complexity
     if (this.hasMultipleSteps(lowerDesc)) {
       factors.push({
-        type: 'multi_step',
+        type: "multi_step",
         weight: 2.5,
-        description: 'Task requires multiple implementation steps'
+        description: "Task requires multiple implementation steps",
       });
     }
 
     // Cross-domain complexity
     if (this.isCrossDomain(lowerDesc)) {
       factors.push({
-        type: 'cross_domain',
+        type: "cross_domain",
         weight: 2.0,
-        description: 'Task spans multiple knowledge domains'
+        description: "Task spans multiple knowledge domains",
       });
     }
 
     // File complexity
     if (this.hasFileComplexity(lowerDesc)) {
       factors.push({
-        type: 'file_complexity',
+        type: "file_complexity",
         weight: 1.5,
-        description: 'Multiple files need modification'
+        description: "Multiple files need modification",
       });
     }
 
     // Integration complexity
     if (this.requiresIntegration(lowerDesc)) {
       factors.push({
-        type: 'integration_required',
+        type: "integration_required",
         weight: 3.0,
-        description: 'Requires integration with external systems'
+        description: "Requires integration with external systems",
       });
     }
 
     // Security sensitivity
     if (this.isSecuritySensitive(lowerDesc)) {
       factors.push({
-        type: 'security_sensitive',
+        type: "security_sensitive",
         weight: 2.5,
-        description: 'Involves security-critical functionality'
+        description: "Involves security-critical functionality",
       });
     }
 
     // Legacy code complexity
     if (this.involvesLegacyCode(lowerDesc)) {
       factors.push({
-        type: 'legacy_code',
+        type: "legacy_code",
         weight: 2.0,
-        description: 'Involves working with legacy code'
+        description: "Involves working with legacy code",
       });
     }
 
     // Performance critical
     if (this.isPerformanceCritical(lowerDesc)) {
       factors.push({
-        type: 'performance_critical',
+        type: "performance_critical",
         weight: 1.8,
-        description: 'Performance optimization required'
+        description: "Performance optimization required",
       });
     }
 
     // External dependencies
     if (this.hasExternalDependencies(lowerDesc)) {
       factors.push({
-        type: 'external_dependencies',
+        type: "external_dependencies",
         weight: 1.5,
-        description: 'Depends on external libraries or services'
+        description: "Depends on external libraries or services",
       });
     }
 
@@ -330,7 +332,7 @@ export class ComplexityCalculator {
       /\b(step|phase|stage)\s*\d+/gi,
       /\b(first|second|third|finally)/gi,
       /[•\-\*]\s/g, // bullet points
-      /\d+\.\s/g    // numbered lists
+      /\d+\.\s/g, // numbered lists
     ];
 
     let stepCount = 0;
@@ -345,9 +347,21 @@ export class ComplexityCalculator {
   }
 
   private isCrossDomain(description: string): boolean {
-    const domains = ['frontend', 'backend', 'database', 'api', 'ui', 'ux', 'testing', 'deployment', 'security'];
-    const mentionedDomains = domains.filter(domain =>
-      description.includes(domain) || description.includes(domain.toUpperCase())
+    const domains = [
+      "frontend",
+      "backend",
+      "database",
+      "api",
+      "ui",
+      "ux",
+      "testing",
+      "deployment",
+      "security",
+    ];
+    const mentionedDomains = domains.filter(
+      (domain) =>
+        description.includes(domain) ||
+        description.includes(domain.toUpperCase()),
     );
     return mentionedDomains.length >= 2;
   }
@@ -357,63 +371,104 @@ export class ComplexityCalculator {
       /\bmultiple\s+(files|components|modules)/i,
       /\bseveral\s+(files|components|modules)/i,
       /\bacross\s+(files|components|modules)/i,
-      /\brefactor\s+.*\s+(files|codebase)/i
+      /\brefactor\s+.*\s+(files|codebase)/i,
     ];
 
-    return fileIndicators.some(pattern => pattern.test(description));
+    return fileIndicators.some((pattern) => pattern.test(description));
   }
 
   private requiresIntegration(description: string): boolean {
     const integrationKeywords = [
-      'integrate', 'api', 'webhook', 'external', 'third-party', 'service',
-      'database', 'connect', 'sync', 'import', 'export'
+      "integrate",
+      "api",
+      "webhook",
+      "external",
+      "third-party",
+      "service",
+      "database",
+      "connect",
+      "sync",
+      "import",
+      "export",
     ];
 
-    return integrationKeywords.some(keyword =>
-      description.toLowerCase().includes(keyword)
+    return integrationKeywords.some((keyword) =>
+      description.toLowerCase().includes(keyword),
     );
   }
 
   private isSecuritySensitive(description: string): boolean {
     const securityKeywords = [
-      'auth', 'authentication', 'authorization', 'security', 'encrypt',
-      'jwt', 'token', 'password', 'oauth', 'permission', 'role', 'access'
+      "auth",
+      "authentication",
+      "authorization",
+      "security",
+      "encrypt",
+      "jwt",
+      "token",
+      "password",
+      "oauth",
+      "permission",
+      "role",
+      "access",
     ];
 
-    return securityKeywords.some(keyword =>
-      description.toLowerCase().includes(keyword)
+    return securityKeywords.some((keyword) =>
+      description.toLowerCase().includes(keyword),
     );
   }
 
   private involvesLegacyCode(description: string): boolean {
     const legacyIndicators = [
-      'legacy', 'refactor', 'migrate', 'modernize', 'upgrade', 'replace'
+      "legacy",
+      "refactor",
+      "migrate",
+      "modernize",
+      "upgrade",
+      "replace",
     ];
 
-    return legacyIndicators.some(keyword =>
-      description.toLowerCase().includes(keyword)
+    return legacyIndicators.some((keyword) =>
+      description.toLowerCase().includes(keyword),
     );
   }
 
   private isPerformanceCritical(description: string): boolean {
     const performanceKeywords = [
-      'performance', 'optimize', 'speed', 'fast', 'efficient', 'cache',
-      'memory', 'cpu', 'latency', 'throughput', 'scale'
+      "performance",
+      "optimize",
+      "speed",
+      "fast",
+      "efficient",
+      "cache",
+      "memory",
+      "cpu",
+      "latency",
+      "throughput",
+      "scale",
     ];
 
-    return performanceKeywords.some(keyword =>
-      description.toLowerCase().includes(keyword)
+    return performanceKeywords.some((keyword) =>
+      description.toLowerCase().includes(keyword),
     );
   }
 
   private hasExternalDependencies(description: string): boolean {
     const dependencyIndicators = [
-      'library', 'package', 'npm', 'dependency', 'external', 'third-party',
-      'framework', 'tool', 'service', 'api'
+      "library",
+      "package",
+      "npm",
+      "dependency",
+      "external",
+      "third-party",
+      "framework",
+      "tool",
+      "service",
+      "api",
     ];
 
-    return dependencyIndicators.some(keyword =>
-      description.toLowerCase().includes(keyword)
+    return dependencyIndicators.some((keyword) =>
+      description.toLowerCase().includes(keyword),
     );
   }
 
@@ -429,22 +484,21 @@ export class ComplexityCalculator {
 
 ### タスク2.1.3: タスク分析エンジンの実装
 
-
 #### テストファースト: src/orchestration/task-analyzer.ts
 
 ```typescript
 // test/orchestration/task-analyzer.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { TaskAnalyzer } from '../../src/orchestration/task-analyzer';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { TaskAnalyzer } from "../../src/orchestration/task-analyzer";
 
-describe('TaskAnalyzer', () => {
+describe("TaskAnalyzer", () => {
   let analyzer: TaskAnalyzer;
 
   beforeEach(() => {
     analyzer = new TaskAnalyzer();
   });
 
-  test('should analyze simple task correctly', () => {
+  test("should analyze simple task correctly", () => {
     const task = "Fix typo in documentation";
     const analysis = analyzer.analyzeTask(task);
 
@@ -453,7 +507,7 @@ describe('TaskAnalyzer', () => {
     expect(analysis.estimatedSubtasks).toBeLessThanOrEqual(1);
   });
 
-  test('should analyze complex task correctly', () => {
+  test("should analyze complex task correctly", () => {
     const task = `
       Implement a complete user management system with:
       1. User registration and authentication
@@ -472,7 +526,7 @@ describe('TaskAnalyzer', () => {
     expect(analysis.requiredModes.length).toBeGreaterThan(1);
   });
 
-  test('should determine required modes correctly', () => {
+  test("should determine required modes correctly", () => {
     const designTask = "Design system architecture for microservices";
     const codeTask = "Implement user authentication API";
     const debugTask = "Fix memory leak in payment processor";
@@ -481,14 +535,15 @@ describe('TaskAnalyzer', () => {
     const codeAnalysis = analyzer.analyzeTask(codeTask);
     const debugAnalysis = analyzer.analyzeTask(debugTask);
 
-    expect(designAnalysis.requiredModes).toContain('architect');
-    expect(codeAnalysis.requiredModes).toContain('code');
-    expect(debugAnalysis.requiredModes).toContain('debug');
+    expect(designAnalysis.requiredModes).toContain("architect");
+    expect(codeAnalysis.requiredModes).toContain("code");
+    expect(debugAnalysis.requiredModes).toContain("debug");
   });
 
-  test('should decide orchestration necessity correctly', () => {
+  test("should decide orchestration necessity correctly", () => {
     const simpleTask = "Update package.json version";
-    const complexTask = "Implement complete CI/CD pipeline with testing, building, and deployment";
+    const complexTask =
+      "Implement complete CI/CD pipeline with testing, building, and deployment";
 
     const simpleAnalysis = analyzer.analyzeTask(simpleTask);
     const complexAnalysis = analyzer.analyzeTask(complexTask);
@@ -497,7 +552,7 @@ describe('TaskAnalyzer', () => {
     expect(analyzer.shouldOrchestrate(complexAnalysis)).toBe(true);
   });
 
-  test('should provide meaningful suggested approach', () => {
+  test("should provide meaningful suggested approach", () => {
     const task = "Migrate from REST API to GraphQL";
     const analysis = analyzer.analyzeTask(task);
 
@@ -505,7 +560,7 @@ describe('TaskAnalyzer', () => {
     expect(analysis.suggestedApproach.length).toBeGreaterThan(10);
   });
 
-  test('should handle edge cases gracefully', () => {
+  test("should handle edge cases gracefully", () => {
     expect(() => analyzer.analyzeTask("")).not.toThrow();
     expect(() => analyzer.analyzeTask("   ")).not.toThrow();
 
@@ -519,9 +574,9 @@ describe('TaskAnalyzer', () => {
 #### 実装: src/orchestration/task-analyzer.ts
 
 ```typescript
-import { ComplexityCalculator } from './complexity-calculator';
-import { ModeSelector } from './mode-selector';
-import type { TaskAnalysis } from './types';
+import { ComplexityCalculator } from "./complexity-calculator";
+import { ModeSelector } from "./mode-selector";
+import type { TaskAnalysis } from "./types";
 
 export class TaskAnalyzer {
   private complexityCalculator: ComplexityCalculator;
@@ -538,12 +593,21 @@ export class TaskAnalyzer {
       return this.createEmptyAnalysis();
     }
 
-    const complexity = this.complexityCalculator.calculateComplexity(description);
-    const complexityFactors = this.complexityCalculator.identifyComplexityFactors(description);
+    const complexity =
+      this.complexityCalculator.calculateComplexity(description);
+    const complexityFactors =
+      this.complexityCalculator.identifyComplexityFactors(description);
     const requiredModes = this.determineRequiredModes(description);
     const requiresOrchestration = complexity >= this.ORCHESTRATION_THRESHOLD;
-    const estimatedSubtasks = this.estimateSubtaskCount(complexity, description);
-    const suggestedApproach = this.generateSuggestedApproach(description, complexity, requiredModes);
+    const estimatedSubtasks = this.estimateSubtaskCount(
+      complexity,
+      description,
+    );
+    const suggestedApproach = this.generateSuggestedApproach(
+      description,
+      complexity,
+      requiredModes,
+    );
 
     return {
       complexity,
@@ -551,7 +615,7 @@ export class TaskAnalyzer {
       requiredModes,
       requiresOrchestration,
       estimatedSubtasks,
-      suggestedApproach
+      suggestedApproach,
     };
   }
 
@@ -565,32 +629,32 @@ export class TaskAnalyzer {
 
     // Architecture/Design indicators
     if (this.hasArchitectureKeywords(lowerDesc)) {
-      modes.add('architect');
+      modes.add("architect");
     }
 
     // Code implementation indicators
     if (this.hasCodeKeywords(lowerDesc)) {
-      modes.add('code');
+      modes.add("code");
     }
 
     // Debugging indicators
     if (this.hasDebugKeywords(lowerDesc)) {
-      modes.add('debug');
+      modes.add("debug");
     }
 
     // Documentation/Knowledge indicators
     if (this.hasAskKeywords(lowerDesc)) {
-      modes.add('ask');
+      modes.add("ask");
     }
 
     // Complex tasks that need orchestration
     if (this.needsOrchestration(lowerDesc)) {
-      modes.add('orchestrator');
+      modes.add("orchestrator");
     }
 
     // If no specific mode identified, default to code
     if (modes.size === 0) {
-      modes.add('code');
+      modes.add("code");
     }
 
     return Array.from(modes);
@@ -607,51 +671,104 @@ export class TaskAnalyzer {
       requiredModes: [],
       requiresOrchestration: false,
       estimatedSubtasks: 0,
-      suggestedApproach: 'No task description provided'
+      suggestedApproach: "No task description provided",
     };
   }
 
   private hasArchitectureKeywords(description: string): boolean {
     const architectureKeywords = [
-      'design', 'architecture', 'structure', 'plan', 'blueprint', 'schema',
-      'system design', 'high-level', 'overview', 'strategy', 'approach'
+      "design",
+      "architecture",
+      "structure",
+      "plan",
+      "blueprint",
+      "schema",
+      "system design",
+      "high-level",
+      "overview",
+      "strategy",
+      "approach",
     ];
-    return architectureKeywords.some(keyword => description.includes(keyword));
+    return architectureKeywords.some((keyword) =>
+      description.includes(keyword),
+    );
   }
 
   private hasCodeKeywords(description: string): boolean {
     const codeKeywords = [
-      'implement', 'code', 'develop', 'build', 'create', 'function',
-      'class', 'method', 'algorithm', 'feature', 'component', 'module'
+      "implement",
+      "code",
+      "develop",
+      "build",
+      "create",
+      "function",
+      "class",
+      "method",
+      "algorithm",
+      "feature",
+      "component",
+      "module",
     ];
-    return codeKeywords.some(keyword => description.includes(keyword));
+    return codeKeywords.some((keyword) => description.includes(keyword));
   }
 
   private hasDebugKeywords(description: string): boolean {
     const debugKeywords = [
-      'fix', 'bug', 'error', 'issue', 'problem', 'debug', 'troubleshoot',
-      'investigate', 'diagnose', 'resolve', 'repair'
+      "fix",
+      "bug",
+      "error",
+      "issue",
+      "problem",
+      "debug",
+      "troubleshoot",
+      "investigate",
+      "diagnose",
+      "resolve",
+      "repair",
     ];
-    return debugKeywords.some(keyword => description.includes(keyword));
+    return debugKeywords.some((keyword) => description.includes(keyword));
   }
 
   private hasAskKeywords(description: string): boolean {
     const askKeywords = [
-      'explain', 'how', 'what', 'why', 'when', 'where', 'documentation',
-      'understand', 'clarify', 'describe', 'tell me', 'help me understand'
+      "explain",
+      "how",
+      "what",
+      "why",
+      "when",
+      "where",
+      "documentation",
+      "understand",
+      "clarify",
+      "describe",
+      "tell me",
+      "help me understand",
     ];
-    return askKeywords.some(keyword => description.includes(keyword));
+    return askKeywords.some((keyword) => description.includes(keyword));
   }
 
   private needsOrchestration(description: string): boolean {
     const orchestrationIndicators = [
-      'complete', 'entire', 'full', 'comprehensive', 'end-to-end',
-      'multiple', 'several', 'various', 'different', 'across'
+      "complete",
+      "entire",
+      "full",
+      "comprehensive",
+      "end-to-end",
+      "multiple",
+      "several",
+      "various",
+      "different",
+      "across",
     ];
-    return orchestrationIndicators.some(keyword => description.includes(keyword));
+    return orchestrationIndicators.some((keyword) =>
+      description.includes(keyword),
+    );
   }
 
-  private estimateSubtaskCount(complexity: number, description: string): number {
+  private estimateSubtaskCount(
+    complexity: number,
+    description: string,
+  ): number {
     // Base estimation from complexity
     let subtasks = Math.ceil(complexity / 2);
 
@@ -661,7 +778,8 @@ export class TaskAnalyzer {
       subtasks = Math.max(subtasks, stepMatches.length);
     }
 
-    const listMatches = description.match(/[•\-\*]\s/g) || description.match(/\d+\.\s/g);
+    const listMatches =
+      description.match(/[•\-\*]\s/g) || description.match(/\d+\.\s/g);
     if (listMatches) {
       subtasks = Math.max(subtasks, listMatches.length);
     }
@@ -669,134 +787,141 @@ export class TaskAnalyzer {
     return Math.min(Math.max(subtasks, 1), 10); // Cap between 1 and 10
   }
 
-  private generateSuggestedApproach(description: string, complexity: number, requiredModes: string[]): string {
+  private generateSuggestedApproach(
+    description: string,
+    complexity: number,
+    requiredModes: string[],
+  ): string {
     if (complexity === 0) {
-      return 'No task description provided';
+      return "No task description provided";
     }
 
     if (complexity < 3) {
-      return `Simple task that can be completed directly with ${requiredModes[0] || 'code'} mode.`;
+      return `Simple task that can be completed directly with ${requiredModes[0] || "code"} mode.`;
     }
 
     if (complexity < 5) {
-      return `Moderate complexity task. Consider breaking into 2-3 focused subtasks using ${requiredModes.join(' and ')} modes.`;
+      return `Moderate complexity task. Consider breaking into 2-3 focused subtasks using ${requiredModes.join(" and ")} modes.`;
     }
 
     const approach = [];
 
-    if (requiredModes.includes('architect')) {
-      approach.push('Start with architectural design and planning');
+    if (requiredModes.includes("architect")) {
+      approach.push("Start with architectural design and planning");
     }
 
-    if (requiredModes.includes('code')) {
-      approach.push('Break implementation into focused, manageable components');
+    if (requiredModes.includes("code")) {
+      approach.push("Break implementation into focused, manageable components");
     }
 
-    if (requiredModes.includes('debug')) {
-      approach.push('Include systematic testing and debugging phases');
+    if (requiredModes.includes("debug")) {
+      approach.push("Include systematic testing and debugging phases");
     }
 
-    approach.push('Use orchestration to coordinate between different modes and subtasks');
+    approach.push(
+      "Use orchestration to coordinate between different modes and subtasks",
+    );
 
-    return approach.join('. ') + '.';
+    return approach.join(". ") + ".";
   }
 }
 ```
 
 ### タスク2.1.4: モード選択エンジンの実装
 
-
 #### テストファースト: src/orchestration/mode-selector.ts
 
 ```typescript
 // test/orchestration/mode-selector.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { ModeSelector } from '../../src/orchestration/mode-selector';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { ModeSelector } from "../../src/orchestration/mode-selector";
 
-describe('ModeSelector', () => {
+describe("ModeSelector", () => {
   let selector: ModeSelector;
 
   beforeEach(() => {
     selector = new ModeSelector();
   });
 
-  test('should select architect mode for design tasks', () => {
+  test("should select architect mode for design tasks", () => {
     const designTasks = [
       "Design the overall system architecture",
       "Create a high-level plan for the microservices",
-      "Plan the database schema for user management"
+      "Plan the database schema for user management",
     ];
 
-    designTasks.forEach(task => {
+    designTasks.forEach((task) => {
       const mode = selector.selectOptimalMode(task);
-      expect(mode).toBe('architect');
+      expect(mode).toBe("architect");
     });
   });
 
-  test('should select code mode for implementation tasks', () => {
+  test("should select code mode for implementation tasks", () => {
     const codeTasks = [
       "Implement user authentication API",
       "Create React component for user profile",
-      "Develop payment processing service"
+      "Develop payment processing service",
     ];
 
-    codeTasks.forEach(task => {
+    codeTasks.forEach((task) => {
       const mode = selector.selectOptimalMode(task);
-      expect(mode).toBe('code');
+      expect(mode).toBe("code");
     });
   });
 
-  test('should select debug mode for troubleshooting tasks', () => {
+  test("should select debug mode for troubleshooting tasks", () => {
     const debugTasks = [
       "Fix memory leak in payment processor",
       "Debug authentication issues",
-      "Resolve performance problems in search"
+      "Resolve performance problems in search",
     ];
 
-    debugTasks.forEach(task => {
+    debugTasks.forEach((task) => {
       const mode = selector.selectOptimalMode(task);
-      expect(mode).toBe('debug');
+      expect(mode).toBe("debug");
     });
   });
 
-  test('should select ask mode for informational tasks', () => {
+  test("should select ask mode for informational tasks", () => {
     const askTasks = [
       "Explain how OAuth2 works",
       "What are the best practices for API design?",
-      "How should we structure our TypeScript project?"
+      "How should we structure our TypeScript project?",
     ];
 
-    askTasks.forEach(task => {
+    askTasks.forEach((task) => {
       const mode = selector.selectOptimalMode(task);
-      expect(mode).toBe('ask');
+      expect(mode).toBe("ask");
     });
   });
 
-  test('should evaluate mode match scores correctly', () => {
+  test("should evaluate mode match scores correctly", () => {
     const task = "Implement user authentication with JWT tokens";
 
-    const codeScore = selector.evaluateModeMatch(task, 'code');
-    const architectScore = selector.evaluateModeMatch(task, 'architect');
-    const debugScore = selector.evaluateModeMatch(task, 'debug');
+    const codeScore = selector.evaluateModeMatch(task, "code");
+    const architectScore = selector.evaluateModeMatch(task, "architect");
+    const debugScore = selector.evaluateModeMatch(task, "debug");
 
     expect(codeScore).toBeGreaterThan(architectScore);
     expect(codeScore).toBeGreaterThan(debugScore);
   });
 
-  test('should get mode capabilities correctly', () => {
-    const codeCapabilities = selector.getModeCapabilities('code');
-    const architectCapabilities = selector.getModeCapabilities('architect');
+  test("should get mode capabilities correctly", () => {
+    const codeCapabilities = selector.getModeCapabilities("code");
+    const architectCapabilities = selector.getModeCapabilities("architect");
 
-    expect(codeCapabilities).toContain('implementation');
-    expect(architectCapabilities).toContain('design');
+    expect(codeCapabilities).toContain("implementation");
+    expect(architectCapabilities).toContain("design");
   });
 
-  test('should handle ambiguous tasks gracefully', () => {
+  test("should handle ambiguous tasks gracefully", () => {
     const ambiguousTask = "Work on the user system";
     const mode = selector.selectOptimalMode(ambiguousTask);
 
     // Should return a valid mode (defaulting to code if unclear)
-    expect(['code', 'architect', 'debug', 'ask', 'orchestrator']).toContain(mode);
+    expect(["code", "architect", "debug", "ask", "orchestrator"]).toContain(
+      mode,
+    );
   });
 });
 ```
@@ -804,8 +929,8 @@ describe('ModeSelector', () => {
 #### 実装: src/orchestration/mode-selector.ts
 
 ```typescript
-import { modeManager } from '../modes';
-import type { ModeSelectionRule } from './types';
+import { modeManager } from "../modes";
+import type { ModeSelectionRule } from "./types";
 
 export class ModeSelector {
   private selectionRules: ModeSelectionRule[];
@@ -816,7 +941,7 @@ export class ModeSelector {
 
   selectOptimalMode(subtask: string): string {
     const lowerTask = subtask.toLowerCase();
-    let bestMatch = { mode: 'code', score: 0 };
+    let bestMatch = { mode: "code", score: 0 };
 
     // Evaluate each available mode
     const availableModes = modeManager.getAllModes();
@@ -854,26 +979,49 @@ export class ModeSelector {
 
   getModeCapabilities(mode: string): string[] {
     const capabilityMap: Record<string, string[]> = {
-      'code': [
-        'implementation', 'coding', 'development', 'programming',
-        'feature creation', 'component building', 'algorithm implementation'
+      code: [
+        "implementation",
+        "coding",
+        "development",
+        "programming",
+        "feature creation",
+        "component building",
+        "algorithm implementation",
       ],
-      'architect': [
-        'design', 'planning', 'architecture', 'system design',
-        'high-level planning', 'technical specifications', 'blueprints'
+      architect: [
+        "design",
+        "planning",
+        "architecture",
+        "system design",
+        "high-level planning",
+        "technical specifications",
+        "blueprints",
       ],
-      'debug': [
-        'troubleshooting', 'bug fixing', 'problem solving', 'diagnostics',
-        'error resolution', 'performance analysis', 'investigation'
+      debug: [
+        "troubleshooting",
+        "bug fixing",
+        "problem solving",
+        "diagnostics",
+        "error resolution",
+        "performance analysis",
+        "investigation",
       ],
-      'ask': [
-        'information', 'explanation', 'documentation', 'guidance',
-        'knowledge sharing', 'clarification', 'educational content'
+      ask: [
+        "information",
+        "explanation",
+        "documentation",
+        "guidance",
+        "knowledge sharing",
+        "clarification",
+        "educational content",
       ],
-      'orchestrator': [
-        'task coordination', 'workflow management', 'delegation',
-        'complex task breakdown', 'multi-mode coordination'
-      ]
+      orchestrator: [
+        "task coordination",
+        "workflow management",
+        "delegation",
+        "complex task breakdown",
+        "multi-mode coordination",
+      ],
     };
 
     return capabilityMap[mode] || [];
@@ -883,88 +1031,140 @@ export class ModeSelector {
     return [
       // Architect mode rules
       {
-        pattern: /\b(design|architecture|plan|blueprint|structure|schema|strategy)\b/i,
-        mode: 'architect',
-        priority: 3
+        pattern:
+          /\b(design|architecture|plan|blueprint|structure|schema|strategy)\b/i,
+        mode: "architect",
+        priority: 3,
       },
       {
         pattern: /\b(high-level|overview|system design|architectural)\b/i,
-        mode: 'architect',
-        priority: 2
+        mode: "architect",
+        priority: 2,
       },
 
       // Code mode rules
       {
         pattern: /\b(implement|code|develop|build|create|write)\b/i,
-        mode: 'code',
-        priority: 3
+        mode: "code",
+        priority: 3,
       },
       {
         pattern: /\b(function|method|class|component|feature|api|endpoint)\b/i,
-        mode: 'code',
-        priority: 2
+        mode: "code",
+        priority: 2,
       },
 
       // Debug mode rules
       {
         pattern: /\b(fix|bug|error|issue|problem|debug|troubleshoot)\b/i,
-        mode: 'debug',
-        priority: 3
+        mode: "debug",
+        priority: 3,
       },
       {
         pattern: /\b(resolve|investigate|diagnose|repair|performance)\b/i,
-        mode: 'debug',
-        priority: 2
+        mode: "debug",
+        priority: 2,
       },
 
       // Ask mode rules
       {
         pattern: /\b(explain|how|what|why|when|where|documentation)\b/i,
-        mode: 'ask',
-        priority: 3
+        mode: "ask",
+        priority: 3,
       },
       {
         pattern: /\b(understand|clarify|describe|help me|tell me)\b/i,
-        mode: 'ask',
-        priority: 2
+        mode: "ask",
+        priority: 2,
       },
 
       // Orchestrator mode rules
       {
         pattern: /\b(complete|entire|full|comprehensive|end-to-end)\b/i,
-        mode: 'orchestrator',
-        priority: 2
+        mode: "orchestrator",
+        priority: 2,
       },
       {
         pattern: /\b(multiple|several|various|different|across)\b/i,
-        mode: 'orchestrator',
-        priority: 1
-      }
+        mode: "orchestrator",
+        priority: 1,
+      },
     ];
   }
 
   private getModeKeywords(mode: string): string[] {
     const keywordMap: Record<string, string[]> = {
-      'architect': [
-        'design', 'architecture', 'plan', 'blueprint', 'structure', 'schema',
-        'strategy', 'high-level', 'overview', 'system design', 'planning'
+      architect: [
+        "design",
+        "architecture",
+        "plan",
+        "blueprint",
+        "structure",
+        "schema",
+        "strategy",
+        "high-level",
+        "overview",
+        "system design",
+        "planning",
       ],
-      'code': [
-        'implement', 'code', 'develop', 'build', 'create', 'write', 'function',
-        'method', 'class', 'component', 'feature', 'api', 'endpoint', 'algorithm'
+      code: [
+        "implement",
+        "code",
+        "develop",
+        "build",
+        "create",
+        "write",
+        "function",
+        "method",
+        "class",
+        "component",
+        "feature",
+        "api",
+        "endpoint",
+        "algorithm",
       ],
-      'debug': [
-        'fix', 'bug', 'error', 'issue', 'problem', 'debug', 'troubleshoot',
-        'resolve', 'investigate', 'diagnose', 'repair', 'performance'
+      debug: [
+        "fix",
+        "bug",
+        "error",
+        "issue",
+        "problem",
+        "debug",
+        "troubleshoot",
+        "resolve",
+        "investigate",
+        "diagnose",
+        "repair",
+        "performance",
       ],
-      'ask': [
-        'explain', 'how', 'what', 'why', 'when', 'where', 'documentation',
-        'understand', 'clarify', 'describe', 'help', 'tell', 'guide'
+      ask: [
+        "explain",
+        "how",
+        "what",
+        "why",
+        "when",
+        "where",
+        "documentation",
+        "understand",
+        "clarify",
+        "describe",
+        "help",
+        "tell",
+        "guide",
       ],
-      'orchestrator': [
-        'complete', 'entire', 'full', 'comprehensive', 'end-to-end',
-        'multiple', 'several', 'various', 'different', 'across', 'coordinate'
-      ]
+      orchestrator: [
+        "complete",
+        "entire",
+        "full",
+        "comprehensive",
+        "end-to-end",
+        "multiple",
+        "several",
+        "various",
+        "different",
+        "across",
+        "coordinate",
+      ],
     };
 
     return keywordMap[mode] || [];
@@ -975,6 +1175,7 @@ export class ModeSelector {
 ## コミット計画
 
 ### コミット1: タスク分析型定義
+
 ```bash
 # プリコミットチェック
 bun test
@@ -987,6 +1188,7 @@ git commit -m "feat(orchestration): add task analysis type definitions"
 ```
 
 ### コミット2: 複雑度計算エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -999,6 +1201,7 @@ git commit -m "feat(orchestration): implement complexity calculation engine with
 ```
 
 ### コミット3: タスク分析エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1011,6 +1214,7 @@ git commit -m "feat(orchestration): implement task analysis engine with tests"
 ```
 
 ### コミット4: モード選択エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1023,6 +1227,7 @@ git commit -m "feat(orchestration): implement mode selection engine with tests"
 ```
 
 ### コミット5: エクスポート設定
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1062,22 +1267,22 @@ export type {
   SubTask,
   DependencyGraph,
   ModeSelectionRule,
-  ComplexityFactorType
-} from './types';
-export { ComplexityCalculator } from './complexity-calculator';
-export { TaskAnalyzer } from './task-analyzer';
-export { ModeSelector } from './mode-selector';
+  ComplexityFactorType,
+} from "./types";
+export { ComplexityCalculator } from "./complexity-calculator";
+export { TaskAnalyzer } from "./task-analyzer";
+export { ModeSelector } from "./mode-selector";
 ```
 
 ## 統合テスト
 
 ```typescript
 // test/orchestration/integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { TaskAnalyzer } from '../../src/orchestration';
+import { describe, test, expect } from "bun:test";
+import { TaskAnalyzer } from "../../src/orchestration";
 
-describe('Task Analysis Integration', () => {
-  test('should handle end-to-end task analysis workflow', () => {
+describe("Task Analysis Integration", () => {
+  test("should handle end-to-end task analysis workflow", () => {
     const analyzer = new TaskAnalyzer();
 
     const complexTask = `
@@ -1096,15 +1301,15 @@ describe('Task Analysis Integration', () => {
 
     expect(analysis.complexity).toBeGreaterThan(8.0);
     expect(analysis.requiresOrchestration).toBe(true);
-    expect(analysis.requiredModes).toContain('orchestrator');
-    expect(analysis.requiredModes).toContain('architect');
-    expect(analysis.requiredModes).toContain('code');
+    expect(analysis.requiredModes).toContain("orchestrator");
+    expect(analysis.requiredModes).toContain("architect");
+    expect(analysis.requiredModes).toContain("code");
     expect(analysis.estimatedSubtasks).toBeGreaterThanOrEqual(6);
     expect(analysis.complexityFactors.length).toBeGreaterThan(0);
-    expect(analysis.suggestedApproach).toContain('orchestration');
+    expect(analysis.suggestedApproach).toContain("orchestration");
   });
 
-  test('should handle simple task analysis workflow', () => {
+  test("should handle simple task analysis workflow", () => {
     const analyzer = new TaskAnalyzer();
 
     const simpleTask = "Fix typo in user profile component";
@@ -1113,10 +1318,10 @@ describe('Task Analysis Integration', () => {
     expect(analysis.complexity).toBeLessThan(3.0);
     expect(analysis.requiresOrchestration).toBe(false);
     expect(analysis.estimatedSubtasks).toBeLessThanOrEqual(1);
-    expect(analysis.requiredModes).toContain('code');
+    expect(analysis.requiredModes).toContain("code");
   });
 
-  test('should provide consistent analysis results', () => {
+  test("should provide consistent analysis results", () => {
     const analyzer = new TaskAnalyzer();
     const task = "Implement OAuth2 authentication with PKCE flow";
 
@@ -1124,7 +1329,9 @@ describe('Task Analysis Integration', () => {
     const analysis2 = analyzer.analyzeTask(task);
 
     expect(analysis1.complexity).toBe(analysis2.complexity);
-    expect(analysis1.requiresOrchestration).toBe(analysis2.requiresOrchestration);
+    expect(analysis1.requiresOrchestration).toBe(
+      analysis2.requiresOrchestration,
+    );
     expect(analysis1.requiredModes).toEqual(analysis2.requiredModes);
   });
 });
@@ -1133,6 +1340,7 @@ describe('Task Analysis Integration', () => {
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase1-task-system から作業ブランチを作成
 git checkout phase1-task-system
@@ -1163,6 +1371,7 @@ git branch -d phase2-task-analyzer # ローカルの作業ブランチを削除
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase1-task-system から作業ブランチ作成
 git checkout phase1-task-system
@@ -1194,6 +1403,7 @@ git branch -d phase2-task-analyzer
 ## 依存関係
 
 このフェーズはフェーズ1（モードシステム、タスクシステム）完了後に実装してください。以下のフェーズに必要となります：
+
 - フェーズ2.2: コンテキスト最適化（分析結果の活用）
 - フェーズ3: GitHub Actionsとの統合
 - フェーズ4: MCP拡張（new_taskツール）

--- a/predev-docs/04-phase2-task-analyzer-design.md
+++ b/predev-docs/04-phase2-task-analyzer-design.md
@@ -1,0 +1,1205 @@
+# フェーズ2.1: タスク分析エンジン - 詳細設計
+
+## 概要
+
+タスク分析エンジンは、複雑なタスクを適切なサブタスクに分解し、各サブタスクに最適なモードを割り当てるオーケストレーション機能の核心部分です。タスクの複雑度を分析し、分割が必要かを判定する機能を実装します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class TaskAnalyzer {
+        -complexityCalculator: ComplexityCalculator
+        -modeSelector: ModeSelector
+        +analyzeTask(description: string): TaskAnalysis
+        +calculateComplexity(task: string): number
+        +determineRequiredModes(task: string): string[]
+        +shouldOrchestrate(analysis: TaskAnalysis): boolean
+    }
+
+    class ComplexityCalculator {
+        -patterns: ComplexityPattern[]
+        +calculateComplexity(description: string): number
+        +identifyComplexityFactors(description: string): ComplexityFactor[]
+        +getComplexityThreshold(): number
+    }
+
+    class SubtaskGenerator {
+        -taskAnalyzer: TaskAnalyzer
+        -dependencyResolver: DependencyResolver
+        +generateSubtasks(analysis: TaskAnalysis): SubTask[]
+        +prioritizeSubtasks(subtasks: SubTask[]): SubTask[]
+        +identifyDependencies(subtasks: SubTask[]): DependencyGraph
+    }
+
+    class ModeSelector {
+        -modeManager: ModeManager
+        -selectionRules: ModeSelectionRule[]
+        +selectOptimalMode(subtask: string): string
+        +getModeCapabilities(mode: string): string[]
+        +evaluateModeMatch(task: string, mode: string): number
+    }
+
+    class TaskAnalysis {
+        <<interface>>
+        +complexity: number
+        +complexityFactors: ComplexityFactor[]
+        +requiredModes: string[]
+        +requiresOrchestration: boolean
+        +estimatedSubtasks: number
+        +suggestedApproach: string
+    }
+
+    class SubTask {
+        +id: string
+        +description: string
+        +mode: string
+        +priority: number
+        +dependencies: string[]
+        +estimatedComplexity: number
+        +estimatedDuration?: number
+    }
+
+    TaskAnalyzer --> ComplexityCalculator : uses
+    TaskAnalyzer --> TaskAnalysis : produces
+    SubtaskGenerator --> TaskAnalyzer : uses
+    SubtaskGenerator --> SubTask : generates
+    TaskAnalyzer --> ModeSelector : uses
+```
+
+
+## TDD実装計画
+
+
+### タスク2.1.1: タスク分析型定義の作成
+
+#### 実装: src/orchestration/types.ts
+
+```typescript
+export interface ComplexityFactor {
+  type: ComplexityFactorType;
+  weight: number;
+  description: string;
+}
+
+export interface TaskAnalysis {
+  complexity: number;
+  complexityFactors: ComplexityFactor[];
+  requiredModes: string[];
+  requiresOrchestration: boolean;
+  estimatedSubtasks: number;
+  suggestedApproach: string;
+}
+
+export interface SubTask {
+  id: string;
+  description: string;
+  mode: string;
+  priority: number;
+  dependencies: string[];
+  estimatedComplexity: number;
+  estimatedDuration?: number;
+}
+
+export interface DependencyGraph {
+  nodes: SubTask[];
+  edges: DependencyEdge[];
+}
+
+export interface DependencyEdge {
+  from: string;
+  to: string;
+  type: 'sequential' | 'parallel' | 'conditional';
+}
+
+export interface ModeSelectionRule {
+  pattern: RegExp;
+  mode: string;
+  priority: number;
+  conditions?: string[];
+}
+
+export type ComplexityFactorType =
+  | 'multi_step'
+  | 'cross_domain'
+  | 'file_complexity'
+  | 'integration_required'
+  | 'performance_critical'
+  | 'security_sensitive'
+  | 'legacy_code'
+  | 'external_dependencies';
+```
+
+### タスク2.1.2: 複雑度計算エンジンの実装
+
+
+#### テストファースト: src/orchestration/complexity-calculator.ts
+
+```typescript
+// test/orchestration/complexity-calculator.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { ComplexityCalculator } from '../../src/orchestration/complexity-calculator';
+
+describe('ComplexityCalculator', () => {
+  let calculator: ComplexityCalculator;
+
+  beforeEach(() => {
+    calculator = new ComplexityCalculator();
+  });
+
+  test('should calculate low complexity for simple tasks', () => {
+    const simpleTask = "Fix typo in README.md";
+    const complexity = calculator.calculateComplexity(simpleTask);
+
+    expect(complexity).toBeLessThan(3.0);
+  });
+
+  test('should calculate high complexity for multi-step tasks', () => {
+    const complexTask = `
+      Implement a complete user authentication system with:
+      - User registration and login
+      - Password reset functionality
+      - Email verification
+      - JWT token management
+      - Rate limiting
+      - Integration with existing database
+    `;
+
+    const complexity = calculator.calculateComplexity(complexTask);
+
+    expect(complexity).toBeGreaterThan(7.0);
+  });
+
+  test('should identify complexity factors correctly', () => {
+    const task = "Refactor legacy payment processing system to support new payment methods";
+    const factors = calculator.identifyComplexityFactors(task);
+
+    const factorTypes = factors.map(f => f.type);
+    expect(factorTypes).toContain('legacy_code');
+    expect(factorTypes).toContain('integration_required');
+  });
+
+  test('should use appropriate complexity threshold', () => {
+    const threshold = calculator.getComplexityThreshold();
+    expect(threshold).toBeGreaterThan(0);
+    expect(threshold).toBeLessThan(10);
+  });
+
+  test('should handle edge cases gracefully', () => {
+    expect(() => calculator.calculateComplexity("")).not.toThrow();
+    expect(() => calculator.calculateComplexity("   ")).not.toThrow();
+    expect(calculator.calculateComplexity("")).toBe(0);
+  });
+
+  test('should assign higher complexity to security-sensitive tasks', () => {
+    const securityTask = "Implement OAuth2 authentication with PKCE flow";
+    const regularTask = "Add logging to user service";
+
+    const securityComplexity = calculator.calculateComplexity(securityTask);
+    const regularComplexity = calculator.calculateComplexity(regularTask);
+
+    expect(securityComplexity).toBeGreaterThan(regularComplexity);
+  });
+});
+```
+
+#### 実装: src/orchestration/complexity-calculator.ts
+
+```typescript
+import type { ComplexityFactor, ComplexityPattern, ComplexityFactorType } from './types';
+
+export class ComplexityCalculator {
+  private readonly BASE_COMPLEXITY = 1.0;
+  private readonly COMPLEXITY_THRESHOLD = 5.0;
+
+  constructor() {
+  }
+
+  calculateComplexity(description: string): number {
+    if (!description || description.trim().length === 0) {
+      return 0;
+    }
+
+    const factors = this.identifyComplexityFactors(description);
+    const baseComplexity = this.BASE_COMPLEXITY;
+
+    // Calculate weighted complexity based on factors
+    const factorComplexity = factors.reduce((total, factor) => {
+      return total + factor.weight;
+    }, 0);
+
+    // Apply length multiplier for very detailed descriptions
+    const lengthMultiplier = this.calculateLengthMultiplier(description);
+
+    return Math.min(baseComplexity + factorComplexity * lengthMultiplier, 10.0);
+  }
+
+  identifyComplexityFactors(description: string): ComplexityFactor[] {
+    const factors: ComplexityFactor[] = [];
+    const lowerDesc = description.toLowerCase();
+
+    // Multi-step complexity
+    if (this.hasMultipleSteps(lowerDesc)) {
+      factors.push({
+        type: 'multi_step',
+        weight: 2.5,
+        description: 'Task requires multiple implementation steps'
+      });
+    }
+
+    // Cross-domain complexity
+    if (this.isCrossDomain(lowerDesc)) {
+      factors.push({
+        type: 'cross_domain',
+        weight: 2.0,
+        description: 'Task spans multiple knowledge domains'
+      });
+    }
+
+    // File complexity
+    if (this.hasFileComplexity(lowerDesc)) {
+      factors.push({
+        type: 'file_complexity',
+        weight: 1.5,
+        description: 'Multiple files need modification'
+      });
+    }
+
+    // Integration complexity
+    if (this.requiresIntegration(lowerDesc)) {
+      factors.push({
+        type: 'integration_required',
+        weight: 3.0,
+        description: 'Requires integration with external systems'
+      });
+    }
+
+    // Security sensitivity
+    if (this.isSecuritySensitive(lowerDesc)) {
+      factors.push({
+        type: 'security_sensitive',
+        weight: 2.5,
+        description: 'Involves security-critical functionality'
+      });
+    }
+
+    // Legacy code complexity
+    if (this.involvesLegacyCode(lowerDesc)) {
+      factors.push({
+        type: 'legacy_code',
+        weight: 2.0,
+        description: 'Involves working with legacy code'
+      });
+    }
+
+    // Performance critical
+    if (this.isPerformanceCritical(lowerDesc)) {
+      factors.push({
+        type: 'performance_critical',
+        weight: 1.8,
+        description: 'Performance optimization required'
+      });
+    }
+
+    // External dependencies
+    if (this.hasExternalDependencies(lowerDesc)) {
+      factors.push({
+        type: 'external_dependencies',
+        weight: 1.5,
+        description: 'Depends on external libraries or services'
+      });
+    }
+
+    return factors;
+  }
+
+  getComplexityThreshold(): number {
+    return this.COMPLEXITY_THRESHOLD;
+  }
+
+  private hasMultipleSteps(description: string): boolean {
+    const stepIndicators = [
+      /\b(and|then|also|additionally|furthermore)/gi,
+      /\b(step|phase|stage)\s*\d+/gi,
+      /\b(first|second|third|finally)/gi,
+      /[•\-\*]\s/g, // bullet points
+      /\d+\.\s/g    // numbered lists
+    ];
+
+    let stepCount = 0;
+    for (const pattern of stepIndicators) {
+      const matches = description.match(pattern);
+      if (matches) {
+        stepCount += matches.length;
+      }
+    }
+
+    return stepCount >= 2;
+  }
+
+  private isCrossDomain(description: string): boolean {
+    const domains = ['frontend', 'backend', 'database', 'api', 'ui', 'ux', 'testing', 'deployment', 'security'];
+    const mentionedDomains = domains.filter(domain =>
+      description.includes(domain) || description.includes(domain.toUpperCase())
+    );
+    return mentionedDomains.length >= 2;
+  }
+
+  private hasFileComplexity(description: string): boolean {
+    const fileIndicators = [
+      /\bmultiple\s+(files|components|modules)/i,
+      /\bseveral\s+(files|components|modules)/i,
+      /\bacross\s+(files|components|modules)/i,
+      /\brefactor\s+.*\s+(files|codebase)/i
+    ];
+
+    return fileIndicators.some(pattern => pattern.test(description));
+  }
+
+  private requiresIntegration(description: string): boolean {
+    const integrationKeywords = [
+      'integrate', 'api', 'webhook', 'external', 'third-party', 'service',
+      'database', 'connect', 'sync', 'import', 'export'
+    ];
+
+    return integrationKeywords.some(keyword =>
+      description.toLowerCase().includes(keyword)
+    );
+  }
+
+  private isSecuritySensitive(description: string): boolean {
+    const securityKeywords = [
+      'auth', 'authentication', 'authorization', 'security', 'encrypt',
+      'jwt', 'token', 'password', 'oauth', 'permission', 'role', 'access'
+    ];
+
+    return securityKeywords.some(keyword =>
+      description.toLowerCase().includes(keyword)
+    );
+  }
+
+  private involvesLegacyCode(description: string): boolean {
+    const legacyIndicators = [
+      'legacy', 'refactor', 'migrate', 'modernize', 'upgrade', 'replace'
+    ];
+
+    return legacyIndicators.some(keyword =>
+      description.toLowerCase().includes(keyword)
+    );
+  }
+
+  private isPerformanceCritical(description: string): boolean {
+    const performanceKeywords = [
+      'performance', 'optimize', 'speed', 'fast', 'efficient', 'cache',
+      'memory', 'cpu', 'latency', 'throughput', 'scale'
+    ];
+
+    return performanceKeywords.some(keyword =>
+      description.toLowerCase().includes(keyword)
+    );
+  }
+
+  private hasExternalDependencies(description: string): boolean {
+    const dependencyIndicators = [
+      'library', 'package', 'npm', 'dependency', 'external', 'third-party',
+      'framework', 'tool', 'service', 'api'
+    ];
+
+    return dependencyIndicators.some(keyword =>
+      description.toLowerCase().includes(keyword)
+    );
+  }
+
+  private calculateLengthMultiplier(description: string): number {
+    const length = description.length;
+    if (length < 100) return 1.0;
+    if (length < 300) return 1.1;
+    if (length < 500) return 1.2;
+    return 1.3;
+  }
+}
+```
+
+### タスク2.1.3: タスク分析エンジンの実装
+
+
+#### テストファースト: src/orchestration/task-analyzer.ts
+
+```typescript
+// test/orchestration/task-analyzer.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TaskAnalyzer } from '../../src/orchestration/task-analyzer';
+
+describe('TaskAnalyzer', () => {
+  let analyzer: TaskAnalyzer;
+
+  beforeEach(() => {
+    analyzer = new TaskAnalyzer();
+  });
+
+  test('should analyze simple task correctly', () => {
+    const task = "Fix typo in documentation";
+    const analysis = analyzer.analyzeTask(task);
+
+    expect(analysis.complexity).toBeLessThan(3.0);
+    expect(analysis.requiresOrchestration).toBe(false);
+    expect(analysis.estimatedSubtasks).toBeLessThanOrEqual(1);
+  });
+
+  test('should analyze complex task correctly', () => {
+    const task = `
+      Implement a complete user management system with:
+      1. User registration and authentication
+      2. Role-based access control
+      3. Email verification system
+      4. Password reset functionality
+      5. Admin dashboard for user management
+      6. Integration with existing payment system
+    `;
+
+    const analysis = analyzer.analyzeTask(task);
+
+    expect(analysis.complexity).toBeGreaterThan(7.0);
+    expect(analysis.requiresOrchestration).toBe(true);
+    expect(analysis.estimatedSubtasks).toBeGreaterThanOrEqual(4);
+    expect(analysis.requiredModes.length).toBeGreaterThan(1);
+  });
+
+  test('should determine required modes correctly', () => {
+    const designTask = "Design system architecture for microservices";
+    const codeTask = "Implement user authentication API";
+    const debugTask = "Fix memory leak in payment processor";
+
+    const designAnalysis = analyzer.analyzeTask(designTask);
+    const codeAnalysis = analyzer.analyzeTask(codeTask);
+    const debugAnalysis = analyzer.analyzeTask(debugTask);
+
+    expect(designAnalysis.requiredModes).toContain('architect');
+    expect(codeAnalysis.requiredModes).toContain('code');
+    expect(debugAnalysis.requiredModes).toContain('debug');
+  });
+
+  test('should decide orchestration necessity correctly', () => {
+    const simpleTask = "Update package.json version";
+    const complexTask = "Implement complete CI/CD pipeline with testing, building, and deployment";
+
+    const simpleAnalysis = analyzer.analyzeTask(simpleTask);
+    const complexAnalysis = analyzer.analyzeTask(complexTask);
+
+    expect(analyzer.shouldOrchestrate(simpleAnalysis)).toBe(false);
+    expect(analyzer.shouldOrchestrate(complexAnalysis)).toBe(true);
+  });
+
+  test('should provide meaningful suggested approach', () => {
+    const task = "Migrate from REST API to GraphQL";
+    const analysis = analyzer.analyzeTask(task);
+
+    expect(analysis.suggestedApproach).toBeTruthy();
+    expect(analysis.suggestedApproach.length).toBeGreaterThan(10);
+  });
+
+  test('should handle edge cases gracefully', () => {
+    expect(() => analyzer.analyzeTask("")).not.toThrow();
+    expect(() => analyzer.analyzeTask("   ")).not.toThrow();
+
+    const emptyAnalysis = analyzer.analyzeTask("");
+    expect(emptyAnalysis.complexity).toBe(0);
+    expect(emptyAnalysis.requiresOrchestration).toBe(false);
+  });
+});
+```
+
+#### 実装: src/orchestration/task-analyzer.ts
+
+```typescript
+import { ComplexityCalculator } from './complexity-calculator';
+import { ModeSelector } from './mode-selector';
+import type { TaskAnalysis } from './types';
+
+export class TaskAnalyzer {
+  private complexityCalculator: ComplexityCalculator;
+  private modeSelector: ModeSelector;
+  private readonly ORCHESTRATION_THRESHOLD = 5.0;
+
+  constructor() {
+    this.complexityCalculator = new ComplexityCalculator();
+    this.modeSelector = new ModeSelector();
+  }
+
+  analyzeTask(description: string): TaskAnalysis {
+    if (!description || description.trim().length === 0) {
+      return this.createEmptyAnalysis();
+    }
+
+    const complexity = this.complexityCalculator.calculateComplexity(description);
+    const complexityFactors = this.complexityCalculator.identifyComplexityFactors(description);
+    const requiredModes = this.determineRequiredModes(description);
+    const requiresOrchestration = complexity >= this.ORCHESTRATION_THRESHOLD;
+    const estimatedSubtasks = this.estimateSubtaskCount(complexity, description);
+    const suggestedApproach = this.generateSuggestedApproach(description, complexity, requiredModes);
+
+    return {
+      complexity,
+      complexityFactors,
+      requiredModes,
+      requiresOrchestration,
+      estimatedSubtasks,
+      suggestedApproach
+    };
+  }
+
+  calculateComplexity(description: string): number {
+    return this.complexityCalculator.calculateComplexity(description);
+  }
+
+  determineRequiredModes(description: string): string[] {
+    const modes = new Set<string>();
+    const lowerDesc = description.toLowerCase();
+
+    // Architecture/Design indicators
+    if (this.hasArchitectureKeywords(lowerDesc)) {
+      modes.add('architect');
+    }
+
+    // Code implementation indicators
+    if (this.hasCodeKeywords(lowerDesc)) {
+      modes.add('code');
+    }
+
+    // Debugging indicators
+    if (this.hasDebugKeywords(lowerDesc)) {
+      modes.add('debug');
+    }
+
+    // Documentation/Knowledge indicators
+    if (this.hasAskKeywords(lowerDesc)) {
+      modes.add('ask');
+    }
+
+    // Complex tasks that need orchestration
+    if (this.needsOrchestration(lowerDesc)) {
+      modes.add('orchestrator');
+    }
+
+    // If no specific mode identified, default to code
+    if (modes.size === 0) {
+      modes.add('code');
+    }
+
+    return Array.from(modes);
+  }
+
+  shouldOrchestrate(analysis: TaskAnalysis): boolean {
+    return analysis.requiresOrchestration;
+  }
+
+  private createEmptyAnalysis(): TaskAnalysis {
+    return {
+      complexity: 0,
+      complexityFactors: [],
+      requiredModes: [],
+      requiresOrchestration: false,
+      estimatedSubtasks: 0,
+      suggestedApproach: 'No task description provided'
+    };
+  }
+
+  private hasArchitectureKeywords(description: string): boolean {
+    const architectureKeywords = [
+      'design', 'architecture', 'structure', 'plan', 'blueprint', 'schema',
+      'system design', 'high-level', 'overview', 'strategy', 'approach'
+    ];
+    return architectureKeywords.some(keyword => description.includes(keyword));
+  }
+
+  private hasCodeKeywords(description: string): boolean {
+    const codeKeywords = [
+      'implement', 'code', 'develop', 'build', 'create', 'function',
+      'class', 'method', 'algorithm', 'feature', 'component', 'module'
+    ];
+    return codeKeywords.some(keyword => description.includes(keyword));
+  }
+
+  private hasDebugKeywords(description: string): boolean {
+    const debugKeywords = [
+      'fix', 'bug', 'error', 'issue', 'problem', 'debug', 'troubleshoot',
+      'investigate', 'diagnose', 'resolve', 'repair'
+    ];
+    return debugKeywords.some(keyword => description.includes(keyword));
+  }
+
+  private hasAskKeywords(description: string): boolean {
+    const askKeywords = [
+      'explain', 'how', 'what', 'why', 'when', 'where', 'documentation',
+      'understand', 'clarify', 'describe', 'tell me', 'help me understand'
+    ];
+    return askKeywords.some(keyword => description.includes(keyword));
+  }
+
+  private needsOrchestration(description: string): boolean {
+    const orchestrationIndicators = [
+      'complete', 'entire', 'full', 'comprehensive', 'end-to-end',
+      'multiple', 'several', 'various', 'different', 'across'
+    ];
+    return orchestrationIndicators.some(keyword => description.includes(keyword));
+  }
+
+  private estimateSubtaskCount(complexity: number, description: string): number {
+    // Base estimation from complexity
+    let subtasks = Math.ceil(complexity / 2);
+
+    // Adjust based on explicit indicators
+    const stepMatches = description.match(/\b(step|phase|stage)\s*\d+/gi);
+    if (stepMatches) {
+      subtasks = Math.max(subtasks, stepMatches.length);
+    }
+
+    const listMatches = description.match(/[•\-\*]\s/g) || description.match(/\d+\.\s/g);
+    if (listMatches) {
+      subtasks = Math.max(subtasks, listMatches.length);
+    }
+
+    return Math.min(Math.max(subtasks, 1), 10); // Cap between 1 and 10
+  }
+
+  private generateSuggestedApproach(description: string, complexity: number, requiredModes: string[]): string {
+    if (complexity === 0) {
+      return 'No task description provided';
+    }
+
+    if (complexity < 3) {
+      return `Simple task that can be completed directly with ${requiredModes[0] || 'code'} mode.`;
+    }
+
+    if (complexity < 5) {
+      return `Moderate complexity task. Consider breaking into 2-3 focused subtasks using ${requiredModes.join(' and ')} modes.`;
+    }
+
+    const approach = [];
+
+    if (requiredModes.includes('architect')) {
+      approach.push('Start with architectural design and planning');
+    }
+
+    if (requiredModes.includes('code')) {
+      approach.push('Break implementation into focused, manageable components');
+    }
+
+    if (requiredModes.includes('debug')) {
+      approach.push('Include systematic testing and debugging phases');
+    }
+
+    approach.push('Use orchestration to coordinate between different modes and subtasks');
+
+    return approach.join('. ') + '.';
+  }
+}
+```
+
+### タスク2.1.4: モード選択エンジンの実装
+
+
+#### テストファースト: src/orchestration/mode-selector.ts
+
+```typescript
+// test/orchestration/mode-selector.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { ModeSelector } from '../../src/orchestration/mode-selector';
+
+describe('ModeSelector', () => {
+  let selector: ModeSelector;
+
+  beforeEach(() => {
+    selector = new ModeSelector();
+  });
+
+  test('should select architect mode for design tasks', () => {
+    const designTasks = [
+      "Design the overall system architecture",
+      "Create a high-level plan for the microservices",
+      "Plan the database schema for user management"
+    ];
+
+    designTasks.forEach(task => {
+      const mode = selector.selectOptimalMode(task);
+      expect(mode).toBe('architect');
+    });
+  });
+
+  test('should select code mode for implementation tasks', () => {
+    const codeTasks = [
+      "Implement user authentication API",
+      "Create React component for user profile",
+      "Develop payment processing service"
+    ];
+
+    codeTasks.forEach(task => {
+      const mode = selector.selectOptimalMode(task);
+      expect(mode).toBe('code');
+    });
+  });
+
+  test('should select debug mode for troubleshooting tasks', () => {
+    const debugTasks = [
+      "Fix memory leak in payment processor",
+      "Debug authentication issues",
+      "Resolve performance problems in search"
+    ];
+
+    debugTasks.forEach(task => {
+      const mode = selector.selectOptimalMode(task);
+      expect(mode).toBe('debug');
+    });
+  });
+
+  test('should select ask mode for informational tasks', () => {
+    const askTasks = [
+      "Explain how OAuth2 works",
+      "What are the best practices for API design?",
+      "How should we structure our TypeScript project?"
+    ];
+
+    askTasks.forEach(task => {
+      const mode = selector.selectOptimalMode(task);
+      expect(mode).toBe('ask');
+    });
+  });
+
+  test('should evaluate mode match scores correctly', () => {
+    const task = "Implement user authentication with JWT tokens";
+
+    const codeScore = selector.evaluateModeMatch(task, 'code');
+    const architectScore = selector.evaluateModeMatch(task, 'architect');
+    const debugScore = selector.evaluateModeMatch(task, 'debug');
+
+    expect(codeScore).toBeGreaterThan(architectScore);
+    expect(codeScore).toBeGreaterThan(debugScore);
+  });
+
+  test('should get mode capabilities correctly', () => {
+    const codeCapabilities = selector.getModeCapabilities('code');
+    const architectCapabilities = selector.getModeCapabilities('architect');
+
+    expect(codeCapabilities).toContain('implementation');
+    expect(architectCapabilities).toContain('design');
+  });
+
+  test('should handle ambiguous tasks gracefully', () => {
+    const ambiguousTask = "Work on the user system";
+    const mode = selector.selectOptimalMode(ambiguousTask);
+
+    // Should return a valid mode (defaulting to code if unclear)
+    expect(['code', 'architect', 'debug', 'ask', 'orchestrator']).toContain(mode);
+  });
+});
+```
+
+#### 実装: src/orchestration/mode-selector.ts
+
+```typescript
+import { modeManager } from '../modes';
+import type { ModeSelectionRule } from './types';
+
+export class ModeSelector {
+  private selectionRules: ModeSelectionRule[];
+
+  constructor() {
+    this.selectionRules = this.initializeSelectionRules();
+  }
+
+  selectOptimalMode(subtask: string): string {
+    const lowerTask = subtask.toLowerCase();
+    let bestMatch = { mode: 'code', score: 0 };
+
+    // Evaluate each available mode
+    const availableModes = modeManager.getAllModes();
+    for (const mode of availableModes) {
+      const score = this.evaluateModeMatch(subtask, mode.slug);
+      if (score > bestMatch.score) {
+        bestMatch = { mode: mode.slug, score };
+      }
+    }
+
+    return bestMatch.mode;
+  }
+
+  evaluateModeMatch(task: string, mode: string): number {
+    const lowerTask = task.toLowerCase();
+    let score = 0;
+
+    // Get mode-specific keywords and calculate match score
+    const modeKeywords = this.getModeKeywords(mode);
+    for (const keyword of modeKeywords) {
+      if (lowerTask.includes(keyword.toLowerCase())) {
+        score += keyword.length * 0.1; // Longer keywords = better match
+      }
+    }
+
+    // Apply rule-based scoring
+    for (const rule of this.selectionRules) {
+      if (rule.mode === mode && rule.pattern.test(task)) {
+        score += rule.priority;
+      }
+    }
+
+    return score;
+  }
+
+  getModeCapabilities(mode: string): string[] {
+    const capabilityMap: Record<string, string[]> = {
+      'code': [
+        'implementation', 'coding', 'development', 'programming',
+        'feature creation', 'component building', 'algorithm implementation'
+      ],
+      'architect': [
+        'design', 'planning', 'architecture', 'system design',
+        'high-level planning', 'technical specifications', 'blueprints'
+      ],
+      'debug': [
+        'troubleshooting', 'bug fixing', 'problem solving', 'diagnostics',
+        'error resolution', 'performance analysis', 'investigation'
+      ],
+      'ask': [
+        'information', 'explanation', 'documentation', 'guidance',
+        'knowledge sharing', 'clarification', 'educational content'
+      ],
+      'orchestrator': [
+        'task coordination', 'workflow management', 'delegation',
+        'complex task breakdown', 'multi-mode coordination'
+      ]
+    };
+
+    return capabilityMap[mode] || [];
+  }
+
+  private initializeSelectionRules(): ModeSelectionRule[] {
+    return [
+      // Architect mode rules
+      {
+        pattern: /\b(design|architecture|plan|blueprint|structure|schema|strategy)\b/i,
+        mode: 'architect',
+        priority: 3
+      },
+      {
+        pattern: /\b(high-level|overview|system design|architectural)\b/i,
+        mode: 'architect',
+        priority: 2
+      },
+
+      // Code mode rules
+      {
+        pattern: /\b(implement|code|develop|build|create|write)\b/i,
+        mode: 'code',
+        priority: 3
+      },
+      {
+        pattern: /\b(function|method|class|component|feature|api|endpoint)\b/i,
+        mode: 'code',
+        priority: 2
+      },
+
+      // Debug mode rules
+      {
+        pattern: /\b(fix|bug|error|issue|problem|debug|troubleshoot)\b/i,
+        mode: 'debug',
+        priority: 3
+      },
+      {
+        pattern: /\b(resolve|investigate|diagnose|repair|performance)\b/i,
+        mode: 'debug',
+        priority: 2
+      },
+
+      // Ask mode rules
+      {
+        pattern: /\b(explain|how|what|why|when|where|documentation)\b/i,
+        mode: 'ask',
+        priority: 3
+      },
+      {
+        pattern: /\b(understand|clarify|describe|help me|tell me)\b/i,
+        mode: 'ask',
+        priority: 2
+      },
+
+      // Orchestrator mode rules
+      {
+        pattern: /\b(complete|entire|full|comprehensive|end-to-end)\b/i,
+        mode: 'orchestrator',
+        priority: 2
+      },
+      {
+        pattern: /\b(multiple|several|various|different|across)\b/i,
+        mode: 'orchestrator',
+        priority: 1
+      }
+    ];
+  }
+
+  private getModeKeywords(mode: string): string[] {
+    const keywordMap: Record<string, string[]> = {
+      'architect': [
+        'design', 'architecture', 'plan', 'blueprint', 'structure', 'schema',
+        'strategy', 'high-level', 'overview', 'system design', 'planning'
+      ],
+      'code': [
+        'implement', 'code', 'develop', 'build', 'create', 'write', 'function',
+        'method', 'class', 'component', 'feature', 'api', 'endpoint', 'algorithm'
+      ],
+      'debug': [
+        'fix', 'bug', 'error', 'issue', 'problem', 'debug', 'troubleshoot',
+        'resolve', 'investigate', 'diagnose', 'repair', 'performance'
+      ],
+      'ask': [
+        'explain', 'how', 'what', 'why', 'when', 'where', 'documentation',
+        'understand', 'clarify', 'describe', 'help', 'tell', 'guide'
+      ],
+      'orchestrator': [
+        'complete', 'entire', 'full', 'comprehensive', 'end-to-end',
+        'multiple', 'several', 'various', 'different', 'across', 'coordinate'
+      ]
+    };
+
+    return keywordMap[mode] || [];
+  }
+}
+```
+
+## コミット計画
+
+### コミット1: タスク分析型定義
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/types.ts
+git commit -m "feat(orchestration): add task analysis type definitions"
+```
+
+### コミット2: 複雑度計算エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/complexity-calculator.ts test/orchestration/complexity-calculator.test.ts
+git commit -m "feat(orchestration): implement complexity calculation engine with tests"
+```
+
+### コミット3: タスク分析エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/task-analyzer.ts test/orchestration/task-analyzer.test.ts
+git commit -m "feat(orchestration): implement task analysis engine with tests"
+```
+
+### コミット4: モード選択エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/mode-selector.ts test/orchestration/mode-selector.test.ts
+git commit -m "feat(orchestration): implement mode selection engine with tests"
+```
+
+### コミット5: エクスポート設定
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/index.ts
+git commit -m "feat(orchestration): add module exports for task analysis system"
+```
+
+## ディレクトリ構造
+
+```
+src/
+└── orchestration/
+    ├── types.ts                    # タスク分析型定義
+    ├── complexity-calculator.ts    # 複雑度計算エンジン
+    ├── task-analyzer.ts           # タスク分析エンジン
+    ├── mode-selector.ts           # モード選択エンジン
+    └── index.ts                   # エクスポート
+
+test/
+└── orchestration/
+    ├── complexity-calculator.test.ts
+    ├── task-analyzer.test.ts
+    └── mode-selector.test.ts
+```
+
+## index.tsの実装
+
+```typescript
+// src/orchestration/index.ts
+export type {
+  TaskAnalysis,
+  ComplexityFactor,
+  SubTask,
+  DependencyGraph,
+  ModeSelectionRule,
+  ComplexityFactorType
+} from './types';
+export { ComplexityCalculator } from './complexity-calculator';
+export { TaskAnalyzer } from './task-analyzer';
+export { ModeSelector } from './mode-selector';
+```
+
+## 統合テスト
+
+```typescript
+// test/orchestration/integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { TaskAnalyzer } from '../../src/orchestration';
+
+describe('Task Analysis Integration', () => {
+  test('should handle end-to-end task analysis workflow', () => {
+    const analyzer = new TaskAnalyzer();
+
+    const complexTask = `
+      Create a complete e-commerce platform with:
+      1. User authentication and registration
+      2. Product catalog with search and filtering
+      3. Shopping cart functionality
+      4. Payment processing integration
+      5. Order management system
+      6. Admin dashboard for inventory management
+      7. Email notification system
+      8. Mobile responsive design
+    `;
+
+    const analysis = analyzer.analyzeTask(complexTask);
+
+    expect(analysis.complexity).toBeGreaterThan(8.0);
+    expect(analysis.requiresOrchestration).toBe(true);
+    expect(analysis.requiredModes).toContain('orchestrator');
+    expect(analysis.requiredModes).toContain('architect');
+    expect(analysis.requiredModes).toContain('code');
+    expect(analysis.estimatedSubtasks).toBeGreaterThanOrEqual(6);
+    expect(analysis.complexityFactors.length).toBeGreaterThan(0);
+    expect(analysis.suggestedApproach).toContain('orchestration');
+  });
+
+  test('should handle simple task analysis workflow', () => {
+    const analyzer = new TaskAnalyzer();
+
+    const simpleTask = "Fix typo in user profile component";
+    const analysis = analyzer.analyzeTask(simpleTask);
+
+    expect(analysis.complexity).toBeLessThan(3.0);
+    expect(analysis.requiresOrchestration).toBe(false);
+    expect(analysis.estimatedSubtasks).toBeLessThanOrEqual(1);
+    expect(analysis.requiredModes).toContain('code');
+  });
+
+  test('should provide consistent analysis results', () => {
+    const analyzer = new TaskAnalyzer();
+    const task = "Implement OAuth2 authentication with PKCE flow";
+
+    const analysis1 = analyzer.analyzeTask(task);
+    const analysis2 = analyzer.analyzeTask(task);
+
+    expect(analysis1.complexity).toBe(analysis2.complexity);
+    expect(analysis1.requiresOrchestration).toBe(analysis2.requiresOrchestration);
+    expect(analysis1.requiredModes).toEqual(analysis2.requiredModes);
+  });
+});
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase1-task-system から作業ブランチを作成
+git checkout phase1-task-system
+git pull origin phase1-task-system # 念のため最新化
+git checkout -b phase2-task-analyzer phase1-task-system
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(task-analyzer): implement task analyzer" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase2-task-analyzer
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase1-task-system とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase1-task-system
+git pull origin phase1-task-system # リモートの変更を取り込み最新化
+git branch -d phase2-task-analyzer # ローカルの作業ブランチを削除
+# git push origin --delete phase2-task-analyzer # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase1-task-system から作業ブランチ作成
+git checkout phase1-task-system
+git pull origin phase1-task-system # 念のため最新化
+git checkout -b phase2-task-analyzer phase1-task-system
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(task-analyzer): implement task analyzer" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase2-task-analyzer
+# GitHub上で phase1-task-system をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase1-task-system
+git pull origin phase1-task-system
+git branch -d phase2-task-analyzer
+```
+
+## 依存関係
+
+このフェーズはフェーズ1（モードシステム、タスクシステム）完了後に実装してください。以下のフェーズに必要となります：
+- フェーズ2.2: コンテキスト最適化（分析結果の活用）
+- フェーズ3: GitHub Actionsとの統合
+- フェーズ4: MCP拡張（new_taskツール）
+
+## 次のステップ
+
+1. フェーズ2.2でコンテキスト最適化エンジンを実装（このタスク分析結果を活用）
+2. フェーズ3でGitHub Actionsとの統合
+3. フェーズ4でMCPツールの拡張

--- a/predev-docs/05-phase2-context-optimizer-design.md
+++ b/predev-docs/05-phase2-context-optimizer-design.md
@@ -1,0 +1,1685 @@
+# フェーズ2.2: コンテキスト最適化 - 詳細設計
+
+## 概要
+
+コンテキスト最適化エンジンは、各モードに最適化されたコンテキストを生成し、トークン使用量を30-50%削減しながらAIの応答精度を向上させるシステムです。モード別の情報優先度に基づく動的コンテキスト生成機能を実装します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class ContextOptimizer {
+        -priorityCalculator: PriorityCalculator
+        -tokenOptimizer: TokenOptimizer
+        +createContextForSubTask(params: ContextParams): TaskContext
+        +extractRelevantInfo(previousResults: string[], mode: string): any
+        +optimizeContext(context: any, maxTokens: number): any
+        +calculateReductionRatio(original: any, optimized: any): number
+    }
+
+    class PriorityCalculator {
+        -modePriorities: Map<string, ModePriorities>
+        -contextWeights: ContextWeights
+        +calculatePriority(info: any, mode: string): number
+        +getModePriorities(mode: string): ModePriorities
+        +rankInformationByPriority(items: any[], mode: string): any[]
+    }
+
+    class ModePriorities {
+        +design_decision: number
+        +technical_detail: number
+        +dependency_info: number
+        +file_change: number
+        +error_info: number
+        +performance_data: number
+        +security_concern: number
+        +test_result: number
+    }
+
+    class TokenOptimizer {
+        -tokenCounter: TokenCounter
+        -compressionStrategies: CompressionStrategy[]
+        +optimizeForTokenLimit(content: any, limit: number): any
+        +calculateTokenCount(content: string): number
+        +prioritizeContent(content: any[], priorities: number[]): any[]
+        +compressContent(content: string, targetRatio: number): string
+    }
+
+    class RelevanceAnalyzer {
+        -semanticAnalyzer: SemanticAnalyzer
+        -patternMatcher: PatternMatcher
+        +analyzeRelevance(content: string, context: string): number
+        +extractKeyInformation(content: string, mode: string): KeyInfo[]
+        +filterIrrelevantContent(content: string[], threshold: number): string[]
+    }
+
+    class ContextParams {
+        <<interface>>
+        +mode: string
+        +taskDescription: string
+        +previousResults: string[]
+        +globalContext: Record<string, any>
+        +maxTokens: number
+        +priorityOverrides?: Record<string, number>
+    }
+
+    ContextOptimizer --> PriorityCalculator : uses
+    ContextOptimizer --> TokenOptimizer : uses
+    PriorityCalculator --> ModePriorities : uses
+    TokenOptimizer --> TokenCounter : uses
+```
+
+## TDD実装計画
+
+### タスク2.2.1: コンテキスト最適化型定義の作成
+
+#### テストファースト: src/orchestration/context-types.ts
+
+```typescript
+// test/orchestration/context-
+import { describe, test, expect } from 'bun:test';
+import type {
+  ContextParams,
+  ModePriorities,
+  ContextWeights,
+  CompressionStrategy,
+  KeyInfo
+} from '../../src/orchestration/context-types';
+
+describe('Context Optimization Types', () => {
+  test('should define ContextParams interface correctly', () => {
+    const params: ContextParams = {
+      mode: 'code',
+      taskDescription: 'Implement user authentication',
+      previousResults: ['Design completed', 'Database schema created'],
+      globalContext: {
+        projectType: 'web-app',
+        framework: 'React'
+      },
+      maxTokens: 4000,
+      priorityOverrides: {
+        'technical_detail': 0.9,
+        'file_change': 0.8
+      }
+    };
+
+    expect(params.mode).toBe('code');
+    expect(params.previousResults.length).toBe(2);
+    expect(params.globalContext.framework).toBe('React');
+    expect(params.priorityOverrides?.['technical_detail']).toBe(0.9);
+  });
+
+  test('should define ModePriorities correctly', () => {
+    const priorities: ModePriorities = {
+      design_decision: 0.9,
+      technical_detail: 0.8,
+      dependency_info: 0.7,
+      file_change: 0.6,
+      error_info: 0.5,
+      performance_data: 0.4,
+      security_concern: 0.8,
+      test_result: 0.3
+    };
+
+    expect(priorities.design_decision).toBe(0.9);
+    expect(priorities.security_concern).toBe(0.8);
+    expect(typeof priorities.test_result).toBe('number');
+  });
+
+  test('should define KeyInfo correctly', () => {
+    const keyInfo: KeyInfo = {
+      type: 'file_change',
+      content: 'Modified src/auth/login.ts',
+      relevanceScore: 0.85,
+      tokens: 45,
+      category: 'implementation'
+    };
+
+    expect(keyInfo.type).toBe('file_change');
+    expect(keyInfo.relevanceScore).toBe(0.85);
+    expect(keyInfo.tokens).toBe(45);
+  });
+
+  test('should define CompressionStrategy correctly', () => {
+    const strategy: CompressionStrategy = {
+      name: 'summarize_logs',
+      applicableTypes: ['error_info', 'performance_data'],
+      compressionRatio: 0.3,
+      preserveKeywords: ['error', 'performance', 'critical']
+    };
+
+    expect(strategy.name).toBe('summarize_logs');
+    expect(strategy.compressionRatio).toBe(0.3);
+    expect(strategy.preserveKeywords).toContain('error');
+  });
+});
+```
+
+#### 実装: src/orchestration/context-types.ts
+
+```typescript
+export interface ContextParams {
+  mode: string;
+  taskDescription: string;
+  previousResults: string[];
+  globalContext: Record<string, any>;
+  maxTokens: number;
+  priorityOverrides?: Record<string, number>;
+}
+
+export interface ModePriorities {
+  design_decision: number;
+  technical_detail: number;
+  dependency_info: number;
+  file_change: number;
+  error_info: number;
+  performance_data: number;
+  security_concern: number;
+  test_result: number;
+}
+
+export interface ContextWeights {
+  recency: number;          // How recent the information is
+  relevance: number;        // How relevant to the current task
+  specificity: number;      // How specific vs general the information
+  actionability: number;    // How actionable the information is
+}
+
+export interface KeyInfo {
+  type: string;
+  content: string;
+  relevanceScore: number;
+  tokens: number;
+  category: 'implementation' | 'design' | 'debugging' | 'testing' | 'documentation';
+  timestamp?: Date;
+}
+
+export interface CompressionStrategy {
+  name: string;
+  applicableTypes: string[];
+  compressionRatio: number;
+  preserveKeywords: string[];
+  algorithm?: 'summarize' | 'extract_key_points' | 'compress_logs' | 'deduplicate';
+}
+
+export interface OptimizationResult {
+  originalTokens: number;
+  optimizedTokens: number;
+  reductionRatio: number;
+  preservedInfo: KeyInfo[];
+  removedInfo: string[];
+  optimizationStrategies: string[];
+}
+
+export interface SemanticMatch {
+  score: number;
+  matchedKeywords: string[];
+  context: string;
+  confidence: number;
+}
+
+export type ContextCategory =
+  | 'code_changes'
+  | 'design_decisions'
+  | 'error_logs'
+  | 'test_results'
+  | 'performance_metrics'
+  | 'dependency_updates'
+  | 'security_findings'
+  | 'documentation_updates';
+
+export type OptimizationLevel = 'aggressive' | 'balanced' | 'conservative';
+```
+
+### タスク2.2.2: 優先度計算エンジンの実装
+
+#### テストファースト: src/orchestration/priority-calculator.ts
+
+```typescript
+// test/orchestration/priority-calculator.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { PriorityCalculator } from '../../src/orchestration/priority-calculator';
+
+describe('PriorityCalculator', () => {
+  let calculator: PriorityCalculator;
+
+  beforeEach(() => {
+    calculator = new PriorityCalculator();
+  });
+
+  test('should calculate correct priorities for code mode', () => {
+    const codePriorities = calculator.getModePriorities('code');
+
+    expect(codePriorities.technical_detail).toBeGreaterThan(codePriorities.design_decision);
+    expect(codePriorities.file_change).toBeGreaterThan(codePriorities.performance_data);
+    expect(codePriorities.error_info).toBeGreaterThan(codePriorities.test_result);
+  });
+
+  test('should calculate correct priorities for architect mode', () => {
+    const architectPriorities = calculator.getModePriorities('architect');
+
+    expect(architectPriorities.design_decision).toBeGreaterThan(architectPriorities.technical_detail);
+    expect(architectPriorities.dependency_info).toBeGreaterThan(architectPriorities.file_change);
+  });
+
+  test('should calculate correct priorities for debug mode', () => {
+    const debugPriorities = calculator.getModePriorities('debug');
+
+    expect(debugPriorities.error_info).toBeGreaterThan(debugPriorities.design_decision);
+    expect(debugPriorities.performance_data).toBeGreaterThan(debugPriorities.test_result);
+  });
+
+  test('should calculate priority scores for information items', () => {
+    const fileChangeInfo = {
+      type: 'file_change',
+      content: 'Modified src/components/UserProfile.tsx',
+      category: 'implementation'
+    };
+
+    const codeScore = calculator.calculatePriority(fileChangeInfo, 'code');
+    const architectScore = calculator.calculatePriority(fileChangeInfo, 'architect');
+
+    expect(codeScore).toBeGreaterThan(architectScore);
+  });
+
+  test('should rank information by priority correctly', () => {
+    const items = [
+      { type: 'design_decision', content: 'Chose React for frontend' },
+      { type: 'file_change', content: 'Updated user.ts' },
+      { type: 'error_info', content: 'TypeError in login function' },
+      { type: 'test_result', content: 'All tests passing' }
+    ];
+
+    const rankedForCode = calculator.rankInformationByPriority(items, 'code');
+    const rankedForDebug = calculator.rankInformationByPriority(items, 'debug');
+
+    // For code mode, file changes should be high priority
+    expect(rankedForCode[0].type).toBe('file_change');
+
+    // For debug mode, error info should be highest priority
+    expect(rankedForDebug[0].type).toBe('error_info');
+  });
+
+  test('should handle unknown information types gracefully', () => {
+    const unknownInfo = {
+      type: 'unknown_type',
+      content: 'Some unknown information'
+    };
+
+    const score = calculator.calculatePriority(unknownInfo, 'code');
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  test('should apply recency weighting correctly', () => {
+    const oldInfo = {
+      type: 'file_change',
+      content: 'Old change',
+      timestamp: new Date('2023-01-01')
+    };
+
+    const newInfo = {
+      type: 'file_change',
+      content: 'Recent change',
+      timestamp: new Date()
+    };
+
+    const oldScore = calculator.calculatePriority(oldInfo, 'code');
+    const newScore = calculator.calculatePriority(newInfo, 'code');
+
+    expect(newScore).toBeGreaterThan(oldScore);
+  });
+});
+```
+
+#### 実装: src/orchestration/priority-calculator.ts
+
+```typescript
+import type { ModePriorities, ContextWeights, KeyInfo } from './context-types';
+
+export class PriorityCalculator {
+  private modePriorities: Map<string, ModePriorities>;
+  private contextWeights: ContextWeights;
+
+  constructor() {
+    this.modePriorities = this.initializeModePriorities();
+    this.contextWeights = {
+      recency: 0.3,
+      relevance: 0.4,
+      specificity: 0.2,
+      actionability: 0.1
+    };
+  }
+
+  calculatePriority(info: any, mode: string): number {
+    const modePriorities = this.getModePriorities(mode);
+    const infoType = this.normalizeInfoType(info.type);
+
+    // Base priority from mode-specific weights
+    let basePriority = modePriorities[infoType as keyof ModePriorities] || 0.1;
+
+    // Apply context weights
+    const recencyWeight = this.calculateRecencyWeight(info.timestamp);
+    const relevanceWeight = this.calculateRelevanceWeight(info, mode);
+    const specificityWeight = this.calculateSpecificityWeight(info);
+    const actionabilityWeight = this.calculateActionabilityWeight(info, mode);
+
+    const finalPriority = basePriority * (
+      this.contextWeights.recency * recencyWeight +
+      this.contextWeights.relevance * relevanceWeight +
+      this.contextWeights.specificity * specificityWeight +
+      this.contextWeights.actionability * actionabilityWeight
+    );
+
+    return Math.min(Math.max(finalPriority, 0), 1);
+  }
+
+  getModePriorities(mode: string): ModePriorities {
+    return this.modePriorities.get(mode) || this.modePriorities.get('code')!;
+  }
+
+  rankInformationByPriority(items: any[], mode: string): any[] {
+    return items
+      .map(item => ({
+        ...item,
+        priority: this.calculatePriority(item, mode)
+      }))
+      .sort((a, b) => b.priority - a.priority);
+  }
+
+  updateModePriorities(mode: string, overrides: Partial<ModePriorities>): void {
+    const current = this.getModePriorities(mode);
+    const updated = { ...current, ...overrides };
+    this.modePriorities.set(mode, updated);
+  }
+
+  private initializeModePriorities(): Map<string, ModePriorities> {
+    const map = new Map<string, ModePriorities>();
+
+    // Code mode priorities
+    map.set('code', {
+      design_decision: 0.4,
+      technical_detail: 0.9,
+      dependency_info: 0.7,
+      file_change: 0.8,
+      error_info: 0.8,
+      performance_data: 0.5,
+      security_concern: 0.7,
+      test_result: 0.6
+    });
+
+    // Architect mode priorities
+    map.set('architect', {
+      design_decision: 0.9,
+      technical_detail: 0.6,
+      dependency_info: 0.8,
+      file_change: 0.3,
+      error_info: 0.4,
+      performance_data: 0.7,
+      security_concern: 0.8,
+      test_result: 0.3
+    });
+
+    // Debug mode priorities
+    map.set('debug', {
+      design_decision: 0.2,
+      technical_detail: 0.7,
+      dependency_info: 0.6,
+      file_change: 0.5,
+      error_info: 0.9,
+      performance_data: 0.8,
+      security_concern: 0.6,
+      test_result: 0.7
+    });
+
+    // Ask mode priorities
+    map.set('ask', {
+      design_decision: 0.7,
+      technical_detail: 0.8,
+      dependency_info: 0.6,
+      file_change: 0.2,
+      error_info: 0.3,
+      performance_data: 0.4,
+      security_concern: 0.5,
+      test_result: 0.4
+    });
+
+    // Orchestrator mode priorities
+    map.set('orchestrator', {
+      design_decision: 0.8,
+      technical_detail: 0.5,
+      dependency_info: 0.9,
+      file_change: 0.4,
+      error_info: 0.6,
+      performance_data: 0.6,
+      security_concern: 0.7,
+      test_result: 0.5
+    });
+
+    return map;
+  }
+
+  private normalizeInfoType(type: string): string {
+    const typeMapping: Record<string, string> = {
+      'code_change': 'file_change',
+      'file_modification': 'file_change',
+      'architecture': 'design_decision',
+      'design': 'design_decision',
+      'bug': 'error_info',
+      'exception': 'error_info',
+      'perf': 'performance_data',
+      'benchmark': 'performance_data',
+      'security': 'security_concern',
+      'vulnerability': 'security_concern',
+      'test': 'test_result',
+      'spec': 'test_result'
+    };
+
+    return typeMapping[type] || type;
+  }
+
+  private calculateRecencyWeight(timestamp?: Date): number {
+    if (!timestamp) return 0.5; // Default for items without timestamp
+
+    const now = new Date();
+    const ageInHours = (now.getTime() - timestamp.getTime()) / (1000 * 60 * 60);
+
+    // More recent = higher weight
+    if (ageInHours < 1) return 1.0;
+    if (ageInHours < 24) return 0.8;
+    if (ageInHours < 168) return 0.6; // 1 week
+    return 0.3;
+  }
+
+  private calculateRelevanceWeight(info: any, mode: string): number {
+    const content = (info.content || '').toLowerCase();
+    const modeKeywords = this.getModeKeywords(mode);
+
+    let relevanceScore = 0;
+    for (const keyword of modeKeywords) {
+      if (content.includes(keyword.toLowerCase())) {
+        relevanceScore += 0.1;
+      }
+    }
+
+    return Math.min(relevanceScore, 1.0);
+  }
+
+  private calculateSpecificityWeight(info: any): number {
+    const content = info.content || '';
+
+    // More specific content has higher weight
+    const hasNumbers = /\d/.test(content);
+    const hasFileNames = /\.[a-z]{2,4}/.test(content);
+    const hasSpecificTerms = /\b(function|class|variable|method|component)\b/i.test(content);
+
+    let specificity = 0.3; // Base specificity
+    if (hasNumbers) specificity += 0.2;
+    if (hasFileNames) specificity += 0.3;
+    if (hasSpecificTerms) specificity += 0.2;
+
+    return Math.min(specificity, 1.0);
+  }
+
+  private calculateActionabilityWeight(info: any, mode: string): number {
+    const content = (info.content || '').toLowerCase();
+
+    // Different modes have different actionability indicators
+    const actionableIndicators = this.getActionableIndicators(mode);
+
+    let actionabilityScore = 0.2; // Base score
+    for (const indicator of actionableIndicators) {
+      if (content.includes(indicator)) {
+        actionabilityScore += 0.2;
+      }
+    }
+
+    return Math.min(actionabilityScore, 1.0);
+  }
+
+  private getModeKeywords(mode: string): string[] {
+    const keywordMap: Record<string, string[]> = {
+      'code': ['implement', 'function', 'class', 'method', 'algorithm', 'code'],
+      'architect': ['design', 'architecture', 'pattern', 'structure', 'system'],
+      'debug': ['error', 'bug', 'exception', 'fix', 'problem', 'issue'],
+      'ask': ['explain', 'how', 'what', 'why', 'documentation', 'guide'],
+      'orchestrator': ['coordinate', 'manage', 'organize', 'workflow', 'process']
+    };
+
+    return keywordMap[mode] || [];
+  }
+
+  private getActionableIndicators(mode: string): string[] {
+    const indicatorMap: Record<string, string[]> = {
+      'code': ['todo', 'implement', 'fix', 'update', 'create'],
+      'architect': ['design', 'plan', 'decide', 'choose', 'define'],
+      'debug': ['investigate', 'reproduce', 'fix', 'test', 'verify'],
+      'ask': ['research', 'document', 'explain', 'clarify', 'define'],
+      'orchestrator': ['coordinate', 'assign', 'delegate', 'schedule', 'prioritize']
+    };
+
+    return indicatorMap[mode] || [];
+  }
+}
+```
+
+### タスク2.2.3: トークン最適化エンジンの実装
+
+#### テストファースト: src/orchestration/token-optimizer.ts
+
+```typescript
+// test/orchestration/token-optimizer.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { TokenOptimizer } from '../../src/orchestration/token-optimizer';
+
+describe('TokenOptimizer', () => {
+  let optimizer: TokenOptimizer;
+
+  beforeEach(() => {
+    optimizer = new TokenOptimizer();
+  });
+
+  test('should calculate token count approximately correctly', () => {
+    const shortText = "Hello world";
+    const longText = "This is a much longer text that contains many more words and should result in a higher token count than the shorter text.";
+
+    const shortTokens = optimizer.calculateTokenCount(shortText);
+    const longTokens = optimizer.calculateTokenCount(longText);
+
+    expect(shortTokens).toBeLessThan(longTokens);
+    expect(shortTokens).toBeGreaterThan(0);
+  });
+
+  test('should optimize content for token limit', () => {
+    const content = {
+      messages: [
+        "This is a very long message that contains lots of detailed information about the implementation",
+        "Short message",
+        "Another long message with extensive details about architecture and design decisions that might not be necessary",
+        "Critical error message"
+      ],
+      priorities: [0.3, 0.8, 0.2, 0.9]
+    };
+
+    const optimized = optimizer.optimizeForTokenLimit(content, 100);
+
+    expect(optimized.messages.length).toBeLessThanOrEqual(content.messages.length);
+    // High priority items should be preserved
+    expect(optimized.messages).toContain("Short message");
+    expect(optimized.messages).toContain("Critical error message");
+  });
+
+  test('should prioritize content correctly', () => {
+    const content = [
+      { text: "Low priority item", id: 1 },
+      { text: "High priority item", id: 2 },
+      { text: "Medium priority item", id: 3 }
+    ];
+    const priorities = [0.2, 0.9, 0.5];
+
+    const prioritized = optimizer.prioritizeContent(content, priorities);
+
+    expect(prioritized[0].id).toBe(2); // High priority first
+    expect(prioritized[1].id).toBe(3); // Medium priority second
+    expect(prioritized[2].id).toBe(1); // Low priority last
+  });
+
+  test('should compress content while preserving key information', () => {
+    const verbose = `
+      The user authentication system needs to be implemented with the following requirements:
+      1. It should support email and password login
+      2. It should include password reset functionality
+      3. It should have rate limiting to prevent brute force attacks
+      4. It should use JWT tokens for session management
+      5. It should integrate with the existing user database
+    `;
+
+    const compressed = optimizer.compressContent(verbose, 0.5);
+
+    expect(compressed.length).toBeLessThan(verbose.length);
+    expect(compressed).toContain("authentication");
+    expect(compressed).toContain("JWT");
+    expect(compressed).toContain("password");
+  });
+
+  test('should handle edge cases gracefully', () => {
+    expect(() => optimizer.calculateTokenCount("")).not.toThrow();
+    expect(() => optimizer.optimizeForTokenLimit({}, 0)).not.toThrow();
+    expect(() => optimizer.compressContent("", 0.5)).not.toThrow();
+
+    expect(optimizer.calculateTokenCount("")).toBe(0);
+  });
+
+  test('should preserve essential keywords during compression', () => {
+    const content = "Implement user authentication with secure password hashing and JWT token management";
+    const compressed = optimizer.compressContent(content, 0.3);
+
+    // Essential keywords should be preserved
+    const essentialKeywords = ['authentication', 'password', 'JWT', 'secure'];
+    const preservedCount = essentialKeywords.filter(keyword =>
+      compressed.toLowerCase().includes(keyword.toLowerCase())
+    ).length;
+
+    expect(preservedCount).toBeGreaterThan(essentialKeywords.length * 0.5);
+  });
+});
+```
+
+#### 実装: src/orchestration/token-optimizer.ts
+
+```typescript
+import type { CompressionStrategy, OptimizationResult } from './context-types';
+
+interface TokenCounter {
+  count(text: string): number;
+}
+
+export class TokenOptimizer {
+  private tokenCounter: TokenCounter;
+  private compressionStrategies: CompressionStrategy[];
+
+  constructor() {
+    this.tokenCounter = new SimpleTokenCounter();
+    this.compressionStrategies = this.initializeCompressionStrategies();
+  }
+
+  optimizeForTokenLimit(content: any, limit: number): any {
+    if (!content || limit <= 0) {
+      return content;
+    }
+
+    const currentTokens = this.calculateContentTokens(content);
+    if (currentTokens <= limit) {
+      return content;
+    }
+
+    // Apply optimization strategies in order of effectiveness
+    let optimizedContent = content;
+
+    // 1. Remove low priority items first
+    optimizedContent = this.removeLowPriorityItems(optimizedContent, limit);
+
+    // 2. Compress verbose content
+    optimizedContent = this.compressVerboseContent(optimizedContent, limit);
+
+    // 3. Apply summarization
+    optimizedContent = this.applySummarization(optimizedContent, limit);
+
+    return optimizedContent;
+  }
+
+  calculateTokenCount(content: string): number {
+    if (!content) return 0;
+    return this.tokenCounter.count(content);
+  }
+
+  prioritizeContent(content: any[], priorities: number[]): any[] {
+    if (content.length !== priorities.length) {
+      return content;
+    }
+
+    const indexed = content.map((item, index) => ({
+      item,
+      priority: priorities[index],
+      index
+    }));
+
+    return indexed
+      .sort((a, b) => b.priority - a.priority)
+      .map(({ item }) => item);
+  }
+
+  compressContent(content: string, targetRatio: number): string {
+    if (!content || targetRatio >= 1) {
+      return content;
+    }
+
+    const targetLength = Math.floor(content.length * targetRatio);
+
+    // Extract key sentences and phrases
+    const sentences = this.extractSentences(content);
+    const keyPhrases = this.extractKeyPhrases(content);
+
+    // Rank sentences by importance
+    const rankedSentences = this.rankSentencesByImportance(sentences, keyPhrases);
+
+    // Select sentences until we reach target length
+    let compressedLength = 0;
+    const selectedSentences: string[] = [];
+
+    for (const sentence of rankedSentences) {
+      if (compressedLength + sentence.length <= targetLength) {
+        selectedSentences.push(sentence);
+        compressedLength += sentence.length;
+      } else {
+        break;
+      }
+    }
+
+    return selectedSentences.join(' ').trim();
+  }
+
+  generateOptimizationReport(original: any, optimized: any): OptimizationResult {
+    const originalTokens = this.calculateContentTokens(original);
+    const optimizedTokens = this.calculateContentTokens(optimized);
+    const reductionRatio = (originalTokens - optimizedTokens) / originalTokens;
+
+    return {
+      originalTokens,
+      optimizedTokens,
+      reductionRatio,
+      preservedInfo: [], // TODO: Track preserved information
+      removedInfo: [], // TODO: Track removed information
+      optimizationStrategies: [] // TODO: Track applied strategies
+    };
+  }
+
+  private calculateContentTokens(content: any): number {
+    if (typeof content === 'string') {
+      return this.calculateTokenCount(content);
+    }
+
+    if (Array.isArray(content)) {
+      return content.reduce((total, item) => total + this.calculateContentTokens(item), 0);
+    }
+
+    if (typeof content === 'object' && content !== null) {
+      return Object.values(content).reduce((total, value) => total + this.calculateContentTokens(value), 0);
+    }
+
+    return 0;
+  }
+
+  private removeLowPriorityItems(content: any, limit: number): any {
+    if (Array.isArray(content) && content.length > 0 && typeof content[0] === 'object') {
+      // If content has priority information, filter by priority
+      const sortedByPriority = content
+        .filter(item => item.priority !== undefined)
+        .sort((a, b) => b.priority - a.priority);
+
+      const result = [];
+      let currentTokens = 0;
+
+      for (const item of sortedByPriority) {
+        const itemTokens = this.calculateContentTokens(item);
+        if (currentTokens + itemTokens <= limit) {
+          result.push(item);
+          currentTokens += itemTokens;
+        }
+      }
+
+      return result;
+    }
+
+    return content;
+  }
+
+  private compressVerboseContent(content: any, limit: number): any {
+    if (typeof content === 'string') {
+      const currentTokens = this.calculateTokenCount(content);
+      if (currentTokens > limit) {
+        const targetRatio = limit / currentTokens;
+        return this.compressContent(content, targetRatio);
+      }
+    }
+
+    if (typeof content === 'object' && content !== null) {
+      const compressed: any = {};
+      for (const [key, value] of Object.entries(content)) {
+        compressed[key] = this.compressVerboseContent(value, Math.floor(limit * 0.3));
+      }
+      return compressed;
+    }
+
+    return content;
+  }
+
+  private applySummarization(content: any, limit: number): any {
+    // Apply summarization strategies
+    for (const strategy of this.compressionStrategies) {
+      if (this.calculateContentTokens(content) <= limit) {
+        break;
+      }
+      content = this.applyCompressionStrategy(content, strategy);
+    }
+
+    return content;
+  }
+
+  private extractSentences(content: string): string[] {
+    return content
+      .split(/[.!?]+/)
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+  }
+
+  private extractKeyPhrases(content: string): string[] {
+    // Simple key phrase extraction
+    const keywords = [
+      'implement', 'create', 'design', 'fix', 'error', 'function',
+      'component', 'service', 'authentication', 'database', 'api',
+      'security', 'performance', 'test', 'user', 'system'
+    ];
+
+    return keywords.filter(keyword =>
+      content.toLowerCase().includes(keyword.toLowerCase())
+    );
+  }
+
+  private rankSentencesByImportance(sentences: string[], keyPhrases: string[]): string[] {
+    return sentences
+      .map(sentence => ({
+        sentence,
+        score: this.calculateSentenceScore(sentence, keyPhrases)
+      }))
+      .sort((a, b) => b.score - a.score)
+      .map(item => item.sentence);
+  }
+
+  private calculateSentenceScore(sentence: string, keyPhrases: string[]): number {
+    let score = 0;
+    const lowerSentence = sentence.toLowerCase();
+
+    // Score based on key phrase presence
+    for (const phrase of keyPhrases) {
+      if (lowerSentence.includes(phrase.toLowerCase())) {
+        score += 1;
+      }
+    }
+
+    // Bonus for sentences with numbers (often specific)
+    if (/\d/.test(sentence)) {
+      score += 0.5;
+    }
+
+    // Bonus for sentences with technical terms
+    if (/\b(function|class|method|api|database|component)\b/i.test(sentence)) {
+      score += 0.3;
+    }
+
+    return score;
+  }
+
+  private applyCompressionStrategy(content: any, strategy: CompressionStrategy): any {
+    // Apply specific compression strategies
+    switch (strategy.algorithm) {
+      case 'summarize':
+        return this.summarizeContent(content, strategy);
+      case 'extract_key_points':
+        return this.extractKeyPoints(content, strategy);
+      case 'deduplicate':
+        return this.deduplicateContent(content, strategy);
+      default:
+        return content;
+    }
+  }
+
+  private summarizeContent(content: any, strategy: CompressionStrategy): any {
+    if (typeof content === 'string') {
+      return this.compressContent(content, strategy.compressionRatio);
+    }
+    return content;
+  }
+
+  private extractKeyPoints(content: any, strategy: CompressionStrategy): any {
+    if (typeof content === 'string') {
+      const sentences = this.extractSentences(content);
+      const keyPhrases = strategy.preserveKeywords;
+
+      const importantSentences = sentences.filter(sentence =>
+        keyPhrases.some(keyword =>
+          sentence.toLowerCase().includes(keyword.toLowerCase())
+        )
+      );
+
+      return importantSentences.slice(0, Math.ceil(sentences.length * strategy.compressionRatio)).join('. ');
+    }
+    return content;
+  }
+
+  private deduplicateContent(content: any, strategy: CompressionStrategy): any {
+    if (Array.isArray(content)) {
+      const seen = new Set();
+      return content.filter(item => {
+        const key = JSON.stringify(item);
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      });
+    }
+    return content;
+  }
+
+  private initializeCompressionStrategies(): CompressionStrategy[] {
+    return [
+      {
+        name: 'remove_duplicates',
+        applicableTypes: ['all'],
+        compressionRatio: 0.9,
+        preserveKeywords: [],
+        algorithm: 'deduplicate'
+      },
+      {
+        name: 'summarize_verbose',
+        applicableTypes: ['design_decision', 'technical_detail'],
+        compressionRatio: 0.6,
+        preserveKeywords: ['important', 'critical', 'key', 'main'],
+        algorithm: 'summarize'
+      },
+      {
+        name: 'extract_error_essentials',
+        applicableTypes: ['error_info'],
+        compressionRatio: 0.4,
+        preserveKeywords: ['error', 'exception', 'failed', 'critical'],
+        algorithm: 'extract_key_points'
+      }
+    ];
+  }
+}
+
+// Simple token counter implementation
+class SimpleTokenCounter implements TokenCounter {
+  count(text: string): number {
+    if (!text) return 0;
+
+    // Rough approximation: ~4 characters per token for English text
+    // This is a simplified approach; in production, use a proper tokenizer
+    const words = text.trim().split(/\s+/).length;
+    const chars = text.length;
+
+    // Estimate tokens based on word count and character count
+    return Math.ceil(Math.max(words * 0.75, chars / 4));
+  }
+}
+```
+
+### タスク2.2.4: コンテキスト最適化エンジンの統合
+
+#### テストファースト: src/orchestration/context-optimizer.ts
+
+```typescript
+// test/orchestration/context-optimizer.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { ContextOptimizer } from '../../src/orchestration/context-optimizer';
+import type { ContextParams } from '../../src/orchestration/context-types';
+
+describe('ContextOptimizer', () => {
+  let optimizer: ContextOptimizer;
+
+  beforeEach(() => {
+    optimizer = new ContextOptimizer();
+  });
+
+  test('should create optimized context for code mode', () => {
+    const params: ContextParams = {
+      mode: 'code',
+      taskDescription: 'Implement user login functionality',
+      previousResults: [
+        'Database schema created with user table',
+        'Password hashing utility implemented',
+        'JWT token service created'
+      ],
+      globalContext: {
+        framework: 'React',
+        backend: 'Node.js',
+        database: 'PostgreSQL'
+      },
+      maxTokens: 2000
+    };
+
+    const context = optimizer.createContextForSubTask(params);
+
+    expect(context.maxTokens).toBeLessThanOrEqual(2000);
+    expect(context.modeSpecificContext).toBeDefined();
+    expect(context.previousResults.length).toBeGreaterThan(0);
+  });
+
+  test('should prioritize relevant information for different modes', () => {
+    const previousResults = [
+      'System architecture designed with microservices',
+      'Database schema created',
+      'Authentication API implemented',
+      'Critical bug found in payment processing',
+      'Performance tests show 95% improvement'
+    ];
+
+    const codeRelevant = optimizer.extractRelevantInfo(previousResults, 'code');
+    const debugRelevant = optimizer.extractRelevantInfo(previousResults, 'debug');
+    const architectRelevant = optimizer.extractRelevantInfo(previousResults, 'architect');
+
+    // Code mode should prioritize implementation details
+    expect(JSON.stringify(codeRelevant)).toContain('implemented');
+
+    // Debug mode should prioritize error information
+    expect(JSON.stringify(debugRelevant)).toContain('bug');
+
+    // Architect mode should prioritize design information
+    expect(JSON.stringify(architectRelevant)).toContain('architecture');
+  });
+
+  test('should achieve significant token reduction', () => {
+    const verboseContext = {
+      longDescription: 'This is a very long description '.repeat(100),
+      detailedLogs: 'Detailed log entry '.repeat(50),
+      extensiveDocumentation: 'Documentation paragraph '.repeat(30)
+    };
+
+    const optimized = optimizer.optimizeContext(verboseContext, 500);
+
+    const originalSize = JSON.stringify(verboseContext).length;
+    const optimizedSize = JSON.stringify(optimized).length;
+    const reduction = (originalSize - optimizedSize) / originalSize;
+
+    expect(reduction).toBeGreaterThan(0.3); // At least 30% reduction
+  });
+
+  test('should calculate reduction ratio correctly', () => {
+    const original = { content: 'This is a very long content '.repeat(20) };
+    const optimized = { content: 'Short content' };
+
+    const ratio = optimizer.calculateReductionRatio(original, optimized);
+
+    expect(ratio).toBeGreaterThan(0);
+    expect(ratio).toBeLessThanOrEqual(1);
+  });
+
+  test('should preserve high priority information', () => {
+    const params: ContextParams = {
+      mode: 'debug',
+      taskDescription: 'Fix critical authentication bug',
+      previousResults: [
+        'User reported login failures',
+        'System shows 500 errors in auth service',
+        'Database connection is stable',
+        'Previous bug fix implemented for payments'
+      ],
+      globalContext: {},
+      maxTokens: 200,
+      priorityOverrides: {
+        'error_info': 0.95
+      }
+    };
+
+    const context = optimizer.createContextForSubTask(params);
+    const contextStr = JSON.stringify(context);
+
+    // Should preserve error-related information
+    expect(contextStr).toContain('error');
+    expect(contextStr).toContain('auth');
+  });
+
+  test('should handle edge cases gracefully', () => {
+    expect(() => optimizer.createContextForSubTask({
+      mode: 'code',
+      taskDescription: '',
+      previousResults: [],
+      globalContext: {},
+      maxTokens: 0
+    })).not.toThrow();
+
+    expect(() => optimizer.optimizeContext(null, 100)).not.toThrow();
+    expect(() => optimizer.extractRelevantInfo([], 'unknown_mode')).not.toThrow();
+  });
+});
+```
+
+#### 実装: src/orchestration/context-optimizer.ts
+
+```typescript
+import { PriorityCalculator } from './priority-calculator';
+import { TokenOptimizer } from './token-optimizer';
+import type { ContextParams, OptimizationResult, KeyInfo } from './context-types';
+import type { TaskContext } from '../tasks/types';
+
+export class ContextOptimizer {
+  private priorityCalculator: PriorityCalculator;
+  private tokenOptimizer: TokenOptimizer;
+
+  constructor() {
+    this.priorityCalculator = new PriorityCalculator();
+    this.tokenOptimizer = new TokenOptimizer();
+  }
+
+  createContextForSubTask(params: ContextParams): TaskContext {
+    // Apply priority overrides if provided
+    if (params.priorityOverrides) {
+      this.priorityCalculator.updateModePriorities(params.mode, params.priorityOverrides);
+    }
+
+    // Extract and prioritize relevant information
+    const relevantInfo = this.extractRelevantInfo(params.previousResults, params.mode);
+
+    // Create mode-specific context
+    const modeSpecificContext = this.createModeSpecificContext(params);
+
+    // Optimize for token limit
+    const optimizedInfo = this.optimizeContext({
+      relevantInfo,
+      modeSpecificContext,
+      globalContext: params.globalContext
+    }, params.maxTokens);
+
+    return {
+      previousResults: optimizedInfo.relevantInfo || [],
+      globalContext: optimizedInfo.globalContext || {},
+      modeSpecificContext: optimizedInfo.modeSpecificContext || {},
+      maxTokens: params.maxTokens
+    };
+  }
+
+  extractRelevantInfo(previousResults: string[], mode: string): string[] {
+    if (!previousResults || previousResults.length === 0) {
+      return [];
+    }
+
+    // Convert results to info objects for prioritization
+    const infoObjects = previousResults.map((result, index) => ({
+      type: this.classifyInformation(result),
+      content: result,
+      timestamp: new Date(Date.now() - index * 60000), // Simulate recency
+      category: this.categorizeForMode(result, mode)
+    }));
+
+    // Rank by priority for the given mode
+    const ranked = this.priorityCalculator.rankInformationByPriority(infoObjects, mode);
+
+    // Return the content of top-ranked items
+    return ranked.map(item => item.content);
+  }
+
+  optimizeContext(context: any, maxTokens: number): any {
+    if (maxTokens <= 0) {
+      return context;
+    }
+
+    const currentTokens = this.calculateContextTokens(context);
+    if (currentTokens <= maxTokens) {
+      return context;
+    }
+
+    // Use token optimizer to reduce size
+    return this.tokenOptimizer.optimizeForTokenLimit(context, maxTokens);
+  }
+
+  calculateReductionRatio(original: any, optimized: any): number {
+    const originalTokens = this.calculateContextTokens(original);
+    const optimizedTokens = this.calculateContextTokens(optimized);
+
+    if (originalTokens === 0) return 0;
+
+    return Math.max(0, (originalTokens - optimizedTokens) / originalTokens);
+  }
+
+  generateOptimizationReport(original: any, optimized: any): OptimizationResult {
+    const originalTokens = this.calculateContextTokens(original);
+    const optimizedTokens = this.calculateContextTokens(optimized);
+    const reductionRatio = this.calculateReductionRatio(original, optimized);
+
+    return {
+      originalTokens,
+      optimizedTokens,
+      reductionRatio,
+      preservedInfo: this.extractPreservedInfo(original, optimized),
+      removedInfo: this.extractRemovedInfo(original, optimized),
+      optimizationStrategies: ['prioritization', 'token_optimization', 'relevance_filtering']
+    };
+  }
+
+  private createModeSpecificContext(params: ContextParams): Record<string, any> {
+    const { mode, taskDescription } = params;
+
+    const baseContext = {
+      mode,
+      taskDescription,
+      optimizationLevel: this.determineOptimizationLevel(params.maxTokens)
+    };
+
+    // Add mode-specific optimizations
+    switch (mode) {
+      case 'code':
+        return {
+          ...baseContext,
+          focusAreas: ['implementation_details', 'file_changes', 'technical_requirements'],
+          excludeTypes: ['high_level_design', 'business_requirements']
+        };
+
+      case 'architect':
+        return {
+          ...baseContext,
+          focusAreas: ['system_design', 'dependencies', 'architecture_decisions'],
+          excludeTypes: ['implementation_details', 'low_level_bugs']
+        };
+
+      case 'debug':
+        return {
+          ...baseContext,
+          focusAreas: ['error_information', 'performance_data', 'system_logs'],
+          excludeTypes: ['design_decisions', 'future_planning']
+        };
+
+      case 'ask':
+        return {
+          ...baseContext,
+          focusAreas: ['documentation', 'explanations', 'knowledge_base'],
+          excludeTypes: ['implementation_specifics', 'error_logs']
+        };
+
+      case 'orchestrator':
+        return {
+          ...baseContext,
+          focusAreas: ['task_dependencies', 'coordination_requirements', 'overall_progress'],
+          excludeTypes: ['implementation_details']
+        };
+
+      default:
+        return baseContext;
+    }
+  }
+
+  private classifyInformation(content: string): string {
+    const lowerContent = content.toLowerCase();
+
+    if (this.containsKeywords(lowerContent, ['error', 'exception', 'failed', 'bug'])) {
+      return 'error_info';
+    }
+
+    if (this.containsKeywords(lowerContent, ['design', 'architecture', 'decided', 'plan'])) {
+      return 'design_decision';
+    }
+
+    if (this.containsKeywords(lowerContent, ['implemented', 'created', 'added', 'modified', 'file'])) {
+      return 'file_change';
+    }
+
+    if (this.containsKeywords(lowerContent, ['performance', 'speed', 'memory', 'cpu', 'latency'])) {
+      return 'performance_data';
+    }
+
+    if (this.containsKeywords(lowerContent, ['test', 'spec', 'passed', 'failed', 'coverage'])) {
+      return 'test_result';
+    }
+
+    if (this.containsKeywords(lowerContent, ['security', 'auth', 'permission', 'vulnerability'])) {
+      return 'security_concern';
+    }
+
+    if (this.containsKeywords(lowerContent, ['dependency', 'library', 'package', 'import'])) {
+      return 'dependency_info';
+    }
+
+    return 'technical_detail';
+  }
+
+  private categorizeForMode(content: string, mode: string): 'implementation' | 'design' | 'debugging' | 'testing' | 'documentation' {
+    const lowerContent = content.toLowerCase();
+
+    if (mode === 'architect' || this.containsKeywords(lowerContent, ['design', 'architecture', 'plan'])) {
+      return 'design';
+    }
+
+    if (mode === 'debug' || this.containsKeywords(lowerContent, ['error', 'bug', 'fix', 'debug'])) {
+      return 'debugging';
+    }
+
+    if (this.containsKeywords(lowerContent, ['test', 'spec', 'coverage', 'verify'])) {
+      return 'testing';
+    }
+
+    if (this.containsKeywords(lowerContent, ['document', 'explain', 'guide', 'readme'])) {
+      return 'documentation';
+    }
+
+    return 'implementation';
+  }
+
+  private containsKeywords(content: string, keywords: string[]): boolean {
+    return keywords.some(keyword => content.includes(keyword));
+  }
+
+  private determineOptimizationLevel(maxTokens: number): 'aggressive' | 'balanced' | 'conservative' {
+    if (maxTokens < 1000) return 'aggressive';
+    if (maxTokens < 3000) return 'balanced';
+    return 'conservative';
+  }
+
+  private calculateContextTokens(context: any): number {
+    return this.tokenOptimizer.calculateTokenCount(JSON.stringify(context));
+  }
+
+  private extractPreservedInfo(original: any, optimized: any): KeyInfo[] {
+    // Simplified implementation - in practice, this would track actual preserved information
+    return [];
+  }
+
+  private extractRemovedInfo(original: any, optimized: any): string[] {
+    // Simplified implementation - in practice, this would track removed information
+    return [];
+  }
+}
+```
+
+## コミット計画
+
+### コミット1: コンテキスト最適化型定義
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/context-types.ts test/orchestration/context-types.test.ts
+git commit -m "feat(orchestration): add context optimization type definitions with tests"
+```
+
+### コミット2: 優先度計算エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/priority-calculator.ts test/orchestration/priority-calculator.test.ts
+git commit -m "feat(orchestration): implement priority calculation engine with tests"
+```
+
+### コミット3: トークン最適化エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/token-optimizer.ts test/orchestration/token-optimizer.test.ts
+git commit -m "feat(orchestration): implement token optimization engine with tests"
+```
+
+### コミット4: コンテキスト最適化エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/context-optimizer.ts test/orchestration/context-optimizer.test.ts
+git commit -m "feat(orchestration): implement context optimization engine with tests"
+```
+
+### コミット5: エクスポート更新
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/orchestration/index.ts
+git commit -m "feat(orchestration): add context optimization exports"
+```
+
+## ディレクトリ構造
+
+```
+src/
+└── orchestration/
+    ├── types.ts                    # タスク分析型定義
+    ├── context-types.ts           # コンテキスト最適化型定義
+    ├── complexity-calculator.ts    # 複雑度計算エンジン
+    ├── task-analyzer.ts           # タスク分析エンジン
+    ├── mode-selector.ts           # モード選択エンジン
+    ├── priority-calculator.ts     # 優先度計算エンジン
+    ├── token-optimizer.ts         # トークン最適化エンジン
+    ├── context-optimizer.ts       # コンテキスト最適化エンジン
+    └── index.ts                   # エクスポート
+
+test/
+└── orchestration/
+    ├── context-types.test.ts
+    ├── complexity-calculator.test.ts
+    ├── task-analyzer.test.ts
+    ├── mode-selector.test.ts
+    ├── priority-calculator.test.ts
+    ├── token-optimizer.test.ts
+    └── context-optimizer.test.ts
+```
+
+## index.tsの更新
+
+```typescript
+// src/orchestration/index.ts
+export type {
+  TaskAnalysis,
+  ComplexityFactor,
+  SubTask,
+  DependencyGraph,
+  ModeSelectionRule,
+  ComplexityPattern,
+  ComplexityFactorType
+} from './types';
+
+export type {
+  ContextParams,
+  ModePriorities,
+  ContextWeights,
+  KeyInfo,
+  CompressionStrategy,
+  OptimizationResult,
+  SemanticMatch,
+  ContextCategory,
+  OptimizationLevel
+} from './context-types';
+
+export { ComplexityCalculator } from './complexity-calculator';
+export { TaskAnalyzer } from './task-analyzer';
+export { ModeSelector } from './mode-selector';
+export { PriorityCalculator } from './priority-calculator';
+export { TokenOptimizer } from './token-optimizer';
+export { ContextOptimizer } from './context-optimizer';
+```
+
+## 統合テスト
+
+```typescript
+// test/orchestration/context-integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { ContextOptimizer, TaskAnalyzer } from '../../src/orchestration';
+
+describe('Context Optimization Integration', () => {
+  test('should handle complete context optimization workflow', () => {
+    const analyzer = new TaskAnalyzer();
+    const optimizer = new ContextOptimizer();
+
+    const complexTask = `
+      Implement a complete user management system with:
+      1. Authentication with JWT tokens
+      2. Role-based access control
+      3. Password reset functionality
+      4. Email verification
+      5. User profile management
+      6. Admin dashboard
+    `;
+
+    // Analyze task complexity
+    const analysis = analyzer.analyzeTask(complexTask);
+    expect(analysis.requiresOrchestration).toBe(true);
+
+    // Create optimized context for a subtask
+    const contextParams = {
+      mode: 'code',
+      taskDescription: 'Implement JWT authentication',
+      previousResults: [
+        'System architecture designed with microservices approach',
+        'Database schema created with user, role, and session tables',
+        'Password hashing service implemented using bcrypt',
+        'Email service configured with SendGrid',
+        'Basic user registration endpoint created',
+        'Input validation middleware implemented',
+        'Error handling framework established'
+      ],
+      globalContext: {
+        framework: 'Express.js',
+        database: 'PostgreSQL',
+        authStrategy: 'JWT',
+        emailProvider: 'SendGrid'
+      },
+      maxTokens: 1500
+    };
+
+    const optimizedContext = optimizer.createContextForSubTask(contextParams);
+
+    // Verify optimization
+    expect(optimizedContext.maxTokens).toBe(1500);
+    expect(optimizedContext.previousResults.length).toBeGreaterThan(0);
+    expect(optimizedContext.modeSpecificContext.mode).toBe('code');
+
+    // Verify relevant information is prioritized
+    const contextStr = JSON.stringify(optimizedContext);
+    expect(contextStr).toContain('JWT');
+    expect(contextStr).toContain('auth');
+  });
+
+  test('should achieve target token reduction', () => {
+    const optimizer = new ContextOptimizer();
+
+    const verboseContext = {
+      previousResults: [
+        'This is a very detailed explanation of how the authentication system was designed with extensive documentation about the security considerations and implementation details that goes on for many sentences and includes lots of technical jargon and specific implementation details that might not be relevant for the current task',
+        'Database schema created',
+        'Password hashing implemented',
+        'Email service configured'
+      ],
+      globalContext: {
+        detailedDescription: 'This is another very long description that contains lots of information about the project setup and configuration that might not be directly relevant to the current subtask but was included for completeness'
+      }
+    };
+
+    const original = JSON.stringify(verboseContext);
+    const optimized = optimizer.optimizeContext(verboseContext, 500);
+    const optimizedStr = JSON.stringify(optimized);
+
+    const reductionRatio = (original.length - optimizedStr.length) / original.length;
+    expect(reductionRatio).toBeGreaterThan(0.3); // At least 30% reduction
+  });
+
+  test('should maintain context quality across modes', () => {
+    const optimizer = new ContextOptimizer();
+
+    const previousResults = [
+      'System architecture designed with microservices',
+      'Critical authentication bug discovered in login flow',
+      'User interface components created for login page',
+      'Database performance optimized with indexing',
+      'Unit tests written for authentication service'
+    ];
+
+    const modes = ['code', 'architect', 'debug'];
+
+    for (const mode of modes) {
+      const contextParams = {
+        mode,
+        taskDescription: `${mode} mode task`,
+        previousResults,
+        globalContext: {},
+        maxTokens: 800
+      };
+
+      const context = optimizer.createContextForSubTask(contextParams);
+
+      expect(context.previousResults.length).toBeGreaterThan(0);
+      expect(context.modeSpecificContext.mode).toBe(mode);
+
+      // Each mode should prioritize different information
+      const contextStr = JSON.stringify(context);
+      if (mode === 'debug') {
+        expect(contextStr).toContain('bug');
+      } else if (mode === 'architect') {
+        expect(contextStr).toContain('architecture');
+      }
+    }
+  });
+});
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase2-task-analyzer から作業ブランチを作成
+git checkout phase2-task-analyzer
+git pull origin phase2-task-analyzer # 念のため最新化
+git checkout -b phase2-context-optimizer phase2-task-analyzer
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(context-optimizer): implement context optimizer" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase2-context-optimizer
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase2-task-analyzer とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase2-task-analyzer
+git pull origin phase2-task-analyzer # リモートの変更を取り込み最新化
+git branch -d phase2-context-optimizer # ローカルの作業ブランチを削除
+# git push origin --delete phase2-context-optimizer # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase2-task-analyzer から作業ブランチ作成
+git checkout phase2-task-analyzer
+git pull origin phase2-task-analyzer # 念のため最新化
+git checkout -b phase2-context-optimizer phase2-task-analyzer
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(context-optimizer): implement context optimizer" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase2-context-optimizer
+# GitHub上で phase2-task-analyzer をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase2-task-analyzer
+git pull origin phase2-task-analyzer
+git branch -d phase2-context-optimizer
+```
+
+## 依存関係
+
+このフェーズはフェーズ2.1（タスク分析エンジン）完了後に実装してください。以下のフェーズに必要となります：
+- フェーズ3: GitHub Actionsとの統合（最適化されたコンテキストの活用）
+- フェーズ4: MCP拡張（コンテキスト最適化の活用）
+
+## 次のステップ
+
+1. フェーズ3でGitHub Actionsとの統合（この最適化システムを活用）
+2. フェーズ4でMCPツールの拡張

--- a/predev-docs/05-phase2-context-optimizer-design.md
+++ b/predev-docs/05-phase2-context-optimizer-design.md
@@ -5,6 +5,7 @@
 コンテキスト最適化エンジンは、各モードに最適化されたコンテキストを生成し、トークン使用量を30-50%削減しながらAIの応答精度を向上させるシステムです。モード別の情報優先度に基づく動的コンテキスト生成機能を実装します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -84,39 +85,39 @@ classDiagram
 
 ```typescript
 // test/orchestration/context-
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from "bun:test";
 import type {
   ContextParams,
   ModePriorities,
   ContextWeights,
   CompressionStrategy,
-  KeyInfo
-} from '../../src/orchestration/context-types';
+  KeyInfo,
+} from "../../src/orchestration/context-types";
 
-describe('Context Optimization Types', () => {
-  test('should define ContextParams interface correctly', () => {
+describe("Context Optimization Types", () => {
+  test("should define ContextParams interface correctly", () => {
     const params: ContextParams = {
-      mode: 'code',
-      taskDescription: 'Implement user authentication',
-      previousResults: ['Design completed', 'Database schema created'],
+      mode: "code",
+      taskDescription: "Implement user authentication",
+      previousResults: ["Design completed", "Database schema created"],
       globalContext: {
-        projectType: 'web-app',
-        framework: 'React'
+        projectType: "web-app",
+        framework: "React",
       },
       maxTokens: 4000,
       priorityOverrides: {
-        'technical_detail': 0.9,
-        'file_change': 0.8
-      }
+        technical_detail: 0.9,
+        file_change: 0.8,
+      },
     };
 
-    expect(params.mode).toBe('code');
+    expect(params.mode).toBe("code");
     expect(params.previousResults.length).toBe(2);
-    expect(params.globalContext.framework).toBe('React');
-    expect(params.priorityOverrides?.['technical_detail']).toBe(0.9);
+    expect(params.globalContext.framework).toBe("React");
+    expect(params.priorityOverrides?.["technical_detail"]).toBe(0.9);
   });
 
-  test('should define ModePriorities correctly', () => {
+  test("should define ModePriorities correctly", () => {
     const priorities: ModePriorities = {
       design_decision: 0.9,
       technical_detail: 0.8,
@@ -125,39 +126,39 @@ describe('Context Optimization Types', () => {
       error_info: 0.5,
       performance_data: 0.4,
       security_concern: 0.8,
-      test_result: 0.3
+      test_result: 0.3,
     };
 
     expect(priorities.design_decision).toBe(0.9);
     expect(priorities.security_concern).toBe(0.8);
-    expect(typeof priorities.test_result).toBe('number');
+    expect(typeof priorities.test_result).toBe("number");
   });
 
-  test('should define KeyInfo correctly', () => {
+  test("should define KeyInfo correctly", () => {
     const keyInfo: KeyInfo = {
-      type: 'file_change',
-      content: 'Modified src/auth/login.ts',
+      type: "file_change",
+      content: "Modified src/auth/login.ts",
       relevanceScore: 0.85,
       tokens: 45,
-      category: 'implementation'
+      category: "implementation",
     };
 
-    expect(keyInfo.type).toBe('file_change');
+    expect(keyInfo.type).toBe("file_change");
     expect(keyInfo.relevanceScore).toBe(0.85);
     expect(keyInfo.tokens).toBe(45);
   });
 
-  test('should define CompressionStrategy correctly', () => {
+  test("should define CompressionStrategy correctly", () => {
     const strategy: CompressionStrategy = {
-      name: 'summarize_logs',
-      applicableTypes: ['error_info', 'performance_data'],
+      name: "summarize_logs",
+      applicableTypes: ["error_info", "performance_data"],
       compressionRatio: 0.3,
-      preserveKeywords: ['error', 'performance', 'critical']
+      preserveKeywords: ["error", "performance", "critical"],
     };
 
-    expect(strategy.name).toBe('summarize_logs');
+    expect(strategy.name).toBe("summarize_logs");
     expect(strategy.compressionRatio).toBe(0.3);
-    expect(strategy.preserveKeywords).toContain('error');
+    expect(strategy.preserveKeywords).toContain("error");
   });
 });
 ```
@@ -186,10 +187,10 @@ export interface ModePriorities {
 }
 
 export interface ContextWeights {
-  recency: number;          // How recent the information is
-  relevance: number;        // How relevant to the current task
-  specificity: number;      // How specific vs general the information
-  actionability: number;    // How actionable the information is
+  recency: number; // How recent the information is
+  relevance: number; // How relevant to the current task
+  specificity: number; // How specific vs general the information
+  actionability: number; // How actionable the information is
 }
 
 export interface KeyInfo {
@@ -197,7 +198,12 @@ export interface KeyInfo {
   content: string;
   relevanceScore: number;
   tokens: number;
-  category: 'implementation' | 'design' | 'debugging' | 'testing' | 'documentation';
+  category:
+    | "implementation"
+    | "design"
+    | "debugging"
+    | "testing"
+    | "documentation";
   timestamp?: Date;
 }
 
@@ -206,7 +212,11 @@ export interface CompressionStrategy {
   applicableTypes: string[];
   compressionRatio: number;
   preserveKeywords: string[];
-  algorithm?: 'summarize' | 'extract_key_points' | 'compress_logs' | 'deduplicate';
+  algorithm?:
+    | "summarize"
+    | "extract_key_points"
+    | "compress_logs"
+    | "deduplicate";
 }
 
 export interface OptimizationResult {
@@ -226,16 +236,16 @@ export interface SemanticMatch {
 }
 
 export type ContextCategory =
-  | 'code_changes'
-  | 'design_decisions'
-  | 'error_logs'
-  | 'test_results'
-  | 'performance_metrics'
-  | 'dependency_updates'
-  | 'security_findings'
-  | 'documentation_updates';
+  | "code_changes"
+  | "design_decisions"
+  | "error_logs"
+  | "test_results"
+  | "performance_metrics"
+  | "dependency_updates"
+  | "security_findings"
+  | "documentation_updates";
 
-export type OptimizationLevel = 'aggressive' | 'balanced' | 'conservative';
+export type OptimizationLevel = "aggressive" | "balanced" | "conservative";
 ```
 
 ### タスク2.2.2: 優先度計算エンジンの実装
@@ -244,95 +254,112 @@ export type OptimizationLevel = 'aggressive' | 'balanced' | 'conservative';
 
 ```typescript
 // test/orchestration/priority-calculator.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { PriorityCalculator } from '../../src/orchestration/priority-calculator';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { PriorityCalculator } from "../../src/orchestration/priority-calculator";
 
-describe('PriorityCalculator', () => {
+describe("PriorityCalculator", () => {
   let calculator: PriorityCalculator;
 
   beforeEach(() => {
     calculator = new PriorityCalculator();
   });
 
-  test('should calculate correct priorities for code mode', () => {
-    const codePriorities = calculator.getModePriorities('code');
+  test("should calculate correct priorities for code mode", () => {
+    const codePriorities = calculator.getModePriorities("code");
 
-    expect(codePriorities.technical_detail).toBeGreaterThan(codePriorities.design_decision);
-    expect(codePriorities.file_change).toBeGreaterThan(codePriorities.performance_data);
-    expect(codePriorities.error_info).toBeGreaterThan(codePriorities.test_result);
+    expect(codePriorities.technical_detail).toBeGreaterThan(
+      codePriorities.design_decision,
+    );
+    expect(codePriorities.file_change).toBeGreaterThan(
+      codePriorities.performance_data,
+    );
+    expect(codePriorities.error_info).toBeGreaterThan(
+      codePriorities.test_result,
+    );
   });
 
-  test('should calculate correct priorities for architect mode', () => {
-    const architectPriorities = calculator.getModePriorities('architect');
+  test("should calculate correct priorities for architect mode", () => {
+    const architectPriorities = calculator.getModePriorities("architect");
 
-    expect(architectPriorities.design_decision).toBeGreaterThan(architectPriorities.technical_detail);
-    expect(architectPriorities.dependency_info).toBeGreaterThan(architectPriorities.file_change);
+    expect(architectPriorities.design_decision).toBeGreaterThan(
+      architectPriorities.technical_detail,
+    );
+    expect(architectPriorities.dependency_info).toBeGreaterThan(
+      architectPriorities.file_change,
+    );
   });
 
-  test('should calculate correct priorities for debug mode', () => {
-    const debugPriorities = calculator.getModePriorities('debug');
+  test("should calculate correct priorities for debug mode", () => {
+    const debugPriorities = calculator.getModePriorities("debug");
 
-    expect(debugPriorities.error_info).toBeGreaterThan(debugPriorities.design_decision);
-    expect(debugPriorities.performance_data).toBeGreaterThan(debugPriorities.test_result);
+    expect(debugPriorities.error_info).toBeGreaterThan(
+      debugPriorities.design_decision,
+    );
+    expect(debugPriorities.performance_data).toBeGreaterThan(
+      debugPriorities.test_result,
+    );
   });
 
-  test('should calculate priority scores for information items', () => {
+  test("should calculate priority scores for information items", () => {
     const fileChangeInfo = {
-      type: 'file_change',
-      content: 'Modified src/components/UserProfile.tsx',
-      category: 'implementation'
+      type: "file_change",
+      content: "Modified src/components/UserProfile.tsx",
+      category: "implementation",
     };
 
-    const codeScore = calculator.calculatePriority(fileChangeInfo, 'code');
-    const architectScore = calculator.calculatePriority(fileChangeInfo, 'architect');
+    const codeScore = calculator.calculatePriority(fileChangeInfo, "code");
+    const architectScore = calculator.calculatePriority(
+      fileChangeInfo,
+      "architect",
+    );
 
     expect(codeScore).toBeGreaterThan(architectScore);
   });
 
-  test('should rank information by priority correctly', () => {
+  test("should rank information by priority correctly", () => {
     const items = [
-      { type: 'design_decision', content: 'Chose React for frontend' },
-      { type: 'file_change', content: 'Updated user.ts' },
-      { type: 'error_info', content: 'TypeError in login function' },
-      { type: 'test_result', content: 'All tests passing' }
+      { type: "design_decision", content: "Chose React for frontend" },
+      { type: "file_change", content: "Updated user.ts" },
+      { type: "error_info", content: "TypeError in login function" },
+      { type: "test_result", content: "All tests passing" },
     ];
 
-    const rankedForCode = calculator.rankInformationByPriority(items, 'code');
-    const rankedForDebug = calculator.rankInformationByPriority(items, 'debug');
+    const rankedForCode = calculator.rankInformationByPriority(items, "code");
+    const rankedForDebug = calculator.rankInformationByPriority(items, "debug");
 
     // For code mode, file changes should be high priority
-    expect(rankedForCode[0].type).toBe('file_change');
+    expect(rankedForCode[0].type).toBe("file_change");
 
     // For debug mode, error info should be highest priority
-    expect(rankedForDebug[0].type).toBe('error_info');
+    expect(rankedForDebug[0].type).toBe("error_info");
   });
 
-  test('should handle unknown information types gracefully', () => {
+  test("should handle unknown information types gracefully", () => {
     const unknownInfo = {
-      type: 'unknown_type',
-      content: 'Some unknown information'
+      type: "unknown_type",
+      content: "Some unknown information",
     };
 
-    const score = calculator.calculatePriority(unknownInfo, 'code');
+    const score = calculator.calculatePriority(unknownInfo, "code");
     expect(score).toBeGreaterThanOrEqual(0);
     expect(score).toBeLessThanOrEqual(1);
   });
 
-  test('should apply recency weighting correctly', () => {
+  test("should apply recency weighting correctly", () => {
     const oldInfo = {
-      type: 'file_change',
-      content: 'Old change',
-      timestamp: new Date('2023-01-01')
+      type: "file_change",
+      content: "Old change",
+      timestamp: new Date("2023-01-01"),
     };
 
     const newInfo = {
-      type: 'file_change',
-      content: 'Recent change',
-      timestamp: new Date()
+      type: "file_change",
+      content: "Recent change",
+      timestamp: new Date(),
     };
 
-    const oldScore = calculator.calculatePriority(oldInfo, 'code');
-    const newScore = calculator.calculatePriority(newInfo, 'code');
+    const oldScore = calculator.calculatePriority(oldInfo, "code");
+    const newScore = calculator.calculatePriority(newInfo, "code");
 
     expect(newScore).toBeGreaterThan(oldScore);
   });
@@ -342,7 +369,7 @@ describe('PriorityCalculator', () => {
 #### 実装: src/orchestration/priority-calculator.ts
 
 ```typescript
-import type { ModePriorities, ContextWeights, KeyInfo } from './context-types';
+import type { ModePriorities, ContextWeights, KeyInfo } from "./context-types";
 
 export class PriorityCalculator {
   private modePriorities: Map<string, ModePriorities>;
@@ -354,7 +381,7 @@ export class PriorityCalculator {
       recency: 0.3,
       relevance: 0.4,
       specificity: 0.2,
-      actionability: 0.1
+      actionability: 0.1,
     };
   }
 
@@ -371,25 +398,25 @@ export class PriorityCalculator {
     const specificityWeight = this.calculateSpecificityWeight(info);
     const actionabilityWeight = this.calculateActionabilityWeight(info, mode);
 
-    const finalPriority = basePriority * (
-      this.contextWeights.recency * recencyWeight +
-      this.contextWeights.relevance * relevanceWeight +
-      this.contextWeights.specificity * specificityWeight +
-      this.contextWeights.actionability * actionabilityWeight
-    );
+    const finalPriority =
+      basePriority *
+      (this.contextWeights.recency * recencyWeight +
+        this.contextWeights.relevance * relevanceWeight +
+        this.contextWeights.specificity * specificityWeight +
+        this.contextWeights.actionability * actionabilityWeight);
 
     return Math.min(Math.max(finalPriority, 0), 1);
   }
 
   getModePriorities(mode: string): ModePriorities {
-    return this.modePriorities.get(mode) || this.modePriorities.get('code')!;
+    return this.modePriorities.get(mode) || this.modePriorities.get("code")!;
   }
 
   rankInformationByPriority(items: any[], mode: string): any[] {
     return items
-      .map(item => ({
+      .map((item) => ({
         ...item,
-        priority: this.calculatePriority(item, mode)
+        priority: this.calculatePriority(item, mode),
       }))
       .sort((a, b) => b.priority - a.priority);
   }
@@ -404,7 +431,7 @@ export class PriorityCalculator {
     const map = new Map<string, ModePriorities>();
 
     // Code mode priorities
-    map.set('code', {
+    map.set("code", {
       design_decision: 0.4,
       technical_detail: 0.9,
       dependency_info: 0.7,
@@ -412,11 +439,11 @@ export class PriorityCalculator {
       error_info: 0.8,
       performance_data: 0.5,
       security_concern: 0.7,
-      test_result: 0.6
+      test_result: 0.6,
     });
 
     // Architect mode priorities
-    map.set('architect', {
+    map.set("architect", {
       design_decision: 0.9,
       technical_detail: 0.6,
       dependency_info: 0.8,
@@ -424,11 +451,11 @@ export class PriorityCalculator {
       error_info: 0.4,
       performance_data: 0.7,
       security_concern: 0.8,
-      test_result: 0.3
+      test_result: 0.3,
     });
 
     // Debug mode priorities
-    map.set('debug', {
+    map.set("debug", {
       design_decision: 0.2,
       technical_detail: 0.7,
       dependency_info: 0.6,
@@ -436,11 +463,11 @@ export class PriorityCalculator {
       error_info: 0.9,
       performance_data: 0.8,
       security_concern: 0.6,
-      test_result: 0.7
+      test_result: 0.7,
     });
 
     // Ask mode priorities
-    map.set('ask', {
+    map.set("ask", {
       design_decision: 0.7,
       technical_detail: 0.8,
       dependency_info: 0.6,
@@ -448,11 +475,11 @@ export class PriorityCalculator {
       error_info: 0.3,
       performance_data: 0.4,
       security_concern: 0.5,
-      test_result: 0.4
+      test_result: 0.4,
     });
 
     // Orchestrator mode priorities
-    map.set('orchestrator', {
+    map.set("orchestrator", {
       design_decision: 0.8,
       technical_detail: 0.5,
       dependency_info: 0.9,
@@ -460,7 +487,7 @@ export class PriorityCalculator {
       error_info: 0.6,
       performance_data: 0.6,
       security_concern: 0.7,
-      test_result: 0.5
+      test_result: 0.5,
     });
 
     return map;
@@ -468,18 +495,18 @@ export class PriorityCalculator {
 
   private normalizeInfoType(type: string): string {
     const typeMapping: Record<string, string> = {
-      'code_change': 'file_change',
-      'file_modification': 'file_change',
-      'architecture': 'design_decision',
-      'design': 'design_decision',
-      'bug': 'error_info',
-      'exception': 'error_info',
-      'perf': 'performance_data',
-      'benchmark': 'performance_data',
-      'security': 'security_concern',
-      'vulnerability': 'security_concern',
-      'test': 'test_result',
-      'spec': 'test_result'
+      code_change: "file_change",
+      file_modification: "file_change",
+      architecture: "design_decision",
+      design: "design_decision",
+      bug: "error_info",
+      exception: "error_info",
+      perf: "performance_data",
+      benchmark: "performance_data",
+      security: "security_concern",
+      vulnerability: "security_concern",
+      test: "test_result",
+      spec: "test_result",
     };
 
     return typeMapping[type] || type;
@@ -499,7 +526,7 @@ export class PriorityCalculator {
   }
 
   private calculateRelevanceWeight(info: any, mode: string): number {
-    const content = (info.content || '').toLowerCase();
+    const content = (info.content || "").toLowerCase();
     const modeKeywords = this.getModeKeywords(mode);
 
     let relevanceScore = 0;
@@ -513,12 +540,13 @@ export class PriorityCalculator {
   }
 
   private calculateSpecificityWeight(info: any): number {
-    const content = info.content || '';
+    const content = info.content || "";
 
     // More specific content has higher weight
     const hasNumbers = /\d/.test(content);
     const hasFileNames = /\.[a-z]{2,4}/.test(content);
-    const hasSpecificTerms = /\b(function|class|variable|method|component)\b/i.test(content);
+    const hasSpecificTerms =
+      /\b(function|class|variable|method|component)\b/i.test(content);
 
     let specificity = 0.3; // Base specificity
     if (hasNumbers) specificity += 0.2;
@@ -529,7 +557,7 @@ export class PriorityCalculator {
   }
 
   private calculateActionabilityWeight(info: any, mode: string): number {
-    const content = (info.content || '').toLowerCase();
+    const content = (info.content || "").toLowerCase();
 
     // Different modes have different actionability indicators
     const actionableIndicators = this.getActionableIndicators(mode);
@@ -546,11 +574,11 @@ export class PriorityCalculator {
 
   private getModeKeywords(mode: string): string[] {
     const keywordMap: Record<string, string[]> = {
-      'code': ['implement', 'function', 'class', 'method', 'algorithm', 'code'],
-      'architect': ['design', 'architecture', 'pattern', 'structure', 'system'],
-      'debug': ['error', 'bug', 'exception', 'fix', 'problem', 'issue'],
-      'ask': ['explain', 'how', 'what', 'why', 'documentation', 'guide'],
-      'orchestrator': ['coordinate', 'manage', 'organize', 'workflow', 'process']
+      code: ["implement", "function", "class", "method", "algorithm", "code"],
+      architect: ["design", "architecture", "pattern", "structure", "system"],
+      debug: ["error", "bug", "exception", "fix", "problem", "issue"],
+      ask: ["explain", "how", "what", "why", "documentation", "guide"],
+      orchestrator: ["coordinate", "manage", "organize", "workflow", "process"],
     };
 
     return keywordMap[mode] || [];
@@ -558,11 +586,17 @@ export class PriorityCalculator {
 
   private getActionableIndicators(mode: string): string[] {
     const indicatorMap: Record<string, string[]> = {
-      'code': ['todo', 'implement', 'fix', 'update', 'create'],
-      'architect': ['design', 'plan', 'decide', 'choose', 'define'],
-      'debug': ['investigate', 'reproduce', 'fix', 'test', 'verify'],
-      'ask': ['research', 'document', 'explain', 'clarify', 'define'],
-      'orchestrator': ['coordinate', 'assign', 'delegate', 'schedule', 'prioritize']
+      code: ["todo", "implement", "fix", "update", "create"],
+      architect: ["design", "plan", "decide", "choose", "define"],
+      debug: ["investigate", "reproduce", "fix", "test", "verify"],
+      ask: ["research", "document", "explain", "clarify", "define"],
+      orchestrator: [
+        "coordinate",
+        "assign",
+        "delegate",
+        "schedule",
+        "prioritize",
+      ],
     };
 
     return indicatorMap[mode] || [];
@@ -576,19 +610,20 @@ export class PriorityCalculator {
 
 ```typescript
 // test/orchestration/token-optimizer.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { TokenOptimizer } from '../../src/orchestration/token-optimizer';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { TokenOptimizer } from "../../src/orchestration/token-optimizer";
 
-describe('TokenOptimizer', () => {
+describe("TokenOptimizer", () => {
   let optimizer: TokenOptimizer;
 
   beforeEach(() => {
     optimizer = new TokenOptimizer();
   });
 
-  test('should calculate token count approximately correctly', () => {
+  test("should calculate token count approximately correctly", () => {
     const shortText = "Hello world";
-    const longText = "This is a much longer text that contains many more words and should result in a higher token count than the shorter text.";
+    const longText =
+      "This is a much longer text that contains many more words and should result in a higher token count than the shorter text.";
 
     const shortTokens = optimizer.calculateTokenCount(shortText);
     const longTokens = optimizer.calculateTokenCount(longText);
@@ -597,30 +632,32 @@ describe('TokenOptimizer', () => {
     expect(shortTokens).toBeGreaterThan(0);
   });
 
-  test('should optimize content for token limit', () => {
+  test("should optimize content for token limit", () => {
     const content = {
       messages: [
         "This is a very long message that contains lots of detailed information about the implementation",
         "Short message",
         "Another long message with extensive details about architecture and design decisions that might not be necessary",
-        "Critical error message"
+        "Critical error message",
       ],
-      priorities: [0.3, 0.8, 0.2, 0.9]
+      priorities: [0.3, 0.8, 0.2, 0.9],
     };
 
     const optimized = optimizer.optimizeForTokenLimit(content, 100);
 
-    expect(optimized.messages.length).toBeLessThanOrEqual(content.messages.length);
+    expect(optimized.messages.length).toBeLessThanOrEqual(
+      content.messages.length,
+    );
     // High priority items should be preserved
     expect(optimized.messages).toContain("Short message");
     expect(optimized.messages).toContain("Critical error message");
   });
 
-  test('should prioritize content correctly', () => {
+  test("should prioritize content correctly", () => {
     const content = [
       { text: "Low priority item", id: 1 },
       { text: "High priority item", id: 2 },
-      { text: "Medium priority item", id: 3 }
+      { text: "Medium priority item", id: 3 },
     ];
     const priorities = [0.2, 0.9, 0.5];
 
@@ -631,7 +668,7 @@ describe('TokenOptimizer', () => {
     expect(prioritized[2].id).toBe(1); // Low priority last
   });
 
-  test('should compress content while preserving key information', () => {
+  test("should compress content while preserving key information", () => {
     const verbose = `
       The user authentication system needs to be implemented with the following requirements:
       1. It should support email and password login
@@ -649,7 +686,7 @@ describe('TokenOptimizer', () => {
     expect(compressed).toContain("password");
   });
 
-  test('should handle edge cases gracefully', () => {
+  test("should handle edge cases gracefully", () => {
     expect(() => optimizer.calculateTokenCount("")).not.toThrow();
     expect(() => optimizer.optimizeForTokenLimit({}, 0)).not.toThrow();
     expect(() => optimizer.compressContent("", 0.5)).not.toThrow();
@@ -657,14 +694,15 @@ describe('TokenOptimizer', () => {
     expect(optimizer.calculateTokenCount("")).toBe(0);
   });
 
-  test('should preserve essential keywords during compression', () => {
-    const content = "Implement user authentication with secure password hashing and JWT token management";
+  test("should preserve essential keywords during compression", () => {
+    const content =
+      "Implement user authentication with secure password hashing and JWT token management";
     const compressed = optimizer.compressContent(content, 0.3);
 
     // Essential keywords should be preserved
-    const essentialKeywords = ['authentication', 'password', 'JWT', 'secure'];
-    const preservedCount = essentialKeywords.filter(keyword =>
-      compressed.toLowerCase().includes(keyword.toLowerCase())
+    const essentialKeywords = ["authentication", "password", "JWT", "secure"];
+    const preservedCount = essentialKeywords.filter((keyword) =>
+      compressed.toLowerCase().includes(keyword.toLowerCase()),
     ).length;
 
     expect(preservedCount).toBeGreaterThan(essentialKeywords.length * 0.5);
@@ -675,7 +713,7 @@ describe('TokenOptimizer', () => {
 #### 実装: src/orchestration/token-optimizer.ts
 
 ```typescript
-import type { CompressionStrategy, OptimizationResult } from './context-types';
+import type { CompressionStrategy, OptimizationResult } from "./context-types";
 
 interface TokenCounter {
   count(text: string): number;
@@ -728,7 +766,7 @@ export class TokenOptimizer {
     const indexed = content.map((item, index) => ({
       item,
       priority: priorities[index],
-      index
+      index,
     }));
 
     return indexed
@@ -748,7 +786,10 @@ export class TokenOptimizer {
     const keyPhrases = this.extractKeyPhrases(content);
 
     // Rank sentences by importance
-    const rankedSentences = this.rankSentencesByImportance(sentences, keyPhrases);
+    const rankedSentences = this.rankSentencesByImportance(
+      sentences,
+      keyPhrases,
+    );
 
     // Select sentences until we reach target length
     let compressedLength = 0;
@@ -763,10 +804,13 @@ export class TokenOptimizer {
       }
     }
 
-    return selectedSentences.join(' ').trim();
+    return selectedSentences.join(" ").trim();
   }
 
-  generateOptimizationReport(original: any, optimized: any): OptimizationResult {
+  generateOptimizationReport(
+    original: any,
+    optimized: any,
+  ): OptimizationResult {
     const originalTokens = this.calculateContentTokens(original);
     const optimizedTokens = this.calculateContentTokens(optimized);
     const reductionRatio = (originalTokens - optimizedTokens) / originalTokens;
@@ -777,31 +821,41 @@ export class TokenOptimizer {
       reductionRatio,
       preservedInfo: [], // TODO: Track preserved information
       removedInfo: [], // TODO: Track removed information
-      optimizationStrategies: [] // TODO: Track applied strategies
+      optimizationStrategies: [], // TODO: Track applied strategies
     };
   }
 
   private calculateContentTokens(content: any): number {
-    if (typeof content === 'string') {
+    if (typeof content === "string") {
       return this.calculateTokenCount(content);
     }
 
     if (Array.isArray(content)) {
-      return content.reduce((total, item) => total + this.calculateContentTokens(item), 0);
+      return content.reduce(
+        (total, item) => total + this.calculateContentTokens(item),
+        0,
+      );
     }
 
-    if (typeof content === 'object' && content !== null) {
-      return Object.values(content).reduce((total, value) => total + this.calculateContentTokens(value), 0);
+    if (typeof content === "object" && content !== null) {
+      return Object.values(content).reduce(
+        (total, value) => total + this.calculateContentTokens(value),
+        0,
+      );
     }
 
     return 0;
   }
 
   private removeLowPriorityItems(content: any, limit: number): any {
-    if (Array.isArray(content) && content.length > 0 && typeof content[0] === 'object') {
+    if (
+      Array.isArray(content) &&
+      content.length > 0 &&
+      typeof content[0] === "object"
+    ) {
       // If content has priority information, filter by priority
       const sortedByPriority = content
-        .filter(item => item.priority !== undefined)
+        .filter((item) => item.priority !== undefined)
         .sort((a, b) => b.priority - a.priority);
 
       const result = [];
@@ -822,7 +876,7 @@ export class TokenOptimizer {
   }
 
   private compressVerboseContent(content: any, limit: number): any {
-    if (typeof content === 'string') {
+    if (typeof content === "string") {
       const currentTokens = this.calculateTokenCount(content);
       if (currentTokens > limit) {
         const targetRatio = limit / currentTokens;
@@ -830,10 +884,13 @@ export class TokenOptimizer {
       }
     }
 
-    if (typeof content === 'object' && content !== null) {
+    if (typeof content === "object" && content !== null) {
       const compressed: any = {};
       for (const [key, value] of Object.entries(content)) {
-        compressed[key] = this.compressVerboseContent(value, Math.floor(limit * 0.3));
+        compressed[key] = this.compressVerboseContent(
+          value,
+          Math.floor(limit * 0.3),
+        );
       }
       return compressed;
     }
@@ -856,34 +913,53 @@ export class TokenOptimizer {
   private extractSentences(content: string): string[] {
     return content
       .split(/[.!?]+/)
-      .map(s => s.trim())
-      .filter(s => s.length > 0);
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
   }
 
   private extractKeyPhrases(content: string): string[] {
     // Simple key phrase extraction
     const keywords = [
-      'implement', 'create', 'design', 'fix', 'error', 'function',
-      'component', 'service', 'authentication', 'database', 'api',
-      'security', 'performance', 'test', 'user', 'system'
+      "implement",
+      "create",
+      "design",
+      "fix",
+      "error",
+      "function",
+      "component",
+      "service",
+      "authentication",
+      "database",
+      "api",
+      "security",
+      "performance",
+      "test",
+      "user",
+      "system",
     ];
 
-    return keywords.filter(keyword =>
-      content.toLowerCase().includes(keyword.toLowerCase())
+    return keywords.filter((keyword) =>
+      content.toLowerCase().includes(keyword.toLowerCase()),
     );
   }
 
-  private rankSentencesByImportance(sentences: string[], keyPhrases: string[]): string[] {
+  private rankSentencesByImportance(
+    sentences: string[],
+    keyPhrases: string[],
+  ): string[] {
     return sentences
-      .map(sentence => ({
+      .map((sentence) => ({
         sentence,
-        score: this.calculateSentenceScore(sentence, keyPhrases)
+        score: this.calculateSentenceScore(sentence, keyPhrases),
       }))
       .sort((a, b) => b.score - a.score)
-      .map(item => item.sentence);
+      .map((item) => item.sentence);
   }
 
-  private calculateSentenceScore(sentence: string, keyPhrases: string[]): number {
+  private calculateSentenceScore(
+    sentence: string,
+    keyPhrases: string[],
+  ): number {
     let score = 0;
     const lowerSentence = sentence.toLowerCase();
 
@@ -907,14 +983,17 @@ export class TokenOptimizer {
     return score;
   }
 
-  private applyCompressionStrategy(content: any, strategy: CompressionStrategy): any {
+  private applyCompressionStrategy(
+    content: any,
+    strategy: CompressionStrategy,
+  ): any {
     // Apply specific compression strategies
     switch (strategy.algorithm) {
-      case 'summarize':
+      case "summarize":
         return this.summarizeContent(content, strategy);
-      case 'extract_key_points':
+      case "extract_key_points":
         return this.extractKeyPoints(content, strategy);
-      case 'deduplicate':
+      case "deduplicate":
         return this.deduplicateContent(content, strategy);
       default:
         return content;
@@ -922,24 +1001,26 @@ export class TokenOptimizer {
   }
 
   private summarizeContent(content: any, strategy: CompressionStrategy): any {
-    if (typeof content === 'string') {
+    if (typeof content === "string") {
       return this.compressContent(content, strategy.compressionRatio);
     }
     return content;
   }
 
   private extractKeyPoints(content: any, strategy: CompressionStrategy): any {
-    if (typeof content === 'string') {
+    if (typeof content === "string") {
       const sentences = this.extractSentences(content);
       const keyPhrases = strategy.preserveKeywords;
 
-      const importantSentences = sentences.filter(sentence =>
-        keyPhrases.some(keyword =>
-          sentence.toLowerCase().includes(keyword.toLowerCase())
-        )
+      const importantSentences = sentences.filter((sentence) =>
+        keyPhrases.some((keyword) =>
+          sentence.toLowerCase().includes(keyword.toLowerCase()),
+        ),
       );
 
-      return importantSentences.slice(0, Math.ceil(sentences.length * strategy.compressionRatio)).join('. ');
+      return importantSentences
+        .slice(0, Math.ceil(sentences.length * strategy.compressionRatio))
+        .join(". ");
     }
     return content;
   }
@@ -947,7 +1028,7 @@ export class TokenOptimizer {
   private deduplicateContent(content: any, strategy: CompressionStrategy): any {
     if (Array.isArray(content)) {
       const seen = new Set();
-      return content.filter(item => {
+      return content.filter((item) => {
         const key = JSON.stringify(item);
         if (seen.has(key)) {
           return false;
@@ -962,26 +1043,26 @@ export class TokenOptimizer {
   private initializeCompressionStrategies(): CompressionStrategy[] {
     return [
       {
-        name: 'remove_duplicates',
-        applicableTypes: ['all'],
+        name: "remove_duplicates",
+        applicableTypes: ["all"],
         compressionRatio: 0.9,
         preserveKeywords: [],
-        algorithm: 'deduplicate'
+        algorithm: "deduplicate",
       },
       {
-        name: 'summarize_verbose',
-        applicableTypes: ['design_decision', 'technical_detail'],
+        name: "summarize_verbose",
+        applicableTypes: ["design_decision", "technical_detail"],
         compressionRatio: 0.6,
-        preserveKeywords: ['important', 'critical', 'key', 'main'],
-        algorithm: 'summarize'
+        preserveKeywords: ["important", "critical", "key", "main"],
+        algorithm: "summarize",
       },
       {
-        name: 'extract_error_essentials',
-        applicableTypes: ['error_info'],
+        name: "extract_error_essentials",
+        applicableTypes: ["error_info"],
         compressionRatio: 0.4,
-        preserveKeywords: ['error', 'exception', 'failed', 'critical'],
-        algorithm: 'extract_key_points'
-      }
+        preserveKeywords: ["error", "exception", "failed", "critical"],
+        algorithm: "extract_key_points",
+      },
     ];
   }
 }
@@ -1008,32 +1089,32 @@ class SimpleTokenCounter implements TokenCounter {
 
 ```typescript
 // test/orchestration/context-optimizer.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { ContextOptimizer } from '../../src/orchestration/context-optimizer';
-import type { ContextParams } from '../../src/orchestration/context-types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { ContextOptimizer } from "../../src/orchestration/context-optimizer";
+import type { ContextParams } from "../../src/orchestration/context-types";
 
-describe('ContextOptimizer', () => {
+describe("ContextOptimizer", () => {
   let optimizer: ContextOptimizer;
 
   beforeEach(() => {
     optimizer = new ContextOptimizer();
   });
 
-  test('should create optimized context for code mode', () => {
+  test("should create optimized context for code mode", () => {
     const params: ContextParams = {
-      mode: 'code',
-      taskDescription: 'Implement user login functionality',
+      mode: "code",
+      taskDescription: "Implement user login functionality",
       previousResults: [
-        'Database schema created with user table',
-        'Password hashing utility implemented',
-        'JWT token service created'
+        "Database schema created with user table",
+        "Password hashing utility implemented",
+        "JWT token service created",
       ],
       globalContext: {
-        framework: 'React',
-        backend: 'Node.js',
-        database: 'PostgreSQL'
+        framework: "React",
+        backend: "Node.js",
+        database: "PostgreSQL",
       },
-      maxTokens: 2000
+      maxTokens: 2000,
     };
 
     const context = optimizer.createContextForSubTask(params);
@@ -1043,34 +1124,40 @@ describe('ContextOptimizer', () => {
     expect(context.previousResults.length).toBeGreaterThan(0);
   });
 
-  test('should prioritize relevant information for different modes', () => {
+  test("should prioritize relevant information for different modes", () => {
     const previousResults = [
-      'System architecture designed with microservices',
-      'Database schema created',
-      'Authentication API implemented',
-      'Critical bug found in payment processing',
-      'Performance tests show 95% improvement'
+      "System architecture designed with microservices",
+      "Database schema created",
+      "Authentication API implemented",
+      "Critical bug found in payment processing",
+      "Performance tests show 95% improvement",
     ];
 
-    const codeRelevant = optimizer.extractRelevantInfo(previousResults, 'code');
-    const debugRelevant = optimizer.extractRelevantInfo(previousResults, 'debug');
-    const architectRelevant = optimizer.extractRelevantInfo(previousResults, 'architect');
+    const codeRelevant = optimizer.extractRelevantInfo(previousResults, "code");
+    const debugRelevant = optimizer.extractRelevantInfo(
+      previousResults,
+      "debug",
+    );
+    const architectRelevant = optimizer.extractRelevantInfo(
+      previousResults,
+      "architect",
+    );
 
     // Code mode should prioritize implementation details
-    expect(JSON.stringify(codeRelevant)).toContain('implemented');
+    expect(JSON.stringify(codeRelevant)).toContain("implemented");
 
     // Debug mode should prioritize error information
-    expect(JSON.stringify(debugRelevant)).toContain('bug');
+    expect(JSON.stringify(debugRelevant)).toContain("bug");
 
     // Architect mode should prioritize design information
-    expect(JSON.stringify(architectRelevant)).toContain('architecture');
+    expect(JSON.stringify(architectRelevant)).toContain("architecture");
   });
 
-  test('should achieve significant token reduction', () => {
+  test("should achieve significant token reduction", () => {
     const verboseContext = {
-      longDescription: 'This is a very long description '.repeat(100),
-      detailedLogs: 'Detailed log entry '.repeat(50),
-      extensiveDocumentation: 'Documentation paragraph '.repeat(30)
+      longDescription: "This is a very long description ".repeat(100),
+      detailedLogs: "Detailed log entry ".repeat(50),
+      extensiveDocumentation: "Documentation paragraph ".repeat(30),
     };
 
     const optimized = optimizer.optimizeContext(verboseContext, 500);
@@ -1082,9 +1169,9 @@ describe('ContextOptimizer', () => {
     expect(reduction).toBeGreaterThan(0.3); // At least 30% reduction
   });
 
-  test('should calculate reduction ratio correctly', () => {
-    const original = { content: 'This is a very long content '.repeat(20) };
-    const optimized = { content: 'Short content' };
+  test("should calculate reduction ratio correctly", () => {
+    const original = { content: "This is a very long content ".repeat(20) };
+    const optimized = { content: "Short content" };
 
     const ratio = optimizer.calculateReductionRatio(original, optimized);
 
@@ -1092,42 +1179,46 @@ describe('ContextOptimizer', () => {
     expect(ratio).toBeLessThanOrEqual(1);
   });
 
-  test('should preserve high priority information', () => {
+  test("should preserve high priority information", () => {
     const params: ContextParams = {
-      mode: 'debug',
-      taskDescription: 'Fix critical authentication bug',
+      mode: "debug",
+      taskDescription: "Fix critical authentication bug",
       previousResults: [
-        'User reported login failures',
-        'System shows 500 errors in auth service',
-        'Database connection is stable',
-        'Previous bug fix implemented for payments'
+        "User reported login failures",
+        "System shows 500 errors in auth service",
+        "Database connection is stable",
+        "Previous bug fix implemented for payments",
       ],
       globalContext: {},
       maxTokens: 200,
       priorityOverrides: {
-        'error_info': 0.95
-      }
+        error_info: 0.95,
+      },
     };
 
     const context = optimizer.createContextForSubTask(params);
     const contextStr = JSON.stringify(context);
 
     // Should preserve error-related information
-    expect(contextStr).toContain('error');
-    expect(contextStr).toContain('auth');
+    expect(contextStr).toContain("error");
+    expect(contextStr).toContain("auth");
   });
 
-  test('should handle edge cases gracefully', () => {
-    expect(() => optimizer.createContextForSubTask({
-      mode: 'code',
-      taskDescription: '',
-      previousResults: [],
-      globalContext: {},
-      maxTokens: 0
-    })).not.toThrow();
+  test("should handle edge cases gracefully", () => {
+    expect(() =>
+      optimizer.createContextForSubTask({
+        mode: "code",
+        taskDescription: "",
+        previousResults: [],
+        globalContext: {},
+        maxTokens: 0,
+      }),
+    ).not.toThrow();
 
     expect(() => optimizer.optimizeContext(null, 100)).not.toThrow();
-    expect(() => optimizer.extractRelevantInfo([], 'unknown_mode')).not.toThrow();
+    expect(() =>
+      optimizer.extractRelevantInfo([], "unknown_mode"),
+    ).not.toThrow();
   });
 });
 ```
@@ -1135,10 +1226,14 @@ describe('ContextOptimizer', () => {
 #### 実装: src/orchestration/context-optimizer.ts
 
 ```typescript
-import { PriorityCalculator } from './priority-calculator';
-import { TokenOptimizer } from './token-optimizer';
-import type { ContextParams, OptimizationResult, KeyInfo } from './context-types';
-import type { TaskContext } from '../tasks/types';
+import { PriorityCalculator } from "./priority-calculator";
+import { TokenOptimizer } from "./token-optimizer";
+import type {
+  ContextParams,
+  OptimizationResult,
+  KeyInfo,
+} from "./context-types";
+import type { TaskContext } from "../tasks/types";
 
 export class ContextOptimizer {
   private priorityCalculator: PriorityCalculator;
@@ -1152,27 +1247,36 @@ export class ContextOptimizer {
   createContextForSubTask(params: ContextParams): TaskContext {
     // Apply priority overrides if provided
     if (params.priorityOverrides) {
-      this.priorityCalculator.updateModePriorities(params.mode, params.priorityOverrides);
+      this.priorityCalculator.updateModePriorities(
+        params.mode,
+        params.priorityOverrides,
+      );
     }
 
     // Extract and prioritize relevant information
-    const relevantInfo = this.extractRelevantInfo(params.previousResults, params.mode);
+    const relevantInfo = this.extractRelevantInfo(
+      params.previousResults,
+      params.mode,
+    );
 
     // Create mode-specific context
     const modeSpecificContext = this.createModeSpecificContext(params);
 
     // Optimize for token limit
-    const optimizedInfo = this.optimizeContext({
-      relevantInfo,
-      modeSpecificContext,
-      globalContext: params.globalContext
-    }, params.maxTokens);
+    const optimizedInfo = this.optimizeContext(
+      {
+        relevantInfo,
+        modeSpecificContext,
+        globalContext: params.globalContext,
+      },
+      params.maxTokens,
+    );
 
     return {
       previousResults: optimizedInfo.relevantInfo || [],
       globalContext: optimizedInfo.globalContext || {},
       modeSpecificContext: optimizedInfo.modeSpecificContext || {},
-      maxTokens: params.maxTokens
+      maxTokens: params.maxTokens,
     };
   }
 
@@ -1186,14 +1290,17 @@ export class ContextOptimizer {
       type: this.classifyInformation(result),
       content: result,
       timestamp: new Date(Date.now() - index * 60000), // Simulate recency
-      category: this.categorizeForMode(result, mode)
+      category: this.categorizeForMode(result, mode),
     }));
 
     // Rank by priority for the given mode
-    const ranked = this.priorityCalculator.rankInformationByPriority(infoObjects, mode);
+    const ranked = this.priorityCalculator.rankInformationByPriority(
+      infoObjects,
+      mode,
+    );
 
     // Return the content of top-ranked items
-    return ranked.map(item => item.content);
+    return ranked.map((item) => item.content);
   }
 
   optimizeContext(context: any, maxTokens: number): any {
@@ -1219,7 +1326,10 @@ export class ContextOptimizer {
     return Math.max(0, (originalTokens - optimizedTokens) / originalTokens);
   }
 
-  generateOptimizationReport(original: any, optimized: any): OptimizationResult {
+  generateOptimizationReport(
+    original: any,
+    optimized: any,
+  ): OptimizationResult {
     const originalTokens = this.calculateContextTokens(original);
     const optimizedTokens = this.calculateContextTokens(optimized);
     const reductionRatio = this.calculateReductionRatio(original, optimized);
@@ -1230,54 +1340,72 @@ export class ContextOptimizer {
       reductionRatio,
       preservedInfo: this.extractPreservedInfo(original, optimized),
       removedInfo: this.extractRemovedInfo(original, optimized),
-      optimizationStrategies: ['prioritization', 'token_optimization', 'relevance_filtering']
+      optimizationStrategies: [
+        "prioritization",
+        "token_optimization",
+        "relevance_filtering",
+      ],
     };
   }
 
-  private createModeSpecificContext(params: ContextParams): Record<string, any> {
+  private createModeSpecificContext(
+    params: ContextParams,
+  ): Record<string, any> {
     const { mode, taskDescription } = params;
 
     const baseContext = {
       mode,
       taskDescription,
-      optimizationLevel: this.determineOptimizationLevel(params.maxTokens)
+      optimizationLevel: this.determineOptimizationLevel(params.maxTokens),
     };
 
     // Add mode-specific optimizations
     switch (mode) {
-      case 'code':
+      case "code":
         return {
           ...baseContext,
-          focusAreas: ['implementation_details', 'file_changes', 'technical_requirements'],
-          excludeTypes: ['high_level_design', 'business_requirements']
+          focusAreas: [
+            "implementation_details",
+            "file_changes",
+            "technical_requirements",
+          ],
+          excludeTypes: ["high_level_design", "business_requirements"],
         };
 
-      case 'architect':
+      case "architect":
         return {
           ...baseContext,
-          focusAreas: ['system_design', 'dependencies', 'architecture_decisions'],
-          excludeTypes: ['implementation_details', 'low_level_bugs']
+          focusAreas: [
+            "system_design",
+            "dependencies",
+            "architecture_decisions",
+          ],
+          excludeTypes: ["implementation_details", "low_level_bugs"],
         };
 
-      case 'debug':
+      case "debug":
         return {
           ...baseContext,
-          focusAreas: ['error_information', 'performance_data', 'system_logs'],
-          excludeTypes: ['design_decisions', 'future_planning']
+          focusAreas: ["error_information", "performance_data", "system_logs"],
+          excludeTypes: ["design_decisions", "future_planning"],
         };
 
-      case 'ask':
+      case "ask":
         return {
           ...baseContext,
-          focusAreas: ['documentation', 'explanations', 'knowledge_base'],
-          excludeTypes: ['implementation_specifics', 'error_logs']
+          focusAreas: ["documentation", "explanations", "knowledge_base"],
+          excludeTypes: ["implementation_specifics", "error_logs"],
         };
 
-      case 'orchestrator':
+      case "orchestrator":
         return {
           ...baseContext,
-          focusAreas: ['task_dependencies', 'coordination_requirements', 'overall_progress'],
-          excludeTypes: ['implementation_details']
+          focusAreas: [
+            "task_dependencies",
+            "coordination_requirements",
+            "overall_progress",
+          ],
+          excludeTypes: ["implementation_details"],
         };
 
       default:
@@ -1288,67 +1416,144 @@ export class ContextOptimizer {
   private classifyInformation(content: string): string {
     const lowerContent = content.toLowerCase();
 
-    if (this.containsKeywords(lowerContent, ['error', 'exception', 'failed', 'bug'])) {
-      return 'error_info';
+    if (
+      this.containsKeywords(lowerContent, [
+        "error",
+        "exception",
+        "failed",
+        "bug",
+      ])
+    ) {
+      return "error_info";
     }
 
-    if (this.containsKeywords(lowerContent, ['design', 'architecture', 'decided', 'plan'])) {
-      return 'design_decision';
+    if (
+      this.containsKeywords(lowerContent, [
+        "design",
+        "architecture",
+        "decided",
+        "plan",
+      ])
+    ) {
+      return "design_decision";
     }
 
-    if (this.containsKeywords(lowerContent, ['implemented', 'created', 'added', 'modified', 'file'])) {
-      return 'file_change';
+    if (
+      this.containsKeywords(lowerContent, [
+        "implemented",
+        "created",
+        "added",
+        "modified",
+        "file",
+      ])
+    ) {
+      return "file_change";
     }
 
-    if (this.containsKeywords(lowerContent, ['performance', 'speed', 'memory', 'cpu', 'latency'])) {
-      return 'performance_data';
+    if (
+      this.containsKeywords(lowerContent, [
+        "performance",
+        "speed",
+        "memory",
+        "cpu",
+        "latency",
+      ])
+    ) {
+      return "performance_data";
     }
 
-    if (this.containsKeywords(lowerContent, ['test', 'spec', 'passed', 'failed', 'coverage'])) {
-      return 'test_result';
+    if (
+      this.containsKeywords(lowerContent, [
+        "test",
+        "spec",
+        "passed",
+        "failed",
+        "coverage",
+      ])
+    ) {
+      return "test_result";
     }
 
-    if (this.containsKeywords(lowerContent, ['security', 'auth', 'permission', 'vulnerability'])) {
-      return 'security_concern';
+    if (
+      this.containsKeywords(lowerContent, [
+        "security",
+        "auth",
+        "permission",
+        "vulnerability",
+      ])
+    ) {
+      return "security_concern";
     }
 
-    if (this.containsKeywords(lowerContent, ['dependency', 'library', 'package', 'import'])) {
-      return 'dependency_info';
+    if (
+      this.containsKeywords(lowerContent, [
+        "dependency",
+        "library",
+        "package",
+        "import",
+      ])
+    ) {
+      return "dependency_info";
     }
 
-    return 'technical_detail';
+    return "technical_detail";
   }
 
-  private categorizeForMode(content: string, mode: string): 'implementation' | 'design' | 'debugging' | 'testing' | 'documentation' {
+  private categorizeForMode(
+    content: string,
+    mode: string,
+  ): "implementation" | "design" | "debugging" | "testing" | "documentation" {
     const lowerContent = content.toLowerCase();
 
-    if (mode === 'architect' || this.containsKeywords(lowerContent, ['design', 'architecture', 'plan'])) {
-      return 'design';
+    if (
+      mode === "architect" ||
+      this.containsKeywords(lowerContent, ["design", "architecture", "plan"])
+    ) {
+      return "design";
     }
 
-    if (mode === 'debug' || this.containsKeywords(lowerContent, ['error', 'bug', 'fix', 'debug'])) {
-      return 'debugging';
+    if (
+      mode === "debug" ||
+      this.containsKeywords(lowerContent, ["error", "bug", "fix", "debug"])
+    ) {
+      return "debugging";
     }
 
-    if (this.containsKeywords(lowerContent, ['test', 'spec', 'coverage', 'verify'])) {
-      return 'testing';
+    if (
+      this.containsKeywords(lowerContent, [
+        "test",
+        "spec",
+        "coverage",
+        "verify",
+      ])
+    ) {
+      return "testing";
     }
 
-    if (this.containsKeywords(lowerContent, ['document', 'explain', 'guide', 'readme'])) {
-      return 'documentation';
+    if (
+      this.containsKeywords(lowerContent, [
+        "document",
+        "explain",
+        "guide",
+        "readme",
+      ])
+    ) {
+      return "documentation";
     }
 
-    return 'implementation';
+    return "implementation";
   }
 
   private containsKeywords(content: string, keywords: string[]): boolean {
-    return keywords.some(keyword => content.includes(keyword));
+    return keywords.some((keyword) => content.includes(keyword));
   }
 
-  private determineOptimizationLevel(maxTokens: number): 'aggressive' | 'balanced' | 'conservative' {
-    if (maxTokens < 1000) return 'aggressive';
-    if (maxTokens < 3000) return 'balanced';
-    return 'conservative';
+  private determineOptimizationLevel(
+    maxTokens: number,
+  ): "aggressive" | "balanced" | "conservative" {
+    if (maxTokens < 1000) return "aggressive";
+    if (maxTokens < 3000) return "balanced";
+    return "conservative";
   }
 
   private calculateContextTokens(context: any): number {
@@ -1370,6 +1575,7 @@ export class ContextOptimizer {
 ## コミット計画
 
 ### コミット1: コンテキスト最適化型定義
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1382,6 +1588,7 @@ git commit -m "feat(orchestration): add context optimization type definitions wi
 ```
 
 ### コミット2: 優先度計算エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1394,6 +1601,7 @@ git commit -m "feat(orchestration): implement priority calculation engine with t
 ```
 
 ### コミット3: トークン最適化エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1406,6 +1614,7 @@ git commit -m "feat(orchestration): implement token optimization engine with tes
 ```
 
 ### コミット4: コンテキスト最適化エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1418,6 +1627,7 @@ git commit -m "feat(orchestration): implement context optimization engine with t
 ```
 
 ### コミット5: エクスポート更新
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1466,8 +1676,8 @@ export type {
   DependencyGraph,
   ModeSelectionRule,
   ComplexityPattern,
-  ComplexityFactorType
-} from './types';
+  ComplexityFactorType,
+} from "./types";
 
 export type {
   ContextParams,
@@ -1478,26 +1688,26 @@ export type {
   OptimizationResult,
   SemanticMatch,
   ContextCategory,
-  OptimizationLevel
-} from './context-types';
+  OptimizationLevel,
+} from "./context-types";
 
-export { ComplexityCalculator } from './complexity-calculator';
-export { TaskAnalyzer } from './task-analyzer';
-export { ModeSelector } from './mode-selector';
-export { PriorityCalculator } from './priority-calculator';
-export { TokenOptimizer } from './token-optimizer';
-export { ContextOptimizer } from './context-optimizer';
+export { ComplexityCalculator } from "./complexity-calculator";
+export { TaskAnalyzer } from "./task-analyzer";
+export { ModeSelector } from "./mode-selector";
+export { PriorityCalculator } from "./priority-calculator";
+export { TokenOptimizer } from "./token-optimizer";
+export { ContextOptimizer } from "./context-optimizer";
 ```
 
 ## 統合テスト
 
 ```typescript
 // test/orchestration/context-integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { ContextOptimizer, TaskAnalyzer } from '../../src/orchestration';
+import { describe, test, expect } from "bun:test";
+import { ContextOptimizer, TaskAnalyzer } from "../../src/orchestration";
 
-describe('Context Optimization Integration', () => {
-  test('should handle complete context optimization workflow', () => {
+describe("Context Optimization Integration", () => {
+  test("should handle complete context optimization workflow", () => {
     const analyzer = new TaskAnalyzer();
     const optimizer = new ContextOptimizer();
 
@@ -1517,24 +1727,24 @@ describe('Context Optimization Integration', () => {
 
     // Create optimized context for a subtask
     const contextParams = {
-      mode: 'code',
-      taskDescription: 'Implement JWT authentication',
+      mode: "code",
+      taskDescription: "Implement JWT authentication",
       previousResults: [
-        'System architecture designed with microservices approach',
-        'Database schema created with user, role, and session tables',
-        'Password hashing service implemented using bcrypt',
-        'Email service configured with SendGrid',
-        'Basic user registration endpoint created',
-        'Input validation middleware implemented',
-        'Error handling framework established'
+        "System architecture designed with microservices approach",
+        "Database schema created with user, role, and session tables",
+        "Password hashing service implemented using bcrypt",
+        "Email service configured with SendGrid",
+        "Basic user registration endpoint created",
+        "Input validation middleware implemented",
+        "Error handling framework established",
       ],
       globalContext: {
-        framework: 'Express.js',
-        database: 'PostgreSQL',
-        authStrategy: 'JWT',
-        emailProvider: 'SendGrid'
+        framework: "Express.js",
+        database: "PostgreSQL",
+        authStrategy: "JWT",
+        emailProvider: "SendGrid",
       },
-      maxTokens: 1500
+      maxTokens: 1500,
     };
 
     const optimizedContext = optimizer.createContextForSubTask(contextParams);
@@ -1542,49 +1752,51 @@ describe('Context Optimization Integration', () => {
     // Verify optimization
     expect(optimizedContext.maxTokens).toBe(1500);
     expect(optimizedContext.previousResults.length).toBeGreaterThan(0);
-    expect(optimizedContext.modeSpecificContext.mode).toBe('code');
+    expect(optimizedContext.modeSpecificContext.mode).toBe("code");
 
     // Verify relevant information is prioritized
     const contextStr = JSON.stringify(optimizedContext);
-    expect(contextStr).toContain('JWT');
-    expect(contextStr).toContain('auth');
+    expect(contextStr).toContain("JWT");
+    expect(contextStr).toContain("auth");
   });
 
-  test('should achieve target token reduction', () => {
+  test("should achieve target token reduction", () => {
     const optimizer = new ContextOptimizer();
 
     const verboseContext = {
       previousResults: [
-        'This is a very detailed explanation of how the authentication system was designed with extensive documentation about the security considerations and implementation details that goes on for many sentences and includes lots of technical jargon and specific implementation details that might not be relevant for the current task',
-        'Database schema created',
-        'Password hashing implemented',
-        'Email service configured'
+        "This is a very detailed explanation of how the authentication system was designed with extensive documentation about the security considerations and implementation details that goes on for many sentences and includes lots of technical jargon and specific implementation details that might not be relevant for the current task",
+        "Database schema created",
+        "Password hashing implemented",
+        "Email service configured",
       ],
       globalContext: {
-        detailedDescription: 'This is another very long description that contains lots of information about the project setup and configuration that might not be directly relevant to the current subtask but was included for completeness'
-      }
+        detailedDescription:
+          "This is another very long description that contains lots of information about the project setup and configuration that might not be directly relevant to the current subtask but was included for completeness",
+      },
     };
 
     const original = JSON.stringify(verboseContext);
     const optimized = optimizer.optimizeContext(verboseContext, 500);
     const optimizedStr = JSON.stringify(optimized);
 
-    const reductionRatio = (original.length - optimizedStr.length) / original.length;
+    const reductionRatio =
+      (original.length - optimizedStr.length) / original.length;
     expect(reductionRatio).toBeGreaterThan(0.3); // At least 30% reduction
   });
 
-  test('should maintain context quality across modes', () => {
+  test("should maintain context quality across modes", () => {
     const optimizer = new ContextOptimizer();
 
     const previousResults = [
-      'System architecture designed with microservices',
-      'Critical authentication bug discovered in login flow',
-      'User interface components created for login page',
-      'Database performance optimized with indexing',
-      'Unit tests written for authentication service'
+      "System architecture designed with microservices",
+      "Critical authentication bug discovered in login flow",
+      "User interface components created for login page",
+      "Database performance optimized with indexing",
+      "Unit tests written for authentication service",
     ];
 
-    const modes = ['code', 'architect', 'debug'];
+    const modes = ["code", "architect", "debug"];
 
     for (const mode of modes) {
       const contextParams = {
@@ -1592,7 +1804,7 @@ describe('Context Optimization Integration', () => {
         taskDescription: `${mode} mode task`,
         previousResults,
         globalContext: {},
-        maxTokens: 800
+        maxTokens: 800,
       };
 
       const context = optimizer.createContextForSubTask(contextParams);
@@ -1602,10 +1814,10 @@ describe('Context Optimization Integration', () => {
 
       // Each mode should prioritize different information
       const contextStr = JSON.stringify(context);
-      if (mode === 'debug') {
-        expect(contextStr).toContain('bug');
-      } else if (mode === 'architect') {
-        expect(contextStr).toContain('architecture');
+      if (mode === "debug") {
+        expect(contextStr).toContain("bug");
+      } else if (mode === "architect") {
+        expect(contextStr).toContain("architecture");
       }
     }
   });
@@ -1615,6 +1827,7 @@ describe('Context Optimization Integration', () => {
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase2-task-analyzer から作業ブランチを作成
 git checkout phase2-task-analyzer
@@ -1645,6 +1858,7 @@ git branch -d phase2-context-optimizer # ローカルの作業ブランチを削
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase2-task-analyzer から作業ブランチ作成
 git checkout phase2-task-analyzer
@@ -1676,6 +1890,7 @@ git branch -d phase2-context-optimizer
 ## 依存関係
 
 このフェーズはフェーズ2.1（タスク分析エンジン）完了後に実装してください。以下のフェーズに必要となります：
+
 - フェーズ3: GitHub Actionsとの統合（最適化されたコンテキストの活用）
 - フェーズ4: MCP拡張（コンテキスト最適化の活用）
 

--- a/predev-docs/06-phase3-prompt-extension-design.md
+++ b/predev-docs/06-phase3-prompt-extension-design.md
@@ -5,6 +5,7 @@
 プロンプト生成拡張は、既存のプロンプト作成システムを拡張し、モード別・サブタスク別に最適化されたプロンプトを生成する機能を実装します。オーケストレーション機能との統合により、各サブタスクに最適なコンテキストとプロンプトを提供します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -69,8 +70,8 @@ classDiagram
 #### 実装: src/create-prompt/types.ts
 
 ```typescript
-import type { Mode } from '../modes/types';
-import type { SubTask, TaskContext } from '../tasks/types';
+import type { Mode } from "../modes/types";
+import type { SubTask, TaskContext } from "../tasks/types";
 
 export interface PromptTemplate {
   mode: string;
@@ -85,7 +86,7 @@ export interface PromptConstraints {
   maxTokens: number;
   requiredSections: string[];
   forbiddenTerms: string[];
-  outputFormat: 'markdown' | 'json' | 'code' | 'yaml';
+  outputFormat: "markdown" | "json" | "code" | "yaml";
   styleGuidelines?: string[];
 }
 
@@ -129,7 +130,10 @@ export interface PromptMetadata {
   generationTime: number;
 }
 
-export type PromptVariableResolver = (variableName: string, context: any) => string;
+export type PromptVariableResolver = (
+  variableName: string,
+  context: any,
+) => string;
 
 export interface PromptValidationResult {
   isValid: boolean;
@@ -145,107 +149,109 @@ export interface PromptValidationResult {
 
 ```typescript
 // test/create-prompt/mode-prompt-generator.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { ModePromptGenerator } from '../../src/create-prompt/mode-prompt-generator';
-import { modeManager } from '../../src/modes';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { ModePromptGenerator } from "../../src/create-prompt/mode-prompt-generator";
+import { modeManager } from "../../src/modes";
 
-describe('ModePromptGenerator', () => {
+describe("ModePromptGenerator", () => {
   let generator: ModePromptGenerator;
 
   beforeEach(() => {
     generator = new ModePromptGenerator();
   });
 
-  test('should generate code mode specific prompt', () => {
+  test("should generate code mode specific prompt", () => {
     const context = {
-      mode: 'code',
-      taskDescription: 'Implement user authentication API',
+      mode: "code",
+      taskDescription: "Implement user authentication API",
       globalContext: {
-        framework: 'Express.js',
-        database: 'MongoDB'
+        framework: "Express.js",
+        database: "MongoDB",
       },
-      previousResults: ['Database schema designed'],
+      previousResults: ["Database schema designed"],
       constraints: {
         maxTokens: 4000,
-        requiredSections: ['implementation', 'testing'],
+        requiredSections: ["implementation", "testing"],
         forbiddenTerms: [],
-        outputFormat: 'markdown' as const
-      }
+        outputFormat: "markdown" as const,
+      },
     };
 
     const result = generator.generateModeSpecificPrompt(context);
 
-    expect(result.prompt).toContain('implementation');
-    expect(result.prompt).toContain('Express.js');
-    expect(result.prompt).toContain('MongoDB');
-    expect(result.metadata.mode).toBe('code');
+    expect(result.prompt).toContain("implementation");
+    expect(result.prompt).toContain("Express.js");
+    expect(result.prompt).toContain("MongoDB");
+    expect(result.metadata.mode).toBe("code");
     expect(result.qualityScore.overall).toBeGreaterThan(0.7);
   });
 
-  test('should generate architect mode specific prompt', () => {
+  test("should generate architect mode specific prompt", () => {
     const context = {
-      mode: 'architect',
-      taskDescription: 'Design microservices architecture',
+      mode: "architect",
+      taskDescription: "Design microservices architecture",
       globalContext: {
-        scale: 'enterprise',
-        requirements: 'high availability'
+        scale: "enterprise",
+        requirements: "high availability",
       },
       previousResults: [],
       constraints: {
         maxTokens: 5000,
-        requiredSections: ['overview', 'components', 'interactions'],
+        requiredSections: ["overview", "components", "interactions"],
         forbiddenTerms: [],
-        outputFormat: 'markdown' as const
-      }
+        outputFormat: "markdown" as const,
+      },
     };
 
     const result = generator.generateModeSpecificPrompt(context);
 
-    expect(result.prompt).toContain('architecture');
-    expect(result.prompt).toContain('microservices');
-    expect(result.prompt).toContain('high availability');
-    expect(result.metadata.mode).toBe('architect');
+    expect(result.prompt).toContain("architecture");
+    expect(result.prompt).toContain("microservices");
+    expect(result.prompt).toContain("high availability");
+    expect(result.metadata.mode).toBe("architect");
   });
 
-  test('should apply mode constraints correctly', () => {
-    const mode = modeManager.getModeBySlug('debug');
-    const basePrompt = 'Debug the authentication issue';
+  test("should apply mode constraints correctly", () => {
+    const mode = modeManager.getModeBySlug("debug");
+    const basePrompt = "Debug the authentication issue";
 
     const constrainedPrompt = generator.applyModeConstraints(basePrompt, mode);
 
-    expect(constrainedPrompt).toContain('troubleshoot');
-    expect(constrainedPrompt).toContain('analyze');
+    expect(constrainedPrompt).toContain("troubleshoot");
+    expect(constrainedPrompt).toContain("analyze");
     expect(constrainedPrompt.length).toBeGreaterThan(basePrompt.length);
   });
 
-  test('should get mode-specific instructions', () => {
-    const codeInstructions = generator.getModeInstructions('code');
-    const architectInstructions = generator.getModeInstructions('architect');
+  test("should get mode-specific instructions", () => {
+    const codeInstructions = generator.getModeInstructions("code");
+    const architectInstructions = generator.getModeInstructions("architect");
 
-    expect(codeInstructions).toContain('implement');
-    expect(architectInstructions).toContain('design');
+    expect(codeInstructions).toContain("implement");
+    expect(architectInstructions).toContain("design");
     expect(codeInstructions).not.toBe(architectInstructions);
   });
 
-  test('should handle unknown mode gracefully', () => {
+  test("should handle unknown mode gracefully", () => {
     const context = {
-      mode: 'unknown_mode',
-      taskDescription: 'Some task',
+      mode: "unknown_mode",
+      taskDescription: "Some task",
       globalContext: {},
       previousResults: [],
       constraints: {
         maxTokens: 2000,
         requiredSections: [],
         forbiddenTerms: [],
-        outputFormat: 'markdown' as const
-      }
+        outputFormat: "markdown" as const,
+      },
     };
 
     const result = generator.generateModeSpecificPrompt(context);
 
     expect(result.prompt).toBeTruthy();
-    expect(result.metadata.mode).toBe('code'); // fallback to default
-    expect(result.warnings).toContain('Unknown mode, falling back to code mode');
+    expect(result.metadata.mode).toBe("code"); // fallback to default
+    expect(result.warnings).toContain(
+      "Unknown mode, falling back to code mode",
+    );
   });
 });
 ```
@@ -253,15 +259,15 @@ describe('ModePromptGenerator', () => {
 #### 実装: src/create-prompt/mode-prompt-generator.ts
 
 ```typescript
-import { modeManager } from '../modes';
-import type { Mode } from '../modes/types';
+import { modeManager } from "../modes";
+import type { Mode } from "../modes/types";
 import type {
   ModePromptContext,
   PromptTemplate,
   PromptGenerationResult,
   PromptMetadata,
-  QualityScore
-} from './types';
+  QualityScore,
+} from "./types";
 
 export class ModePromptGenerator {
   private promptTemplates: Map<string, PromptTemplate>;
@@ -270,14 +276,18 @@ export class ModePromptGenerator {
     this.promptTemplates = this.initializePromptTemplates();
   }
 
-  generateModeSpecificPrompt(context: ModePromptContext): PromptGenerationResult {
+  generateModeSpecificPrompt(
+    context: ModePromptContext,
+  ): PromptGenerationResult {
     const startTime = Date.now();
-    const mode = modeManager.getModeBySlug(context.mode) || modeManager.getModeBySlug('code')!;
+    const mode =
+      modeManager.getModeBySlug(context.mode) ||
+      modeManager.getModeBySlug("code")!;
     const template = this.getTemplateForMode(context.mode);
 
     const warnings: string[] = [];
     if (!modeManager.getModeBySlug(context.mode)) {
-      warnings.push('Unknown mode, falling back to code mode');
+      warnings.push("Unknown mode, falling back to code mode");
     }
 
     // Generate base prompt from template
@@ -292,15 +302,18 @@ export class ModePromptGenerator {
 
     // Optimize for token limit
     if (context.constraints.maxTokens) {
-      prompt = this.optimizeForTokenLimit(prompt, context.constraints.maxTokens);
+      prompt = this.optimizeForTokenLimit(
+        prompt,
+        context.constraints.maxTokens,
+      );
     }
 
     const metadata: PromptMetadata = {
       mode: mode.slug,
       templateUsed: template.mode,
       tokensUsed: this.estimateTokens(prompt),
-      optimizationApplied: ['mode_constraints', 'token_optimization'],
-      generationTime: Date.now() - startTime
+      optimizationApplied: ["mode_constraints", "token_optimization"],
+      generationTime: Date.now() - startTime,
     };
 
     const qualityScore = this.calculateQualityScore(prompt, context);
@@ -309,13 +322,13 @@ export class ModePromptGenerator {
       prompt,
       metadata,
       qualityScore,
-      warnings: warnings.length > 0 ? warnings : undefined
+      warnings: warnings.length > 0 ? warnings : undefined,
     };
   }
 
   getModeInstructions(mode: string): string {
     const instructionMap: Record<string, string> = {
-      'code': `
+      code: `
 ## Implementation Guidelines
 - Focus on clean, maintainable code
 - Include error handling and edge cases
@@ -323,7 +336,7 @@ export class ModePromptGenerator {
 - Follow established coding standards
 - Consider performance implications
       `,
-      'architect': `
+      architect: `
 ## Design Guidelines
 - Consider scalability and maintainability
 - Define clear component boundaries
@@ -331,7 +344,7 @@ export class ModePromptGenerator {
 - Address non-functional requirements
 - Provide migration strategy if needed
       `,
-      'debug': `
+      debug: `
 ## Debugging Guidelines
 - Systematically analyze the problem
 - Identify root causes, not just symptoms
@@ -339,7 +352,7 @@ export class ModePromptGenerator {
 - Include diagnostic commands and tools
 - Suggest preventive measures
       `,
-      'ask': `
+      ask: `
 ## Information Guidelines
 - Provide clear, comprehensive explanations
 - Include relevant examples and use cases
@@ -347,23 +360,23 @@ export class ModePromptGenerator {
 - Structure information logically
 - Anticipate follow-up questions
       `,
-      'orchestrator': `
+      orchestrator: `
 ## Orchestration Guidelines
 - Break down complex tasks systematically
 - Identify dependencies and execution order
 - Delegate to appropriate specialized modes
 - Coordinate between different components
 - Monitor overall progress and quality
-      `
+      `,
     };
 
-    return instructionMap[mode] || instructionMap['code'];
+    return instructionMap[mode] || instructionMap["code"];
   }
 
   applyModeConstraints(prompt: string, mode: Mode): string {
     // Add mode-specific role and context
     const roleDefinition = mode.roleDefinition;
-    const customInstructions = mode.customInstructions || '';
+    const customInstructions = mode.customInstructions || "";
 
     let enhancedPrompt = `${roleDefinition}\n\n`;
 
@@ -375,17 +388,21 @@ export class ModePromptGenerator {
 
     // Apply mode-specific formatting and constraints
     switch (mode.slug) {
-      case 'code':
-        enhancedPrompt += '\n\nPlease provide implementation details, including code examples and testing approaches.';
+      case "code":
+        enhancedPrompt +=
+          "\n\nPlease provide implementation details, including code examples and testing approaches.";
         break;
-      case 'architect':
-        enhancedPrompt += '\n\nPlease provide architectural diagrams, component descriptions, and integration patterns.';
+      case "architect":
+        enhancedPrompt +=
+          "\n\nPlease provide architectural diagrams, component descriptions, and integration patterns.";
         break;
-      case 'debug':
-        enhancedPrompt += '\n\nPlease provide step-by-step debugging analysis and specific solutions.';
+      case "debug":
+        enhancedPrompt +=
+          "\n\nPlease provide step-by-step debugging analysis and specific solutions.";
         break;
-      case 'ask':
-        enhancedPrompt += '\n\nPlease provide comprehensive explanations with examples and references.';
+      case "ask":
+        enhancedPrompt +=
+          "\n\nPlease provide comprehensive explanations with examples and references.";
         break;
     }
 
@@ -395,8 +412,8 @@ export class ModePromptGenerator {
   private initializePromptTemplates(): Map<string, PromptTemplate> {
     const templates = new Map<string, PromptTemplate>();
 
-    templates.set('code', {
-      mode: 'code',
+    templates.set("code", {
+      mode: "code",
       templateString: `
 # Implementation Task: {task}
 
@@ -414,17 +431,23 @@ export class ModePromptGenerator {
 
 Please implement the solution following best practices.
       `,
-      variables: ['task', 'context', 'previousResults', 'requirements', 'technicalConstraints'],
+      variables: [
+        "task",
+        "context",
+        "previousResults",
+        "requirements",
+        "technicalConstraints",
+      ],
       constraints: {
         maxTokens: 4000,
-        requiredSections: ['implementation', 'testing'],
+        requiredSections: ["implementation", "testing"],
         forbiddenTerms: [],
-        outputFormat: 'markdown'
-      }
+        outputFormat: "markdown",
+      },
     });
 
-    templates.set('architect', {
-      mode: 'architect',
+    templates.set("architect", {
+      mode: "architect",
       templateString: `
 # Architecture Design: {task}
 
@@ -442,17 +465,23 @@ Please implement the solution following best practices.
 
 Please design a comprehensive architecture solution.
       `,
-      variables: ['task', 'context', 'previousResults', 'requirements', 'constraints'],
+      variables: [
+        "task",
+        "context",
+        "previousResults",
+        "requirements",
+        "constraints",
+      ],
       constraints: {
         maxTokens: 5000,
-        requiredSections: ['overview', 'components', 'interactions'],
+        requiredSections: ["overview", "components", "interactions"],
         forbiddenTerms: [],
-        outputFormat: 'markdown'
-      }
+        outputFormat: "markdown",
+      },
     });
 
-    templates.set('debug', {
-      mode: 'debug',
+    templates.set("debug", {
+      mode: "debug",
       templateString: `
 # Debugging Task: {task}
 
@@ -470,17 +499,23 @@ Please design a comprehensive architecture solution.
 
 Please provide systematic debugging analysis.
       `,
-      variables: ['task', 'context', 'previousResults', 'systemInfo', 'errorDetails'],
+      variables: [
+        "task",
+        "context",
+        "previousResults",
+        "systemInfo",
+        "errorDetails",
+      ],
       constraints: {
         maxTokens: 3500,
-        requiredSections: ['analysis', 'solution', 'prevention'],
+        requiredSections: ["analysis", "solution", "prevention"],
         forbiddenTerms: [],
-        outputFormat: 'markdown'
-      }
+        outputFormat: "markdown",
+      },
     });
 
-    templates.set('orchestrator', {
-      mode: 'orchestrator',
+    templates.set("orchestrator", {
+      mode: "orchestrator",
       templateString: `
 # Orchestration Plan: {task}
 
@@ -498,39 +533,48 @@ Please provide systematic debugging analysis.
 
 Please outline a detailed orchestration plan.
       `,
-      variables: ['task', 'goal', 'mainSteps', 'considerations', 'coordination'],
+      variables: [
+        "task",
+        "goal",
+        "mainSteps",
+        "considerations",
+        "coordination",
+      ],
       constraints: {
         maxTokens: 4500,
-        requiredSections: ['plan', 'steps', 'dependencies', 'monitoring'],
+        requiredSections: ["plan", "steps", "dependencies", "monitoring"],
         forbiddenTerms: [],
-        outputFormat: 'markdown'
-      }
+        outputFormat: "markdown",
+      },
     });
 
     return templates;
   }
 
   private getTemplateForMode(mode: string): PromptTemplate {
-    return this.promptTemplates.get(mode) || this.promptTemplates.get('code')!;
+    return this.promptTemplates.get(mode) || this.promptTemplates.get("code")!;
   }
 
-  private expandTemplate(template: PromptTemplate, context: ModePromptContext): string {
+  private expandTemplate(
+    template: PromptTemplate,
+    context: ModePromptContext,
+  ): string {
     let prompt = template.templateString;
 
     const variableMap: Record<string, string> = {
-      'task': context.taskDescription,
-      'context': this.formatContext(context.globalContext),
-      'previousResults': this.formatPreviousResults(context.previousResults),
-      'requirements': this.extractRequirements(context),
-      'technicalConstraints': this.formatConstraints(context.constraints),
-      'constraints': this.formatConstraints(context.constraints),
-      'systemInfo': this.formatSystemInfo(context.globalContext),
-      'errorDetails': this.extractErrorDetails(context)
+      task: context.taskDescription,
+      context: this.formatContext(context.globalContext),
+      previousResults: this.formatPreviousResults(context.previousResults),
+      requirements: this.extractRequirements(context),
+      technicalConstraints: this.formatConstraints(context.constraints),
+      constraints: this.formatConstraints(context.constraints),
+      systemInfo: this.formatSystemInfo(context.globalContext),
+      errorDetails: this.extractErrorDetails(context),
     };
 
     for (const [variable, value] of Object.entries(variableMap)) {
-      const regex = new RegExp(`{${variable}}`, 'g');
-      prompt = prompt.replace(regex, value || '');
+      const regex = new RegExp(`{${variable}}`, "g");
+      prompt = prompt.replace(regex, value || "");
     }
 
     return prompt;
@@ -538,59 +582,67 @@ Please outline a detailed orchestration plan.
 
   private formatContext(globalContext: Record<string, any>): string {
     if (!globalContext || Object.keys(globalContext).length === 0) {
-      return 'No specific context provided.';
+      return "No specific context provided.";
     }
 
     return Object.entries(globalContext)
       .map(([key, value]) => `- ${key}: ${value}`)
-      .join('\n');
+      .join("\n");
   }
 
   private formatPreviousResults(results: string[]): string {
     if (!results || results.length === 0) {
-      return 'No previous work completed.';
+      return "No previous work completed.";
     }
 
-    return results.map((result, index) => `${index + 1}. ${result}`).join('\n');
+    return results.map((result, index) => `${index + 1}. ${result}`).join("\n");
   }
 
   private extractRequirements(context: ModePromptContext): string {
     const sections = context.constraints.requiredSections;
     if (!sections || sections.length === 0) {
-      return 'General implementation requirements apply.';
+      return "General implementation requirements apply.";
     }
 
-    return `Please ensure the following sections are included:\n${sections.map(s => `- ${s}`).join('\n')}`;
+    return `Please ensure the following sections are included:\n${sections.map((s) => `- ${s}`).join("\n")}`;
   }
 
   private formatConstraints(constraints: any): string {
-    if (!constraints) return 'No specific constraints.';
+    if (!constraints) return "No specific constraints.";
 
     const items = [];
-    if (constraints.maxTokens) items.push(`Maximum tokens: ${constraints.maxTokens}`);
-    if (constraints.outputFormat) items.push(`Output format: ${constraints.outputFormat}`);
+    if (constraints.maxTokens)
+      items.push(`Maximum tokens: ${constraints.maxTokens}`);
+    if (constraints.outputFormat)
+      items.push(`Output format: ${constraints.outputFormat}`);
     if (constraints.forbiddenTerms?.length > 0) {
-      items.push(`Avoid terms: ${constraints.forbiddenTerms.join(', ')}`);
+      items.push(`Avoid terms: ${constraints.forbiddenTerms.join(", ")}`);
     }
 
-    return items.length > 0 ? items.join('\n') : 'No specific constraints.';
+    return items.length > 0 ? items.join("\n") : "No specific constraints.";
   }
 
   private formatSystemInfo(context: Record<string, any>): string {
-    const systemKeys = ['os', 'framework', 'database', 'version', 'environment'];
+    const systemKeys = [
+      "os",
+      "framework",
+      "database",
+      "version",
+      "environment",
+    ];
     const systemInfo = systemKeys
-      .filter(key => context[key])
-      .map(key => `${key}: ${context[key]}`)
-      .join('\n');
+      .filter((key) => context[key])
+      .map((key) => `${key}: ${context[key]}`)
+      .join("\n");
 
-    return systemInfo || 'System information not provided.';
+    return systemInfo || "System information not provided.";
   }
 
   private extractErrorDetails(context: ModePromptContext): string {
     if (context.modeSpecificData?.error) {
       return context.modeSpecificData.error;
     }
-    return 'Error details to be investigated.';
+    return "Error details to be investigated.";
   }
 
   private injectModeInstructions(prompt: string, instructions: string): string {
@@ -605,11 +657,14 @@ Please outline a detailed orchestration plan.
     }
 
     // Simple optimization: truncate sections that are too verbose
-    const lines = prompt.split('\n');
+    const lines = prompt.split("\n");
     const targetRatio = maxTokens / estimatedTokens;
     const targetLines = Math.floor(lines.length * targetRatio);
 
-    return lines.slice(0, targetLines).join('\n') + '\n\n[Content optimized for token limit]';
+    return (
+      lines.slice(0, targetLines).join("\n") +
+      "\n\n[Content optimized for token limit]"
+    );
   }
 
   // estimateTokensメソッドは、複数のクラスで共通のロジックを使用しています。
@@ -624,23 +679,38 @@ Please outline a detailed orchestration plan.
     return Math.ceil((wordBasedTokens + charBasedTokens) / 2);
   }
 
-  private calculateQualityScore(prompt: string, context: ModePromptContext): QualityScore {
+  private calculateQualityScore(
+    prompt: string,
+    context: ModePromptContext,
+  ): QualityScore {
     // Simple quality metrics
-    const hasRequiredSections = context.constraints.requiredSections.every(section =>
-      prompt.toLowerCase().includes(section.toLowerCase())
+    const hasRequiredSections = context.constraints.requiredSections.every(
+      (section) => prompt.toLowerCase().includes(section.toLowerCase()),
     );
 
     const hasContext = prompt.includes(context.taskDescription);
     const appropriateLength = prompt.length > 200 && prompt.length < 8000;
-    const hasModeSpecificTerms = this.containsModeSpecificTerms(prompt, context.mode);
+    const hasModeSpecificTerms = this.containsModeSpecificTerms(
+      prompt,
+      context.mode,
+    );
 
     const completeness = hasRequiredSections ? 0.9 : 0.6;
     const specificity = hasContext ? 0.8 : 0.5;
     const clarity = appropriateLength ? 0.8 : 0.6;
     const contextRelevance = hasModeSpecificTerms ? 0.85 : 0.7;
-    const tokenEfficiency = this.calculateTokenEfficiency(prompt, context.constraints.maxTokens);
+    const tokenEfficiency = this.calculateTokenEfficiency(
+      prompt,
+      context.constraints.maxTokens,
+    );
 
-    const overall = (completeness + specificity + clarity + contextRelevance + tokenEfficiency) / 5;
+    const overall =
+      (completeness +
+        specificity +
+        clarity +
+        contextRelevance +
+        tokenEfficiency) /
+      5;
 
     return {
       overall,
@@ -648,20 +718,20 @@ Please outline a detailed orchestration plan.
       completeness,
       specificity,
       tokenEfficiency,
-      contextRelevance
+      contextRelevance,
     };
   }
 
   private containsModeSpecificTerms(prompt: string, mode: string): boolean {
     const modeTerms: Record<string, string[]> = {
-      'code': ['implement', 'function', 'class', 'method', 'test'],
-      'architect': ['design', 'architecture', 'component', 'system', 'pattern'],
-      'debug': ['debug', 'analyze', 'troubleshoot', 'investigate', 'fix'],
-      'ask': ['explain', 'describe', 'clarify', 'understand', 'information']
+      code: ["implement", "function", "class", "method", "test"],
+      architect: ["design", "architecture", "component", "system", "pattern"],
+      debug: ["debug", "analyze", "troubleshoot", "investigate", "fix"],
+      ask: ["explain", "describe", "clarify", "understand", "information"],
     };
 
     const terms = modeTerms[mode] || [];
-    return terms.some(term => prompt.toLowerCase().includes(term));
+    return terms.some((term) => prompt.toLowerCase().includes(term));
   }
 
   private calculateTokenEfficiency(prompt: string, maxTokens: number): number {
@@ -681,134 +751,140 @@ Please outline a detailed orchestration plan.
 
 ```typescript
 // test/create-prompt/subtask-prompt-generator.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { SubtaskPromptGenerator } from '../../src/create-prompt/subtask-prompt-generator';
-import type { SubTask, TaskContext } from '../../src/tasks/types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { SubtaskPromptGenerator } from "../../src/create-prompt/subtask-prompt-generator";
+import type { SubTask, TaskContext } from "../../src/tasks/types";
 
-describe('SubtaskPromptGenerator', () => {
+describe("SubtaskPromptGenerator", () => {
   let generator: SubtaskPromptGenerator;
 
   beforeEach(() => {
     generator = new SubtaskPromptGenerator();
   });
 
-  test('should generate prompt for independent subtask', () => {
+  test("should generate prompt for independent subtask", () => {
     const subtask: SubTask = {
-      id: 'subtask-1',
-      description: 'Implement user authentication API endpoints',
-      mode: 'code',
+      id: "subtask-1",
+      description: "Implement user authentication API endpoints",
+      mode: "code",
       priority: 1,
       dependencies: [],
-      estimatedComplexity: 6.5
+      estimatedComplexity: 6.5,
     };
 
     const context: TaskContext = {
       previousResults: [],
       globalContext: {
-        framework: 'Express.js',
-        database: 'MongoDB'
+        framework: "Express.js",
+        database: "MongoDB",
       },
       modeSpecificContext: {
-        implementationFocus: 'security'
+        implementationFocus: "security",
       },
-      maxTokens: 4000
+      maxTokens: 4000,
     };
 
     const result = generator.generateSubtaskPrompt(subtask, context);
 
-    expect(result.prompt).toContain('authentication');
-    expect(result.prompt).toContain('Express.js');
-    expect(result.metadata.mode).toBe('code');
+    expect(result.prompt).toContain("authentication");
+    expect(result.prompt).toContain("Express.js");
+    expect(result.metadata.mode).toBe("code");
     expect(result.qualityScore.overall).toBeGreaterThan(0.7);
   });
 
-  test('should generate prompt for dependent subtask', () => {
+  test("should generate prompt for dependent subtask", () => {
     const subtask: SubTask = {
-      id: 'subtask-3',
-      description: 'Implement password reset functionality',
-      mode: 'code',
+      id: "subtask-3",
+      description: "Implement password reset functionality",
+      mode: "code",
       priority: 3,
-      dependencies: ['subtask-1', 'subtask-2'],
-      estimatedComplexity: 4.0
+      dependencies: ["subtask-1", "subtask-2"],
+      estimatedComplexity: 4.0,
     };
 
     const context: TaskContext = {
       previousResults: [
-        'User registration API completed',
-        'Email service integration completed'
+        "User registration API completed",
+        "Email service integration completed",
       ],
       globalContext: {
-        framework: 'Express.js',
-        emailProvider: 'SendGrid'
+        framework: "Express.js",
+        emailProvider: "SendGrid",
       },
       modeSpecificContext: {},
-      maxTokens: 3500
+      maxTokens: 3500,
     };
 
     const result = generator.generateSubtaskPrompt(subtask, context);
 
-    expect(result.prompt).toContain('password reset');
-    expect(result.prompt).toContain('registration API completed');
-    expect(result.prompt).toContain('Email service integration');
+    expect(result.prompt).toContain("password reset");
+    expect(result.prompt).toContain("registration API completed");
+    expect(result.prompt).toContain("Email service integration");
     expect(result.metadata.tokensUsed).toBeLessThan(3500);
   });
 
-  test('should create contextualized prompt with previous results', () => {
+  test("should create contextualized prompt with previous results", () => {
     const subtask: SubTask = {
-      id: 'subtask-2',
-      description: 'Create user profile management',
-      mode: 'code',
+      id: "subtask-2",
+      description: "Create user profile management",
+      mode: "code",
       priority: 2,
-      dependencies: ['subtask-1'],
-      estimatedComplexity: 5.0
+      dependencies: ["subtask-1"],
+      estimatedComplexity: 5.0,
     };
 
     const previousResults = [
-      'Database schema created with user table',
-      'Authentication middleware implemented',
-      'JWT token generation working'
+      "Database schema created with user table",
+      "Authentication middleware implemented",
+      "JWT token generation working",
     ];
 
-    const prompt = generator.createContextualizedPrompt(subtask, previousResults);
+    const prompt = generator.createContextualizedPrompt(
+      subtask,
+      previousResults,
+    );
 
-    expect(prompt).toContain('profile management');
-    expect(prompt).toContain('Database schema created');
-    expect(prompt).toContain('Authentication middleware');
-    expect(prompt).toContain('JWT token generation');
+    expect(prompt).toContain("profile management");
+    expect(prompt).toContain("Database schema created");
+    expect(prompt).toContain("Authentication middleware");
+    expect(prompt).toContain("JWT token generation");
   });
 
-  test('should inject dependency information correctly', () => {
-    const basePrompt = 'Implement the feature as described.';
-    const dependencies = ['User authentication system', 'Database connection'];
+  test("should inject dependency information correctly", () => {
+    const basePrompt = "Implement the feature as described.";
+    const dependencies = ["User authentication system", "Database connection"];
 
-    const enhancedPrompt = generator.injectDependencyInfo(basePrompt, dependencies);
+    const enhancedPrompt = generator.injectDependencyInfo(
+      basePrompt,
+      dependencies,
+    );
 
-    expect(enhancedPrompt).toContain('authentication system');
-    expect(enhancedPrompt).toContain('Database connection');
-    expect(enhancedPrompt).toContain('Dependencies');
+    expect(enhancedPrompt).toContain("authentication system");
+    expect(enhancedPrompt).toContain("Database connection");
+    expect(enhancedPrompt).toContain("Dependencies");
   });
 
-  test('should handle subtask without dependencies', () => {
+  test("should handle subtask without dependencies", () => {
     const subtask: SubTask = {
-      id: 'subtask-1',
-      description: 'Setup project structure',
-      mode: 'code',
+      id: "subtask-1",
+      description: "Setup project structure",
+      mode: "code",
       priority: 1,
       dependencies: [],
-      estimatedComplexity: 2.0
+      estimatedComplexity: 2.0,
     };
 
     const context: TaskContext = {
       previousResults: [],
       globalContext: {},
       modeSpecificContext: {},
-      maxTokens: 2000
+      maxTokens: 2000,
     };
 
     const result = generator.generateSubtaskPrompt(subtask, context);
 
-    expect(result.prompt).toContain('project structure');
-    expect(result.prompt).not.toContain('Dependencies');
+    expect(result.prompt).toContain("project structure");
+    expect(result.prompt).not.toContain("Dependencies");
     expect(result.warnings).toBeUndefined();
   });
 });
@@ -817,14 +893,14 @@ describe('SubtaskPromptGenerator', () => {
 #### 実装: src/create-prompt/subtask-prompt-generator.ts
 
 ```typescript
-import type { SubTask, TaskContext } from '../tasks/types';
+import type { SubTask, TaskContext } from "../tasks/types";
 import type {
   SubtaskPromptContext,
   PromptGenerationResult,
   PromptMetadata,
-  QualityScore
-} from './types';
-import { ModePromptGenerator } from './mode-prompt-generator';
+  QualityScore,
+} from "./types";
+import { ModePromptGenerator } from "./mode-prompt-generator";
 
 export class SubtaskPromptGenerator {
   private modePromptGenerator: ModePromptGenerator;
@@ -833,7 +909,10 @@ export class SubtaskPromptGenerator {
     this.modePromptGenerator = new ModePromptGenerator();
   }
 
-  generateSubtaskPrompt(subtask: SubTask, context: TaskContext): PromptGenerationResult {
+  generateSubtaskPrompt(
+    subtask: SubTask,
+    context: TaskContext,
+  ): PromptGenerationResult {
     const startTime = Date.now();
 
     // Create enhanced context for subtask
@@ -846,23 +925,31 @@ export class SubtaskPromptGenerator {
         maxTokens: context.maxTokens,
         requiredSections: this.getRequiredSectionsForMode(subtask.mode),
         forbiddenTerms: [],
-        outputFormat: 'markdown'
+        outputFormat: "markdown",
       },
       subtask,
       dependencies: subtask.dependencies,
       parentTaskId: subtask.parentTaskId,
-      executionOrder: subtask.priority
+      executionOrder: subtask.priority,
     };
 
     // Generate base prompt using mode generator
-    const baseResult = this.modePromptGenerator.generateModeSpecificPrompt(subtaskContext);
+    const baseResult =
+      this.modePromptGenerator.generateModeSpecificPrompt(subtaskContext);
 
     // Enhance with subtask-specific context
-    let enhancedPrompt = this.enhanceWithSubtaskContext(baseResult.prompt, subtask, context);
+    let enhancedPrompt = this.enhanceWithSubtaskContext(
+      baseResult.prompt,
+      subtask,
+      context,
+    );
 
     // Add dependency information if present
     if (subtask.dependencies.length > 0) {
-      enhancedPrompt = this.injectDependencyInfo(enhancedPrompt, this.resolveDependencies(subtask.dependencies, context));
+      enhancedPrompt = this.injectDependencyInfo(
+        enhancedPrompt,
+        this.resolveDependencies(subtask.dependencies, context),
+      );
     }
 
     // Add execution context
@@ -871,21 +958,31 @@ export class SubtaskPromptGenerator {
     const metadata: PromptMetadata = {
       ...baseResult.metadata,
       tokensUsed: this.estimateTokens(enhancedPrompt),
-      optimizationApplied: [...baseResult.metadata.optimizationApplied, 'subtask_context', 'dependency_injection'],
-      generationTime: Date.now() - startTime
+      optimizationApplied: [
+        ...baseResult.metadata.optimizationApplied,
+        "subtask_context",
+        "dependency_injection",
+      ],
+      generationTime: Date.now() - startTime,
     };
 
-    const qualityScore = this.calculateSubtaskQualityScore(enhancedPrompt, subtaskContext);
+    const qualityScore = this.calculateSubtaskQualityScore(
+      enhancedPrompt,
+      subtaskContext,
+    );
 
     return {
       prompt: enhancedPrompt,
       metadata,
       qualityScore,
-      warnings: baseResult.warnings
+      warnings: baseResult.warnings,
     };
   }
 
-  createContextualizedPrompt(subtask: SubTask, previousResults: string[]): string {
+  createContextualizedPrompt(
+    subtask: SubTask,
+    previousResults: string[],
+  ): string {
     let prompt = `## Subtask: ${subtask.description}\n\n`;
 
     if (previousResults.length > 0) {
@@ -893,7 +990,7 @@ export class SubtaskPromptGenerator {
       previousResults.forEach((result, index) => {
         prompt += `${index + 1}. ${result}\n`;
       });
-      prompt += '\n';
+      prompt += "\n";
     }
 
     prompt += `### Current Task Requirements\n`;
@@ -903,7 +1000,7 @@ export class SubtaskPromptGenerator {
 
     if (subtask.dependencies.length > 0) {
       prompt += `### Dependencies\n`;
-      prompt += `This task depends on: ${subtask.dependencies.join(', ')}\n\n`;
+      prompt += `This task depends on: ${subtask.dependencies.join(", ")}\n\n`;
     }
 
     prompt += `### Task Description\n${subtask.description}\n\n`;
@@ -919,7 +1016,7 @@ export class SubtaskPromptGenerator {
 
 The following components must be available and functioning before implementing this task:
 
-${dependencies.map((dep, index) => `${index + 1}. ${dep}`).join('\n')}
+${dependencies.map((dep, index) => `${index + 1}. ${dep}`).join("\n")}
 
 Please ensure your implementation builds upon these existing components and maintains compatibility.
 
@@ -930,7 +1027,11 @@ Please ensure your implementation builds upon these existing components and main
     return dependencySection + prompt;
   }
 
-  private enhanceWithSubtaskContext(basePrompt: string, subtask: SubTask, context: TaskContext): string {
+  private enhanceWithSubtaskContext(
+    basePrompt: string,
+    subtask: SubTask,
+    context: TaskContext,
+  ): string {
     let enhanced = basePrompt;
 
     // Add subtask-specific metadata
@@ -944,7 +1045,10 @@ Please ensure your implementation builds upon these existing components and main
     }
 
     // Add mode-specific context if available
-    if (context.modeSpecificContext && Object.keys(context.modeSpecificContext).length > 0) {
+    if (
+      context.modeSpecificContext &&
+      Object.keys(context.modeSpecificContext).length > 0
+    ) {
       enhanced += `\n## Mode-Specific Context\n`;
       Object.entries(context.modeSpecificContext).forEach(([key, value]) => {
         enhanced += `- **${key}**: ${value}\n`;
@@ -954,7 +1058,11 @@ Please ensure your implementation builds upon these existing components and main
     return enhanced;
   }
 
-  private addExecutionContext(prompt: string, subtask: SubTask, context: TaskContext): string {
+  private addExecutionContext(
+    prompt: string,
+    subtask: SubTask,
+    context: TaskContext,
+  ): string {
     let enhanced = prompt;
 
     enhanced += `\n## Execution Guidelines\n`;
@@ -986,7 +1094,10 @@ Please ensure your implementation builds upon these existing components and main
     return enhanced;
   }
 
-  private resolveDependencies(dependencyIds: string[], context: TaskContext): string[] {
+  private resolveDependencies(
+    dependencyIds: string[],
+    context: TaskContext,
+  ): string[] {
     // In a full implementation, this would resolve dependency IDs to their descriptions
     // For now, we'll use the previous results as proxy for dependencies
     const resolvedDependencies: string[] = [];
@@ -995,7 +1106,9 @@ Please ensure your implementation builds upon these existing components and main
       if (index < context.previousResults.length) {
         resolvedDependencies.push(context.previousResults[index]);
       } else {
-        resolvedDependencies.push(`Dependency ${depId} (details to be resolved)`);
+        resolvedDependencies.push(
+          `Dependency ${depId} (details to be resolved)`,
+        );
       }
     });
 
@@ -1004,34 +1117,41 @@ Please ensure your implementation builds upon these existing components and main
 
   private getRequiredSectionsForMode(mode: string): string[] {
     const sectionMap: Record<string, string[]> = {
-      'code': ['implementation', 'testing', 'documentation'],
-      'architect': ['overview', 'components', 'interactions', 'considerations'],
-      'debug': ['analysis', 'investigation', 'solution', 'prevention'],
-      'ask': ['explanation', 'examples', 'references'],
-      'orchestrator': ['breakdown', 'coordination', 'monitoring']
+      code: ["implementation", "testing", "documentation"],
+      architect: ["overview", "components", "interactions", "considerations"],
+      debug: ["analysis", "investigation", "solution", "prevention"],
+      ask: ["explanation", "examples", "references"],
+      orchestrator: ["breakdown", "coordination", "monitoring"],
     };
 
-    return sectionMap[mode] || sectionMap['code'];
+    return sectionMap[mode] || sectionMap["code"];
   }
 
-  private calculateSubtaskQualityScore(prompt: string, context: SubtaskPromptContext): QualityScore {
-    const baseScore = this.modePromptGenerator.calculateQualityScore(prompt, context);
+  private calculateSubtaskQualityScore(
+    prompt: string,
+    context: SubtaskPromptContext,
+  ): QualityScore {
+    const baseScore = this.modePromptGenerator.calculateQualityScore(
+      prompt,
+      context,
+    );
 
     // Additional subtask-specific quality factors
-    const hasDependencyInfo = context.dependencies.length === 0 || prompt.includes('Dependencies');
-    const hasExecutionGuidance = prompt.includes('Execution Guidelines');
-    const hasSubtaskMetadata = prompt.includes('Subtask Information');
+    const hasDependencyInfo =
+      context.dependencies.length === 0 || prompt.includes("Dependencies");
+    const hasExecutionGuidance = prompt.includes("Execution Guidelines");
+    const hasSubtaskMetadata = prompt.includes("Subtask Information");
 
-    const subtaskSpecificity = (
-      (hasDependencyInfo ? 1 : 0) +
-      (hasExecutionGuidance ? 1 : 0) +
-      (hasSubtaskMetadata ? 1 : 0)
-    ) / 3;
+    const subtaskSpecificity =
+      ((hasDependencyInfo ? 1 : 0) +
+        (hasExecutionGuidance ? 1 : 0) +
+        (hasSubtaskMetadata ? 1 : 0)) /
+      3;
 
     return {
       ...baseScore,
       specificity: (baseScore.specificity + subtaskSpecificity) / 2,
-      overall: (baseScore.overall + subtaskSpecificity) / 2
+      overall: (baseScore.overall + subtaskSpecificity) / 2,
     };
   }
 
@@ -1055,110 +1175,116 @@ Please ensure your implementation builds upon these existing components and main
 
 ```typescript
 // test/create-prompt/prompt-extension.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { PromptExtension } from '../../src/create-prompt/prompt-extension';
-import type { Mode } from '../../src/modes/types';
-import type { SubTask, TaskContext } from '../../src/tasks/types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { PromptExtension } from "../../src/create-prompt/prompt-extension";
+import type { Mode } from "../../src/modes/types";
+import type { SubTask, TaskContext } from "../../src/tasks/types";
 
-describe('PromptExtension', () => {
+describe("PromptExtension", () => {
   let promptExtension: PromptExtension;
 
   beforeEach(() => {
     promptExtension = new PromptExtension();
   });
 
-  test('should create prompt for specific mode', () => {
+  test("should create prompt for specific mode", () => {
     const context = {
-      mode: 'code',
-      taskDescription: 'Implement JWT authentication',
-      globalContext: { framework: 'Express.js' },
+      mode: "code",
+      taskDescription: "Implement JWT authentication",
+      globalContext: { framework: "Express.js" },
       previousResults: [],
       constraints: {
         maxTokens: 4000,
-        requiredSections: ['implementation'],
+        requiredSections: ["implementation"],
         forbiddenTerms: [],
-        outputFormat: 'markdown' as const
-      }
+        outputFormat: "markdown" as const,
+      },
     };
 
     const mode: Mode = {
-      slug: 'code',
-      name: 'Code Implementation',
-      roleDefinition: 'You are an expert software developer',
-      groups: ['file_operations', 'code_generation']
+      slug: "code",
+      name: "Code Implementation",
+      roleDefinition: "You are an expert software developer",
+      groups: ["file_operations", "code_generation"],
     };
 
     const result = promptExtension.createPromptForMode(context, mode);
 
-    expect(result.prompt).toContain('JWT authentication');
-    expect(result.prompt).toContain('Express.js');
-    expect(result.metadata.mode).toBe('code');
+    expect(result.prompt).toContain("JWT authentication");
+    expect(result.prompt).toContain("Express.js");
+    expect(result.metadata.mode).toBe("code");
     expect(result.qualityScore.overall).toBeGreaterThan(0.7);
   });
 
-  test('should create prompt for subtask', () => {
+  test("should create prompt for subtask", () => {
     const subtask: SubTask = {
-      id: 'subtask-1',
-      description: 'Implement user registration endpoint',
-      mode: 'code',
+      id: "subtask-1",
+      description: "Implement user registration endpoint",
+      mode: "code",
       priority: 1,
       dependencies: [],
-      estimatedComplexity: 5.0
+      estimatedComplexity: 5.0,
     };
 
     const context: TaskContext = {
       previousResults: [],
       globalContext: {
-        framework: 'Express.js',
-        database: 'MongoDB'
+        framework: "Express.js",
+        database: "MongoDB",
       },
       modeSpecificContext: {},
-      maxTokens: 3000
+      maxTokens: 3000,
     };
 
     const result = promptExtension.createPromptForSubtask(subtask, context);
 
-    expect(result.prompt).toContain('user registration');
-    expect(result.prompt).toContain('Express.js');
+    expect(result.prompt).toContain("user registration");
+    expect(result.prompt).toContain("Express.js");
     expect(result.metadata.tokensUsed).toBeLessThan(3000);
   });
 
-  test('should optimize prompt for constraints', () => {
-    const longPrompt = 'Very long prompt content that exceeds token limits. '.repeat(200);
+  test("should optimize prompt for constraints", () => {
+    const longPrompt =
+      "Very long prompt content that exceeds token limits. ".repeat(200);
     const constraints = {
       maxTokens: 1000,
-      requiredSections: ['summary'],
-      forbiddenTerms: ['harmful'],
-      outputFormat: 'markdown' as const
+      requiredSections: ["summary"],
+      forbiddenTerms: ["harmful"],
+      outputFormat: "markdown" as const,
     };
 
     const optimized = promptExtension.optimizePrompt(longPrompt, constraints);
 
     expect(optimized.length).toBeLessThan(longPrompt.length);
-    expect(optimized).not.toContain('harmful');
+    expect(optimized).not.toContain("harmful");
     expect(promptExtension.estimateTokens(optimized)).toBeLessThan(1000);
   });
 
-  test('should integrate with existing prompt creation system', () => {
-    const existingPrompt = 'This is an existing system prompt.';
+  test("should integrate with existing prompt creation system", () => {
+    const existingPrompt = "This is an existing system prompt.";
     const enhancement = {
-      mode: 'code',
-      taskDescription: 'Add authentication',
+      mode: "code",
+      taskDescription: "Add authentication",
       globalContext: {},
       previousResults: [],
       constraints: {
         maxTokens: 2000,
         requiredSections: [],
         forbiddenTerms: [],
-        outputFormat: 'markdown' as const
-      }
+        outputFormat: "markdown" as const,
+      },
     };
 
-    const result = promptExtension.enhanceExistingPrompt(existingPrompt, enhancement);
+    const result = promptExtension.enhanceExistingPrompt(
+      existingPrompt,
+      enhancement,
+    );
 
-    expect(result.prompt).toContain('existing system prompt');
-    expect(result.prompt).toContain('authentication');
-    expect(result.metadata.optimizationApplied).toContain('existing_prompt_enhancement');
+    expect(result.prompt).toContain("existing system prompt");
+    expect(result.prompt).toContain("authentication");
+    expect(result.metadata.optimizationApplied).toContain(
+      "existing_prompt_enhancement",
+    );
   });
 });
 ```
@@ -1166,16 +1292,16 @@ describe('PromptExtension', () => {
 #### 実装: src/create-prompt/prompt-extension.ts
 
 ```typescript
-import { ModePromptGenerator } from './mode-prompt-generator';
-import { SubtaskPromptGenerator } from './subtask-prompt-generator';
-import type { Mode } from '../modes/types';
-import type { SubTask, TaskContext } from '../tasks/types';
+import { ModePromptGenerator } from "./mode-prompt-generator";
+import { SubtaskPromptGenerator } from "./subtask-prompt-generator";
+import type { Mode } from "../modes/types";
+import type { SubTask, TaskContext } from "../tasks/types";
 import type {
   ModePromptContext,
   PromptConstraints,
   PromptGenerationResult,
-  PromptValidationResult
-} from './types';
+  PromptValidationResult,
+} from "./types";
 
 export class PromptExtension {
   private modePromptGenerator: ModePromptGenerator;
@@ -1186,17 +1312,23 @@ export class PromptExtension {
     this.subtaskPromptGenerator = new SubtaskPromptGenerator();
   }
 
-  createPromptForMode(context: ModePromptContext, mode: Mode): PromptGenerationResult {
+  createPromptForMode(
+    context: ModePromptContext,
+    mode: Mode,
+  ): PromptGenerationResult {
     // Ensure mode is correctly set in context
     const enhancedContext = {
       ...context,
-      mode: mode.slug
+      mode: mode.slug,
     };
 
     return this.modePromptGenerator.generateModeSpecificPrompt(enhancedContext);
   }
 
-  createPromptForSubtask(subtask: SubTask, context: TaskContext): PromptGenerationResult {
+  createPromptForSubtask(
+    subtask: SubTask,
+    context: TaskContext,
+  ): PromptGenerationResult {
     return this.subtaskPromptGenerator.generateSubtaskPrompt(subtask, context);
   }
 
@@ -1205,9 +1337,9 @@ export class PromptExtension {
 
     // Remove forbidden terms
     if (constraints.forbiddenTerms && constraints.forbiddenTerms.length > 0) {
-      constraints.forbiddenTerms.forEach(term => {
-        const regex = new RegExp(term, 'gi');
-        optimized = optimized.replace(regex, '[TERM_REMOVED]');
+      constraints.forbiddenTerms.forEach((term) => {
+        const regex = new RegExp(term, "gi");
+        optimized = optimized.replace(regex, "[TERM_REMOVED]");
       });
     }
 
@@ -1220,8 +1352,14 @@ export class PromptExtension {
     }
 
     // Ensure required sections are present
-    if (constraints.requiredSections && constraints.requiredSections.length > 0) {
-      optimized = this.ensureRequiredSections(optimized, constraints.requiredSections);
+    if (
+      constraints.requiredSections &&
+      constraints.requiredSections.length > 0
+    ) {
+      optimized = this.ensureRequiredSections(
+        optimized,
+        constraints.requiredSections,
+      );
     }
 
     // Apply output format
@@ -1230,31 +1368,47 @@ export class PromptExtension {
     return optimized;
   }
 
-  enhanceExistingPrompt(existingPrompt: string, enhancement: ModePromptContext): PromptGenerationResult {
+  enhanceExistingPrompt(
+    existingPrompt: string,
+    enhancement: ModePromptContext,
+  ): PromptGenerationResult {
     const startTime = Date.now();
 
     // Generate mode-specific enhancement
-    const modeResult = this.modePromptGenerator.generateModeSpecificPrompt(enhancement);
+    const modeResult =
+      this.modePromptGenerator.generateModeSpecificPrompt(enhancement);
 
     // Combine existing prompt with enhancement
-    const combinedPrompt = this.combinePrompts(existingPrompt, modeResult.prompt);
+    const combinedPrompt = this.combinePrompts(
+      existingPrompt,
+      modeResult.prompt,
+    );
 
     // Optimize the combined prompt
-    const optimizedPrompt = this.optimizePrompt(combinedPrompt, enhancement.constraints);
+    const optimizedPrompt = this.optimizePrompt(
+      combinedPrompt,
+      enhancement.constraints,
+    );
 
     return {
       prompt: optimizedPrompt,
       metadata: {
         ...modeResult.metadata,
-        optimizationApplied: [...modeResult.metadata.optimizationApplied, 'existing_prompt_enhancement'],
-        generationTime: Date.now() - startTime
+        optimizationApplied: [
+          ...modeResult.metadata.optimizationApplied,
+          "existing_prompt_enhancement",
+        ],
+        generationTime: Date.now() - startTime,
       },
       qualityScore: modeResult.qualityScore,
-      warnings: modeResult.warnings
+      warnings: modeResult.warnings,
     };
   }
 
-  validatePrompt(prompt: string, constraints: PromptConstraints): PromptValidationResult {
+  validatePrompt(
+    prompt: string,
+    constraints: PromptConstraints,
+  ): PromptValidationResult {
     const errors: string[] = [];
     const warnings: string[] = [];
     const suggestions: string[] = [];
@@ -1262,47 +1416,51 @@ export class PromptExtension {
     // Check token limit
     const tokenCount = this.estimateTokens(prompt);
     if (tokenCount > constraints.maxTokens) {
-      errors.push(`Prompt exceeds token limit: ${tokenCount} > ${constraints.maxTokens}`);
+      errors.push(
+        `Prompt exceeds token limit: ${tokenCount} > ${constraints.maxTokens}`,
+      );
     } else if (tokenCount > constraints.maxTokens * 0.9) {
-      warnings.push('Prompt is close to token limit, consider optimization');
+      warnings.push("Prompt is close to token limit, consider optimization");
     }
 
     // Check required sections
     if (constraints.requiredSections) {
-      const missingSections = constraints.requiredSections.filter(section =>
-        !prompt.toLowerCase().includes(section.toLowerCase())
+      const missingSections = constraints.requiredSections.filter(
+        (section) => !prompt.toLowerCase().includes(section.toLowerCase()),
       );
       if (missingSections.length > 0) {
-        errors.push(`Missing required sections: ${missingSections.join(', ')}`);
+        errors.push(`Missing required sections: ${missingSections.join(", ")}`);
       }
     }
 
     // Check forbidden terms
     if (constraints.forbiddenTerms) {
-      const foundTerms = constraints.forbiddenTerms.filter(term =>
-        prompt.toLowerCase().includes(term.toLowerCase())
+      const foundTerms = constraints.forbiddenTerms.filter((term) =>
+        prompt.toLowerCase().includes(term.toLowerCase()),
       );
       if (foundTerms.length > 0) {
-        errors.push(`Contains forbidden terms: ${foundTerms.join(', ')}`);
+        errors.push(`Contains forbidden terms: ${foundTerms.join(", ")}`);
       }
     }
 
     // Quality suggestions
     if (prompt.length < 100) {
-      suggestions.push('Prompt might be too short for effective guidance');
+      suggestions.push("Prompt might be too short for effective guidance");
     }
     if (prompt.length > 10000) {
-      suggestions.push('Prompt might be too long, consider breaking into sections');
+      suggestions.push(
+        "Prompt might be too long, consider breaking into sections",
+      );
     }
-    if (!prompt.includes('task') && !prompt.includes('Task')) {
-      suggestions.push('Consider making the task description more explicit');
+    if (!prompt.includes("task") && !prompt.includes("Task")) {
+      suggestions.push("Consider making the task description more explicit");
     }
 
     return {
       isValid: errors.length === 0,
       errors,
       warnings,
-      suggestions
+      suggestions,
     };
   }
 
@@ -1327,29 +1485,33 @@ export class PromptExtension {
 
     // Truncate at sentence boundaries when possible
     const sentences = prompt.split(/[.!?]+/);
-    let result = '';
+    let result = "";
 
     for (const sentence of sentences) {
-      if ((result + sentence).length > targetChars - 100) { // Leave buffer
+      if ((result + sentence).length > targetChars - 100) {
+        // Leave buffer
         break;
       }
-      result += sentence + '.';
+      result += sentence + ".";
     }
 
-    return result + '\n\n[Content truncated to fit token limit]';
+    return result + "\n\n[Content truncated to fit token limit]";
   }
 
-  private ensureRequiredSections(prompt: string, requiredSections: string[]): string {
+  private ensureRequiredSections(
+    prompt: string,
+    requiredSections: string[],
+  ): string {
     let enhanced = prompt;
 
-    const missingSections = requiredSections.filter(section =>
-      !prompt.toLowerCase().includes(section.toLowerCase())
+    const missingSections = requiredSections.filter(
+      (section) => !prompt.toLowerCase().includes(section.toLowerCase()),
     );
 
     if (missingSections.length > 0) {
-      enhanced += '\n\n## Required Sections\n';
-      enhanced += 'Please ensure your response includes:\n';
-      missingSections.forEach(section => {
+      enhanced += "\n\n## Required Sections\n";
+      enhanced += "Please ensure your response includes:\n";
+      missingSections.forEach((section) => {
         enhanced += `- ${section}\n`;
       });
     }
@@ -1359,13 +1521,13 @@ export class PromptExtension {
 
   private applyOutputFormat(prompt: string, format: string): string {
     switch (format) {
-      case 'json':
+      case "json":
         return `${prompt}\n\nPlease provide your response in valid JSON format.`;
-      case 'yaml':
+      case "yaml":
         return `${prompt}\n\nPlease provide your response in YAML format.`;
-      case 'code':
+      case "code":
         return `${prompt}\n\nPlease provide your response primarily as code with minimal explanatory text.`;
-      case 'markdown':
+      case "markdown":
       default:
         return `${prompt}\n\nPlease provide your response in well-formatted Markdown.`;
     }
@@ -1380,6 +1542,7 @@ export class PromptExtension {
 ## コミット計画
 
 ### コミット1: プロンプト拡張型定義
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1392,6 +1555,7 @@ git commit -m "feat(create-prompt): add prompt extension type definitions"
 ```
 
 ### コミット2: モード別プロンプト生成エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1404,6 +1568,7 @@ git commit -m "feat(create-prompt): implement mode-specific prompt generation en
 ```
 
 ### コミット3: サブタスクプロンプト生成エンジン
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1416,6 +1581,7 @@ git commit -m "feat(create-prompt): implement subtask prompt generation engine w
 ```
 
 ### コミット4: プロンプト拡張統合クラス
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1428,6 +1594,7 @@ git commit -m "feat(create-prompt): implement prompt extension integration class
 ```
 
 ### コミット5: エクスポート更新
+
 ```bash
 # プリコミットチェック
 bun test
@@ -1463,7 +1630,7 @@ test/
 // src/create-prompt/index.ts
 
 // 既存のエクスポート（変更なし）
-export { createPrompt } from './prompt-creator'; // 既存の関数
+export { createPrompt } from "./prompt-creator"; // 既存の関数
 
 // 新しいプロンプト拡張エクスポート
 export type {
@@ -1474,24 +1641,24 @@ export type {
   SubtaskPromptContext,
   PromptGenerationResult,
   PromptMetadata,
-  PromptValidationResult
-} from './types';
+  PromptValidationResult,
+} from "./types";
 
-export { ModePromptGenerator } from './mode-prompt-generator';
-export { SubtaskPromptGenerator } from './subtask-prompt-generator';
-export { PromptExtension } from './prompt-extension';
+export { ModePromptGenerator } from "./mode-prompt-generator";
+export { SubtaskPromptGenerator } from "./subtask-prompt-generator";
+export { PromptExtension } from "./prompt-extension";
 ```
 
 ## 統合テスト
 
 ```typescript
 // test/create-prompt/integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { PromptExtension } from '../../src/create-prompt/prompt-extension';
-import { TaskAnalyzer } from '../../src/orchestration/task-analyzer';
+import { describe, test, expect } from "bun:test";
+import { PromptExtension } from "../../src/create-prompt/prompt-extension";
+import { TaskAnalyzer } from "../../src/orchestration/task-analyzer";
 
-describe('Prompt Extension Integration', () => {
-  test('should integrate with orchestration system', () => {
+describe("Prompt Extension Integration", () => {
+  test("should integrate with orchestration system", () => {
     const promptExtension = new PromptExtension();
     const taskAnalyzer = new TaskAnalyzer();
 
@@ -1508,21 +1675,26 @@ describe('Prompt Extension Integration', () => {
     expect(analysis.requiresOrchestration).toBe(true);
 
     // Generate prompts for each required mode
-    analysis.requiredModes.forEach(mode => {
+    analysis.requiredModes.forEach((mode) => {
       const context = {
         mode,
         taskDescription: complexTask,
-        globalContext: { framework: 'React', backend: 'Node.js' },
+        globalContext: { framework: "React", backend: "Node.js" },
         previousResults: [],
         constraints: {
           maxTokens: 4000,
-          requiredSections: ['implementation', 'testing'],
+          requiredSections: ["implementation", "testing"],
           forbiddenTerms: [],
-          outputFormat: 'markdown' as const
-        }
+          outputFormat: "markdown" as const,
+        },
       };
 
-      const modeObj = { slug: mode, name: mode, roleDefinition: '', groups: [] };
+      const modeObj = {
+        slug: mode,
+        name: mode,
+        roleDefinition: "",
+        groups: [],
+      };
       const result = promptExtension.createPromptForMode(context, modeObj);
 
       expect(result.prompt).toBeTruthy();
@@ -1531,27 +1703,32 @@ describe('Prompt Extension Integration', () => {
     });
   });
 
-  test('should optimize prompts for token constraints', () => {
+  test("should optimize prompts for token constraints", () => {
     const promptExtension = new PromptExtension();
 
     const longContext = {
-      mode: 'code',
-      taskDescription: 'Implement feature ' + 'with many details '.repeat(100),
-      globalContext: { detail: 'very long context '.repeat(50) },
-      previousResults: ['result '.repeat(30)],
+      mode: "code",
+      taskDescription: "Implement feature " + "with many details ".repeat(100),
+      globalContext: { detail: "very long context ".repeat(50) },
+      previousResults: ["result ".repeat(30)],
       constraints: {
         maxTokens: 1000,
-        requiredSections: ['implementation'],
+        requiredSections: ["implementation"],
         forbiddenTerms: [],
-        outputFormat: 'markdown' as const
-      }
+        outputFormat: "markdown" as const,
+      },
     };
 
-    const modeObj = { slug: 'code', name: 'Code', roleDefinition: '', groups: [] };
+    const modeObj = {
+      slug: "code",
+      name: "Code",
+      roleDefinition: "",
+      groups: [],
+    };
     const result = promptExtension.createPromptForMode(longContext, modeObj);
 
     expect(promptExtension.estimateTokens(result.prompt)).toBeLessThan(1000);
-    expect(result.metadata.optimizationApplied).toContain('token_optimization');
+    expect(result.metadata.optimizationApplied).toContain("token_optimization");
   });
 });
 ```
@@ -1559,6 +1736,7 @@ describe('Prompt Extension Integration', () => {
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase2-context-optimizer から作業ブランチを作成
 git checkout phase2-context-optimizer
@@ -1588,6 +1766,7 @@ git branch -d phase3-prompt-extension
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase2-context-optimizer から作業ブランチ作成
 git checkout phase2-context-optimizer
@@ -1619,6 +1798,7 @@ git branch -d phase3-prompt-extension
 ## 依存関係
 
 このフェーズはフェーズ2（タスク分析、コンテキスト最適化）完了後に実装してください。以下のフェーズに必要となります：
+
 - フェーズ3.2: GitHub Actions統合（拡張されたプロンプト生成の活用）
 - フェーズ4: MCP拡張（プロンプト生成ツール）
 

--- a/predev-docs/06-phase3-prompt-extension-design.md
+++ b/predev-docs/06-phase3-prompt-extension-design.md
@@ -1,0 +1,1630 @@
+# フェーズ3.1: プロンプト生成拡張 - 詳細設計
+
+## 概要
+
+プロンプト生成拡張は、既存のプロンプト作成システムを拡張し、モード別・サブタスク別に最適化されたプロンプトを生成する機能を実装します。オーケストレーション機能との統合により、各サブタスクに最適なコンテキストとプロンプトを提供します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class PromptExtension {
+        -modePromptGenerator: ModePromptGenerator
+        -subtaskPromptGenerator: SubtaskPromptGenerator
+        +createPromptForMode(context: any, mode: Mode): string
+        +createPromptForSubtask(subtask: SubTask): string
+        +optimizePrompt(prompt: string, constraints: PromptConstraints): string
+    }
+
+    class ModePromptGenerator {
+        -modeManager: ModeManager
+        -promptTemplates: Map<string, PromptTemplate>
+        +generateModeSpecificPrompt(context: any, mode: Mode): string
+        +getModeInstructions(mode: string): string
+        +applyModeConstraints(prompt: string, mode: Mode): string
+    }
+
+    class SubtaskPromptGenerator {
+        -contextOptimizer: ContextOptimizer
+        -dependencyAnalyzer: DependencyAnalyzer
+        +generateSubtaskPrompt(subtask: SubTask, context: TaskContext): string
+        +createContextualizedPrompt(subtask: SubTask, previousResults: string[]): string
+        +injectDependencyInfo(prompt: string, dependencies: string[]): string
+    }
+
+    class PromptTemplate {
+        <<interface>>
+        +mode: string
+        +templateString: string
+        +variables: string[]
+        +constraints: PromptConstraints
+        +examples?: string[]
+    }
+
+    class PromptConstraints {
+        <<interface>>
+        +maxTokens: number
+        +requiredSections: string[]
+        +forbiddenTerms: string[]
+        +outputFormat: 'markdown' | 'json' | 'code'
+    }
+
+    PromptExtension --> ModePromptGenerator : uses
+    PromptExtension --> SubtaskPromptGenerator : uses
+    ModePromptGenerator --> PromptTemplate : uses
+    SubtaskPromptGenerator --> PromptTemplate : uses
+```
+
+## TDD実装計画
+
+### タスク3.1.1: プロンプト拡張型定義の作成
+
+#### 実装: src/create-prompt/types.ts
+
+```typescript
+import type { Mode } from '../modes/types';
+import type { SubTask, TaskContext } from '../tasks/types';
+
+export interface PromptTemplate {
+  mode: string;
+  templateString: string;
+  variables: string[];
+  constraints: PromptConstraints;
+  examples?: string[];
+  priority?: number;
+}
+
+export interface PromptConstraints {
+  maxTokens: number;
+  requiredSections: string[];
+  forbiddenTerms: string[];
+  outputFormat: 'markdown' | 'json' | 'code' | 'yaml';
+  styleGuidelines?: string[];
+}
+
+export interface QualityScore {
+  overall: number;
+  clarity: number;
+  completeness: number;
+  specificity: number;
+  tokenEfficiency: number;
+  contextRelevance?: number;
+}
+
+export interface ModePromptContext {
+  mode: string;
+  taskDescription: string;
+  globalContext: Record<string, any>;
+  previousResults: string[];
+  constraints: PromptConstraints;
+  modeSpecificData?: Record<string, any>;
+}
+
+export interface SubtaskPromptContext extends ModePromptContext {
+  subtask: SubTask;
+  dependencies: string[];
+  parentTaskId?: string;
+  executionOrder: number;
+}
+
+export interface PromptGenerationResult {
+  prompt: string;
+  metadata: PromptMetadata;
+  qualityScore: QualityScore;
+  warnings?: string[];
+}
+
+export interface PromptMetadata {
+  mode: string;
+  templateUsed: string;
+  tokensUsed: number;
+  optimizationApplied: string[];
+  generationTime: number;
+}
+
+export type PromptVariableResolver = (variableName: string, context: any) => string;
+
+export interface PromptValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+  suggestions: string[];
+}
+```
+
+### タスク3.1.2: モード別プロンプト生成エンジンの実装
+
+#### テストファースト: src/create-prompt/mode-prompt-generator.ts
+
+```typescript
+// test/create-prompt/mode-prompt-generator.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { ModePromptGenerator } from '../../src/create-prompt/mode-prompt-generator';
+import { modeManager } from '../../src/modes';
+
+describe('ModePromptGenerator', () => {
+  let generator: ModePromptGenerator;
+
+  beforeEach(() => {
+    generator = new ModePromptGenerator();
+  });
+
+  test('should generate code mode specific prompt', () => {
+    const context = {
+      mode: 'code',
+      taskDescription: 'Implement user authentication API',
+      globalContext: {
+        framework: 'Express.js',
+        database: 'MongoDB'
+      },
+      previousResults: ['Database schema designed'],
+      constraints: {
+        maxTokens: 4000,
+        requiredSections: ['implementation', 'testing'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown' as const
+      }
+    };
+
+    const result = generator.generateModeSpecificPrompt(context);
+
+    expect(result.prompt).toContain('implementation');
+    expect(result.prompt).toContain('Express.js');
+    expect(result.prompt).toContain('MongoDB');
+    expect(result.metadata.mode).toBe('code');
+    expect(result.qualityScore.overall).toBeGreaterThan(0.7);
+  });
+
+  test('should generate architect mode specific prompt', () => {
+    const context = {
+      mode: 'architect',
+      taskDescription: 'Design microservices architecture',
+      globalContext: {
+        scale: 'enterprise',
+        requirements: 'high availability'
+      },
+      previousResults: [],
+      constraints: {
+        maxTokens: 5000,
+        requiredSections: ['overview', 'components', 'interactions'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown' as const
+      }
+    };
+
+    const result = generator.generateModeSpecificPrompt(context);
+
+    expect(result.prompt).toContain('architecture');
+    expect(result.prompt).toContain('microservices');
+    expect(result.prompt).toContain('high availability');
+    expect(result.metadata.mode).toBe('architect');
+  });
+
+  test('should apply mode constraints correctly', () => {
+    const mode = modeManager.getModeBySlug('debug');
+    const basePrompt = 'Debug the authentication issue';
+
+    const constrainedPrompt = generator.applyModeConstraints(basePrompt, mode);
+
+    expect(constrainedPrompt).toContain('troubleshoot');
+    expect(constrainedPrompt).toContain('analyze');
+    expect(constrainedPrompt.length).toBeGreaterThan(basePrompt.length);
+  });
+
+  test('should get mode-specific instructions', () => {
+    const codeInstructions = generator.getModeInstructions('code');
+    const architectInstructions = generator.getModeInstructions('architect');
+
+    expect(codeInstructions).toContain('implement');
+    expect(architectInstructions).toContain('design');
+    expect(codeInstructions).not.toBe(architectInstructions);
+  });
+
+  test('should handle unknown mode gracefully', () => {
+    const context = {
+      mode: 'unknown_mode',
+      taskDescription: 'Some task',
+      globalContext: {},
+      previousResults: [],
+      constraints: {
+        maxTokens: 2000,
+        requiredSections: [],
+        forbiddenTerms: [],
+        outputFormat: 'markdown' as const
+      }
+    };
+
+    const result = generator.generateModeSpecificPrompt(context);
+
+    expect(result.prompt).toBeTruthy();
+    expect(result.metadata.mode).toBe('code'); // fallback to default
+    expect(result.warnings).toContain('Unknown mode, falling back to code mode');
+  });
+});
+```
+
+#### 実装: src/create-prompt/mode-prompt-generator.ts
+
+```typescript
+import { modeManager } from '../modes';
+import type { Mode } from '../modes/types';
+import type {
+  ModePromptContext,
+  PromptTemplate,
+  PromptGenerationResult,
+  PromptMetadata,
+  QualityScore
+} from './types';
+
+export class ModePromptGenerator {
+  private promptTemplates: Map<string, PromptTemplate>;
+
+  constructor() {
+    this.promptTemplates = this.initializePromptTemplates();
+  }
+
+  generateModeSpecificPrompt(context: ModePromptContext): PromptGenerationResult {
+    const startTime = Date.now();
+    const mode = modeManager.getModeBySlug(context.mode) || modeManager.getModeBySlug('code')!;
+    const template = this.getTemplateForMode(context.mode);
+
+    const warnings: string[] = [];
+    if (!modeManager.getModeBySlug(context.mode)) {
+      warnings.push('Unknown mode, falling back to code mode');
+    }
+
+    // Generate base prompt from template
+    let prompt = this.expandTemplate(template, context);
+
+    // Apply mode-specific constraints and instructions
+    prompt = this.applyModeConstraints(prompt, mode);
+
+    // Add mode-specific instructions
+    const modeInstructions = this.getModeInstructions(context.mode);
+    prompt = this.injectModeInstructions(prompt, modeInstructions);
+
+    // Optimize for token limit
+    if (context.constraints.maxTokens) {
+      prompt = this.optimizeForTokenLimit(prompt, context.constraints.maxTokens);
+    }
+
+    const metadata: PromptMetadata = {
+      mode: mode.slug,
+      templateUsed: template.mode,
+      tokensUsed: this.estimateTokens(prompt),
+      optimizationApplied: ['mode_constraints', 'token_optimization'],
+      generationTime: Date.now() - startTime
+    };
+
+    const qualityScore = this.calculateQualityScore(prompt, context);
+
+    return {
+      prompt,
+      metadata,
+      qualityScore,
+      warnings: warnings.length > 0 ? warnings : undefined
+    };
+  }
+
+  getModeInstructions(mode: string): string {
+    const instructionMap: Record<string, string> = {
+      'code': `
+## Implementation Guidelines
+- Focus on clean, maintainable code
+- Include error handling and edge cases
+- Provide comprehensive testing approach
+- Follow established coding standards
+- Consider performance implications
+      `,
+      'architect': `
+## Design Guidelines
+- Consider scalability and maintainability
+- Define clear component boundaries
+- Specify integration patterns
+- Address non-functional requirements
+- Provide migration strategy if needed
+      `,
+      'debug': `
+## Debugging Guidelines
+- Systematically analyze the problem
+- Identify root causes, not just symptoms
+- Provide step-by-step troubleshooting
+- Include diagnostic commands and tools
+- Suggest preventive measures
+      `,
+      'ask': `
+## Information Guidelines
+- Provide clear, comprehensive explanations
+- Include relevant examples and use cases
+- Reference authoritative sources
+- Structure information logically
+- Anticipate follow-up questions
+      `,
+      'orchestrator': `
+## Orchestration Guidelines
+- Break down complex tasks systematically
+- Identify dependencies and execution order
+- Delegate to appropriate specialized modes
+- Coordinate between different components
+- Monitor overall progress and quality
+      `
+    };
+
+    return instructionMap[mode] || instructionMap['code'];
+  }
+
+  applyModeConstraints(prompt: string, mode: Mode): string {
+    // Add mode-specific role and context
+    const roleDefinition = mode.roleDefinition;
+    const customInstructions = mode.customInstructions || '';
+
+    let enhancedPrompt = `${roleDefinition}\n\n`;
+
+    if (customInstructions) {
+      enhancedPrompt += `${customInstructions}\n\n`;
+    }
+
+    enhancedPrompt += prompt;
+
+    // Apply mode-specific formatting and constraints
+    switch (mode.slug) {
+      case 'code':
+        enhancedPrompt += '\n\nPlease provide implementation details, including code examples and testing approaches.';
+        break;
+      case 'architect':
+        enhancedPrompt += '\n\nPlease provide architectural diagrams, component descriptions, and integration patterns.';
+        break;
+      case 'debug':
+        enhancedPrompt += '\n\nPlease provide step-by-step debugging analysis and specific solutions.';
+        break;
+      case 'ask':
+        enhancedPrompt += '\n\nPlease provide comprehensive explanations with examples and references.';
+        break;
+    }
+
+    return enhancedPrompt;
+  }
+
+  private initializePromptTemplates(): Map<string, PromptTemplate> {
+    const templates = new Map<string, PromptTemplate>();
+
+    templates.set('code', {
+      mode: 'code',
+      templateString: `
+# Implementation Task: {task}
+
+## Context
+{context}
+
+## Previous Work
+{previousResults}
+
+## Requirements
+{requirements}
+
+## Technical Constraints
+{technicalConstraints}
+
+Please implement the solution following best practices.
+      `,
+      variables: ['task', 'context', 'previousResults', 'requirements', 'technicalConstraints'],
+      constraints: {
+        maxTokens: 4000,
+        requiredSections: ['implementation', 'testing'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown'
+      }
+    });
+
+    templates.set('architect', {
+      mode: 'architect',
+      templateString: `
+# Architecture Design: {task}
+
+## System Context
+{context}
+
+## Background
+{previousResults}
+
+## Requirements
+{requirements}
+
+## Constraints
+{constraints}
+
+Please design a comprehensive architecture solution.
+      `,
+      variables: ['task', 'context', 'previousResults', 'requirements', 'constraints'],
+      constraints: {
+        maxTokens: 5000,
+        requiredSections: ['overview', 'components', 'interactions'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown'
+      }
+    });
+
+    templates.set('debug', {
+      mode: 'debug',
+      templateString: `
+# Debugging Task: {task}
+
+## Problem Description
+{context}
+
+## Investigation History
+{previousResults}
+
+## System Information
+{systemInfo}
+
+## Error Details
+{errorDetails}
+
+Please provide systematic debugging analysis.
+      `,
+      variables: ['task', 'context', 'previousResults', 'systemInfo', 'errorDetails'],
+      constraints: {
+        maxTokens: 3500,
+        requiredSections: ['analysis', 'solution', 'prevention'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown'
+      }
+    });
+
+    templates.set('orchestrator', {
+      mode: 'orchestrator',
+      templateString: `
+# Orchestration Plan: {task}
+
+## Goal
+{goal}
+
+## Main Steps
+{mainSteps}
+
+## Key Considerations
+{considerations}
+
+## Coordination Strategy
+{coordination}
+
+Please outline a detailed orchestration plan.
+      `,
+      variables: ['task', 'goal', 'mainSteps', 'considerations', 'coordination'],
+      constraints: {
+        maxTokens: 4500,
+        requiredSections: ['plan', 'steps', 'dependencies', 'monitoring'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown'
+      }
+    });
+
+    return templates;
+  }
+
+  private getTemplateForMode(mode: string): PromptTemplate {
+    return this.promptTemplates.get(mode) || this.promptTemplates.get('code')!;
+  }
+
+  private expandTemplate(template: PromptTemplate, context: ModePromptContext): string {
+    let prompt = template.templateString;
+
+    const variableMap: Record<string, string> = {
+      'task': context.taskDescription,
+      'context': this.formatContext(context.globalContext),
+      'previousResults': this.formatPreviousResults(context.previousResults),
+      'requirements': this.extractRequirements(context),
+      'technicalConstraints': this.formatConstraints(context.constraints),
+      'constraints': this.formatConstraints(context.constraints),
+      'systemInfo': this.formatSystemInfo(context.globalContext),
+      'errorDetails': this.extractErrorDetails(context)
+    };
+
+    for (const [variable, value] of Object.entries(variableMap)) {
+      const regex = new RegExp(`{${variable}}`, 'g');
+      prompt = prompt.replace(regex, value || '');
+    }
+
+    return prompt;
+  }
+
+  private formatContext(globalContext: Record<string, any>): string {
+    if (!globalContext || Object.keys(globalContext).length === 0) {
+      return 'No specific context provided.';
+    }
+
+    return Object.entries(globalContext)
+      .map(([key, value]) => `- ${key}: ${value}`)
+      .join('\n');
+  }
+
+  private formatPreviousResults(results: string[]): string {
+    if (!results || results.length === 0) {
+      return 'No previous work completed.';
+    }
+
+    return results.map((result, index) => `${index + 1}. ${result}`).join('\n');
+  }
+
+  private extractRequirements(context: ModePromptContext): string {
+    const sections = context.constraints.requiredSections;
+    if (!sections || sections.length === 0) {
+      return 'General implementation requirements apply.';
+    }
+
+    return `Please ensure the following sections are included:\n${sections.map(s => `- ${s}`).join('\n')}`;
+  }
+
+  private formatConstraints(constraints: any): string {
+    if (!constraints) return 'No specific constraints.';
+
+    const items = [];
+    if (constraints.maxTokens) items.push(`Maximum tokens: ${constraints.maxTokens}`);
+    if (constraints.outputFormat) items.push(`Output format: ${constraints.outputFormat}`);
+    if (constraints.forbiddenTerms?.length > 0) {
+      items.push(`Avoid terms: ${constraints.forbiddenTerms.join(', ')}`);
+    }
+
+    return items.length > 0 ? items.join('\n') : 'No specific constraints.';
+  }
+
+  private formatSystemInfo(context: Record<string, any>): string {
+    const systemKeys = ['os', 'framework', 'database', 'version', 'environment'];
+    const systemInfo = systemKeys
+      .filter(key => context[key])
+      .map(key => `${key}: ${context[key]}`)
+      .join('\n');
+
+    return systemInfo || 'System information not provided.';
+  }
+
+  private extractErrorDetails(context: ModePromptContext): string {
+    if (context.modeSpecificData?.error) {
+      return context.modeSpecificData.error;
+    }
+    return 'Error details to be investigated.';
+  }
+
+  private injectModeInstructions(prompt: string, instructions: string): string {
+    return `${prompt}\n\n${instructions}`;
+  }
+
+  private optimizeForTokenLimit(prompt: string, maxTokens: number): string {
+    const estimatedTokens = this.estimateTokens(prompt);
+
+    if (estimatedTokens <= maxTokens) {
+      return prompt;
+    }
+
+    // Simple optimization: truncate sections that are too verbose
+    const lines = prompt.split('\n');
+    const targetRatio = maxTokens / estimatedTokens;
+    const targetLines = Math.floor(lines.length * targetRatio);
+
+    return lines.slice(0, targetLines).join('\n') + '\n\n[Content optimized for token limit]';
+  }
+
+  // estimateTokensメソッドは、複数のクラスで共通のロジックを使用しています。
+  // 実際の開発時には、このロジックを src/create-prompt/utils.ts のような共通ユーティリティファイルに集約し、
+  // 各クラスからインポートして使用することを推奨します。
+  // これにより、コードの重複を避け、メンテナンス性を向上させることができます。
+  private estimateTokens(text: string): number {
+    const words = text.split(/\s+/).length;
+    const chars = text.length;
+    const wordBasedTokens = words * 0.75;
+    const charBasedTokens = chars / 4;
+    return Math.ceil((wordBasedTokens + charBasedTokens) / 2);
+  }
+
+  private calculateQualityScore(prompt: string, context: ModePromptContext): QualityScore {
+    // Simple quality metrics
+    const hasRequiredSections = context.constraints.requiredSections.every(section =>
+      prompt.toLowerCase().includes(section.toLowerCase())
+    );
+
+    const hasContext = prompt.includes(context.taskDescription);
+    const appropriateLength = prompt.length > 200 && prompt.length < 8000;
+    const hasModeSpecificTerms = this.containsModeSpecificTerms(prompt, context.mode);
+
+    const completeness = hasRequiredSections ? 0.9 : 0.6;
+    const specificity = hasContext ? 0.8 : 0.5;
+    const clarity = appropriateLength ? 0.8 : 0.6;
+    const contextRelevance = hasModeSpecificTerms ? 0.85 : 0.7;
+    const tokenEfficiency = this.calculateTokenEfficiency(prompt, context.constraints.maxTokens);
+
+    const overall = (completeness + specificity + clarity + contextRelevance + tokenEfficiency) / 5;
+
+    return {
+      overall,
+      clarity,
+      completeness,
+      specificity,
+      tokenEfficiency,
+      contextRelevance
+    };
+  }
+
+  private containsModeSpecificTerms(prompt: string, mode: string): boolean {
+    const modeTerms: Record<string, string[]> = {
+      'code': ['implement', 'function', 'class', 'method', 'test'],
+      'architect': ['design', 'architecture', 'component', 'system', 'pattern'],
+      'debug': ['debug', 'analyze', 'troubleshoot', 'investigate', 'fix'],
+      'ask': ['explain', 'describe', 'clarify', 'understand', 'information']
+    };
+
+    const terms = modeTerms[mode] || [];
+    return terms.some(term => prompt.toLowerCase().includes(term));
+  }
+
+  private calculateTokenEfficiency(prompt: string, maxTokens: number): number {
+    const estimatedTokens = this.estimateTokens(prompt);
+    const efficiency = Math.min(estimatedTokens / maxTokens, 1.0);
+
+    // Penalize if too close to limit (less room for response)
+    if (efficiency > 0.8) return efficiency * 0.8;
+    return efficiency;
+  }
+}
+```
+
+### タスク3.1.3: サブタスクプロンプト生成エンジンの実装
+
+#### テストファースト: src/create-prompt/subtask-prompt-generator.ts
+
+```typescript
+// test/create-prompt/subtask-prompt-generator.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { SubtaskPromptGenerator } from '../../src/create-prompt/subtask-prompt-generator';
+import type { SubTask, TaskContext } from '../../src/tasks/types';
+
+describe('SubtaskPromptGenerator', () => {
+  let generator: SubtaskPromptGenerator;
+
+  beforeEach(() => {
+    generator = new SubtaskPromptGenerator();
+  });
+
+  test('should generate prompt for independent subtask', () => {
+    const subtask: SubTask = {
+      id: 'subtask-1',
+      description: 'Implement user authentication API endpoints',
+      mode: 'code',
+      priority: 1,
+      dependencies: [],
+      estimatedComplexity: 6.5
+    };
+
+    const context: TaskContext = {
+      previousResults: [],
+      globalContext: {
+        framework: 'Express.js',
+        database: 'MongoDB'
+      },
+      modeSpecificContext: {
+        implementationFocus: 'security'
+      },
+      maxTokens: 4000
+    };
+
+    const result = generator.generateSubtaskPrompt(subtask, context);
+
+    expect(result.prompt).toContain('authentication');
+    expect(result.prompt).toContain('Express.js');
+    expect(result.metadata.mode).toBe('code');
+    expect(result.qualityScore.overall).toBeGreaterThan(0.7);
+  });
+
+  test('should generate prompt for dependent subtask', () => {
+    const subtask: SubTask = {
+      id: 'subtask-3',
+      description: 'Implement password reset functionality',
+      mode: 'code',
+      priority: 3,
+      dependencies: ['subtask-1', 'subtask-2'],
+      estimatedComplexity: 4.0
+    };
+
+    const context: TaskContext = {
+      previousResults: [
+        'User registration API completed',
+        'Email service integration completed'
+      ],
+      globalContext: {
+        framework: 'Express.js',
+        emailProvider: 'SendGrid'
+      },
+      modeSpecificContext: {},
+      maxTokens: 3500
+    };
+
+    const result = generator.generateSubtaskPrompt(subtask, context);
+
+    expect(result.prompt).toContain('password reset');
+    expect(result.prompt).toContain('registration API completed');
+    expect(result.prompt).toContain('Email service integration');
+    expect(result.metadata.tokensUsed).toBeLessThan(3500);
+  });
+
+  test('should create contextualized prompt with previous results', () => {
+    const subtask: SubTask = {
+      id: 'subtask-2',
+      description: 'Create user profile management',
+      mode: 'code',
+      priority: 2,
+      dependencies: ['subtask-1'],
+      estimatedComplexity: 5.0
+    };
+
+    const previousResults = [
+      'Database schema created with user table',
+      'Authentication middleware implemented',
+      'JWT token generation working'
+    ];
+
+    const prompt = generator.createContextualizedPrompt(subtask, previousResults);
+
+    expect(prompt).toContain('profile management');
+    expect(prompt).toContain('Database schema created');
+    expect(prompt).toContain('Authentication middleware');
+    expect(prompt).toContain('JWT token generation');
+  });
+
+  test('should inject dependency information correctly', () => {
+    const basePrompt = 'Implement the feature as described.';
+    const dependencies = ['User authentication system', 'Database connection'];
+
+    const enhancedPrompt = generator.injectDependencyInfo(basePrompt, dependencies);
+
+    expect(enhancedPrompt).toContain('authentication system');
+    expect(enhancedPrompt).toContain('Database connection');
+    expect(enhancedPrompt).toContain('Dependencies');
+  });
+
+  test('should handle subtask without dependencies', () => {
+    const subtask: SubTask = {
+      id: 'subtask-1',
+      description: 'Setup project structure',
+      mode: 'code',
+      priority: 1,
+      dependencies: [],
+      estimatedComplexity: 2.0
+    };
+
+    const context: TaskContext = {
+      previousResults: [],
+      globalContext: {},
+      modeSpecificContext: {},
+      maxTokens: 2000
+    };
+
+    const result = generator.generateSubtaskPrompt(subtask, context);
+
+    expect(result.prompt).toContain('project structure');
+    expect(result.prompt).not.toContain('Dependencies');
+    expect(result.warnings).toBeUndefined();
+  });
+});
+```
+
+#### 実装: src/create-prompt/subtask-prompt-generator.ts
+
+```typescript
+import type { SubTask, TaskContext } from '../tasks/types';
+import type {
+  SubtaskPromptContext,
+  PromptGenerationResult,
+  PromptMetadata,
+  QualityScore
+} from './types';
+import { ModePromptGenerator } from './mode-prompt-generator';
+
+export class SubtaskPromptGenerator {
+  private modePromptGenerator: ModePromptGenerator;
+
+  constructor() {
+    this.modePromptGenerator = new ModePromptGenerator();
+  }
+
+  generateSubtaskPrompt(subtask: SubTask, context: TaskContext): PromptGenerationResult {
+    const startTime = Date.now();
+
+    // Create enhanced context for subtask
+    const subtaskContext: SubtaskPromptContext = {
+      mode: subtask.mode,
+      taskDescription: subtask.description,
+      globalContext: context.globalContext,
+      previousResults: context.previousResults,
+      constraints: {
+        maxTokens: context.maxTokens,
+        requiredSections: this.getRequiredSectionsForMode(subtask.mode),
+        forbiddenTerms: [],
+        outputFormat: 'markdown'
+      },
+      subtask,
+      dependencies: subtask.dependencies,
+      parentTaskId: subtask.parentTaskId,
+      executionOrder: subtask.priority
+    };
+
+    // Generate base prompt using mode generator
+    const baseResult = this.modePromptGenerator.generateModeSpecificPrompt(subtaskContext);
+
+    // Enhance with subtask-specific context
+    let enhancedPrompt = this.enhanceWithSubtaskContext(baseResult.prompt, subtask, context);
+
+    // Add dependency information if present
+    if (subtask.dependencies.length > 0) {
+      enhancedPrompt = this.injectDependencyInfo(enhancedPrompt, this.resolveDependencies(subtask.dependencies, context));
+    }
+
+    // Add execution context
+    enhancedPrompt = this.addExecutionContext(enhancedPrompt, subtask, context);
+
+    const metadata: PromptMetadata = {
+      ...baseResult.metadata,
+      tokensUsed: this.estimateTokens(enhancedPrompt),
+      optimizationApplied: [...baseResult.metadata.optimizationApplied, 'subtask_context', 'dependency_injection'],
+      generationTime: Date.now() - startTime
+    };
+
+    const qualityScore = this.calculateSubtaskQualityScore(enhancedPrompt, subtaskContext);
+
+    return {
+      prompt: enhancedPrompt,
+      metadata,
+      qualityScore,
+      warnings: baseResult.warnings
+    };
+  }
+
+  createContextualizedPrompt(subtask: SubTask, previousResults: string[]): string {
+    let prompt = `## Subtask: ${subtask.description}\n\n`;
+
+    if (previousResults.length > 0) {
+      prompt += `### Previous Work Completed\n`;
+      previousResults.forEach((result, index) => {
+        prompt += `${index + 1}. ${result}\n`;
+      });
+      prompt += '\n';
+    }
+
+    prompt += `### Current Task Requirements\n`;
+    prompt += `- Mode: ${subtask.mode}\n`;
+    prompt += `- Priority: ${subtask.priority}\n`;
+    prompt += `- Estimated Complexity: ${subtask.estimatedComplexity}/10\n\n`;
+
+    if (subtask.dependencies.length > 0) {
+      prompt += `### Dependencies\n`;
+      prompt += `This task depends on: ${subtask.dependencies.join(', ')}\n\n`;
+    }
+
+    prompt += `### Task Description\n${subtask.description}\n\n`;
+
+    return prompt;
+  }
+
+  injectDependencyInfo(prompt: string, dependencies: string[]): string {
+    if (dependencies.length === 0) return prompt;
+
+    const dependencySection = `
+### Dependencies and Prerequisites
+
+The following components must be available and functioning before implementing this task:
+
+${dependencies.map((dep, index) => `${index + 1}. ${dep}`).join('\n')}
+
+Please ensure your implementation builds upon these existing components and maintains compatibility.
+
+---
+
+`;
+
+    return dependencySection + prompt;
+  }
+
+  private enhanceWithSubtaskContext(basePrompt: string, subtask: SubTask, context: TaskContext): string {
+    let enhanced = basePrompt;
+
+    // Add subtask-specific metadata
+    enhanced += `\n## Subtask Information\n`;
+    enhanced += `- **Subtask ID**: ${subtask.id}\n`;
+    enhanced += `- **Execution Priority**: ${subtask.priority}\n`;
+    enhanced += `- **Estimated Complexity**: ${subtask.estimatedComplexity}/10\n`;
+
+    if (subtask.estimatedDuration) {
+      enhanced += `- **Estimated Duration**: ${subtask.estimatedDuration} minutes\n`;
+    }
+
+    // Add mode-specific context if available
+    if (context.modeSpecificContext && Object.keys(context.modeSpecificContext).length > 0) {
+      enhanced += `\n## Mode-Specific Context\n`;
+      Object.entries(context.modeSpecificContext).forEach(([key, value]) => {
+        enhanced += `- **${key}**: ${value}\n`;
+      });
+    }
+
+    return enhanced;
+  }
+
+  private addExecutionContext(prompt: string, subtask: SubTask, context: TaskContext): string {
+    let enhanced = prompt;
+
+    enhanced += `\n## Execution Guidelines\n`;
+
+    // Add complexity-based guidance
+    if (subtask.estimatedComplexity > 7) {
+      enhanced += `- **High Complexity Task**: Break down into smaller steps and validate each step\n`;
+      enhanced += `- **Quality Focus**: Prioritize thorough testing and documentation\n`;
+    } else if (subtask.estimatedComplexity > 4) {
+      enhanced += `- **Moderate Complexity**: Ensure clear implementation with adequate testing\n`;
+    } else {
+      enhanced += `- **Straightforward Task**: Focus on clean, efficient implementation\n`;
+    }
+
+    // Add priority-based guidance
+    if (subtask.priority === 1) {
+      enhanced += `- **Critical Priority**: This task blocks other work - complete accurately and promptly\n`;
+    } else if (subtask.priority <= 3) {
+      enhanced += `- **High Priority**: Important for project progress\n`;
+    }
+
+    // Add dependency guidance
+    if (subtask.dependencies.length > 0) {
+      enhanced += `- **Dependency Aware**: Ensure compatibility with completed prerequisite tasks\n`;
+    }
+
+    enhanced += `\nPlease provide a complete implementation that addresses all requirements and maintains quality standards.`;
+
+    return enhanced;
+  }
+
+  private resolveDependencies(dependencyIds: string[], context: TaskContext): string[] {
+    // In a full implementation, this would resolve dependency IDs to their descriptions
+    // For now, we'll use the previous results as proxy for dependencies
+    const resolvedDependencies: string[] = [];
+
+    dependencyIds.forEach((depId, index) => {
+      if (index < context.previousResults.length) {
+        resolvedDependencies.push(context.previousResults[index]);
+      } else {
+        resolvedDependencies.push(`Dependency ${depId} (details to be resolved)`);
+      }
+    });
+
+    return resolvedDependencies;
+  }
+
+  private getRequiredSectionsForMode(mode: string): string[] {
+    const sectionMap: Record<string, string[]> = {
+      'code': ['implementation', 'testing', 'documentation'],
+      'architect': ['overview', 'components', 'interactions', 'considerations'],
+      'debug': ['analysis', 'investigation', 'solution', 'prevention'],
+      'ask': ['explanation', 'examples', 'references'],
+      'orchestrator': ['breakdown', 'coordination', 'monitoring']
+    };
+
+    return sectionMap[mode] || sectionMap['code'];
+  }
+
+  private calculateSubtaskQualityScore(prompt: string, context: SubtaskPromptContext): QualityScore {
+    const baseScore = this.modePromptGenerator.calculateQualityScore(prompt, context);
+
+    // Additional subtask-specific quality factors
+    const hasDependencyInfo = context.dependencies.length === 0 || prompt.includes('Dependencies');
+    const hasExecutionGuidance = prompt.includes('Execution Guidelines');
+    const hasSubtaskMetadata = prompt.includes('Subtask Information');
+
+    const subtaskSpecificity = (
+      (hasDependencyInfo ? 1 : 0) +
+      (hasExecutionGuidance ? 1 : 0) +
+      (hasSubtaskMetadata ? 1 : 0)
+    ) / 3;
+
+    return {
+      ...baseScore,
+      specificity: (baseScore.specificity + subtaskSpecificity) / 2,
+      overall: (baseScore.overall + subtaskSpecificity) / 2
+    };
+  }
+
+  // estimateTokensメソッドは、複数のクラスで共通のロジックを使用しています。
+  // 実際の開発時には、このロジックを src/create-prompt/utils.ts のような共通ユーティリティファイルに集約し、
+  // 各クラスからインポートして使用することを推奨します。
+  // これにより、コードの重複を避け、メンテナンス性を向上させることができます。
+  private estimateTokens(text: string): number {
+    const words = text.split(/\s+/).length;
+    const chars = text.length;
+    const wordBasedTokens = words * 0.75;
+    const charBasedTokens = chars / 4;
+    return Math.ceil((wordBasedTokens + charBasedTokens) / 2);
+  }
+}
+```
+
+### タスク3.1.4: プロンプト拡張統合クラスの実装
+
+#### テストファースト: src/create-prompt/prompt-extension.ts
+
+```typescript
+// test/create-prompt/prompt-extension.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { PromptExtension } from '../../src/create-prompt/prompt-extension';
+import type { Mode } from '../../src/modes/types';
+import type { SubTask, TaskContext } from '../../src/tasks/types';
+
+describe('PromptExtension', () => {
+  let promptExtension: PromptExtension;
+
+  beforeEach(() => {
+    promptExtension = new PromptExtension();
+  });
+
+  test('should create prompt for specific mode', () => {
+    const context = {
+      mode: 'code',
+      taskDescription: 'Implement JWT authentication',
+      globalContext: { framework: 'Express.js' },
+      previousResults: [],
+      constraints: {
+        maxTokens: 4000,
+        requiredSections: ['implementation'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown' as const
+      }
+    };
+
+    const mode: Mode = {
+      slug: 'code',
+      name: 'Code Implementation',
+      roleDefinition: 'You are an expert software developer',
+      groups: ['file_operations', 'code_generation']
+    };
+
+    const result = promptExtension.createPromptForMode(context, mode);
+
+    expect(result.prompt).toContain('JWT authentication');
+    expect(result.prompt).toContain('Express.js');
+    expect(result.metadata.mode).toBe('code');
+    expect(result.qualityScore.overall).toBeGreaterThan(0.7);
+  });
+
+  test('should create prompt for subtask', () => {
+    const subtask: SubTask = {
+      id: 'subtask-1',
+      description: 'Implement user registration endpoint',
+      mode: 'code',
+      priority: 1,
+      dependencies: [],
+      estimatedComplexity: 5.0
+    };
+
+    const context: TaskContext = {
+      previousResults: [],
+      globalContext: {
+        framework: 'Express.js',
+        database: 'MongoDB'
+      },
+      modeSpecificContext: {},
+      maxTokens: 3000
+    };
+
+    const result = promptExtension.createPromptForSubtask(subtask, context);
+
+    expect(result.prompt).toContain('user registration');
+    expect(result.prompt).toContain('Express.js');
+    expect(result.metadata.tokensUsed).toBeLessThan(3000);
+  });
+
+  test('should optimize prompt for constraints', () => {
+    const longPrompt = 'Very long prompt content that exceeds token limits. '.repeat(200);
+    const constraints = {
+      maxTokens: 1000,
+      requiredSections: ['summary'],
+      forbiddenTerms: ['harmful'],
+      outputFormat: 'markdown' as const
+    };
+
+    const optimized = promptExtension.optimizePrompt(longPrompt, constraints);
+
+    expect(optimized.length).toBeLessThan(longPrompt.length);
+    expect(optimized).not.toContain('harmful');
+    expect(promptExtension.estimateTokens(optimized)).toBeLessThan(1000);
+  });
+
+  test('should integrate with existing prompt creation system', () => {
+    const existingPrompt = 'This is an existing system prompt.';
+    const enhancement = {
+      mode: 'code',
+      taskDescription: 'Add authentication',
+      globalContext: {},
+      previousResults: [],
+      constraints: {
+        maxTokens: 2000,
+        requiredSections: [],
+        forbiddenTerms: [],
+        outputFormat: 'markdown' as const
+      }
+    };
+
+    const result = promptExtension.enhanceExistingPrompt(existingPrompt, enhancement);
+
+    expect(result.prompt).toContain('existing system prompt');
+    expect(result.prompt).toContain('authentication');
+    expect(result.metadata.optimizationApplied).toContain('existing_prompt_enhancement');
+  });
+});
+```
+
+#### 実装: src/create-prompt/prompt-extension.ts
+
+```typescript
+import { ModePromptGenerator } from './mode-prompt-generator';
+import { SubtaskPromptGenerator } from './subtask-prompt-generator';
+import type { Mode } from '../modes/types';
+import type { SubTask, TaskContext } from '../tasks/types';
+import type {
+  ModePromptContext,
+  PromptConstraints,
+  PromptGenerationResult,
+  PromptValidationResult
+} from './types';
+
+export class PromptExtension {
+  private modePromptGenerator: ModePromptGenerator;
+  private subtaskPromptGenerator: SubtaskPromptGenerator;
+
+  constructor() {
+    this.modePromptGenerator = new ModePromptGenerator();
+    this.subtaskPromptGenerator = new SubtaskPromptGenerator();
+  }
+
+  createPromptForMode(context: ModePromptContext, mode: Mode): PromptGenerationResult {
+    // Ensure mode is correctly set in context
+    const enhancedContext = {
+      ...context,
+      mode: mode.slug
+    };
+
+    return this.modePromptGenerator.generateModeSpecificPrompt(enhancedContext);
+  }
+
+  createPromptForSubtask(subtask: SubTask, context: TaskContext): PromptGenerationResult {
+    return this.subtaskPromptGenerator.generateSubtaskPrompt(subtask, context);
+  }
+
+  optimizePrompt(prompt: string, constraints: PromptConstraints): string {
+    let optimized = prompt;
+
+    // Remove forbidden terms
+    if (constraints.forbiddenTerms && constraints.forbiddenTerms.length > 0) {
+      constraints.forbiddenTerms.forEach(term => {
+        const regex = new RegExp(term, 'gi');
+        optimized = optimized.replace(regex, '[TERM_REMOVED]');
+      });
+    }
+
+    // Optimize for token limit
+    if (constraints.maxTokens) {
+      const estimatedTokens = this.estimateTokens(optimized);
+      if (estimatedTokens > constraints.maxTokens) {
+        optimized = this.truncateToTokenLimit(optimized, constraints.maxTokens);
+      }
+    }
+
+    // Ensure required sections are present
+    if (constraints.requiredSections && constraints.requiredSections.length > 0) {
+      optimized = this.ensureRequiredSections(optimized, constraints.requiredSections);
+    }
+
+    // Apply output format
+    optimized = this.applyOutputFormat(optimized, constraints.outputFormat);
+
+    return optimized;
+  }
+
+  enhanceExistingPrompt(existingPrompt: string, enhancement: ModePromptContext): PromptGenerationResult {
+    const startTime = Date.now();
+
+    // Generate mode-specific enhancement
+    const modeResult = this.modePromptGenerator.generateModeSpecificPrompt(enhancement);
+
+    // Combine existing prompt with enhancement
+    const combinedPrompt = this.combinePrompts(existingPrompt, modeResult.prompt);
+
+    // Optimize the combined prompt
+    const optimizedPrompt = this.optimizePrompt(combinedPrompt, enhancement.constraints);
+
+    return {
+      prompt: optimizedPrompt,
+      metadata: {
+        ...modeResult.metadata,
+        optimizationApplied: [...modeResult.metadata.optimizationApplied, 'existing_prompt_enhancement'],
+        generationTime: Date.now() - startTime
+      },
+      qualityScore: modeResult.qualityScore,
+      warnings: modeResult.warnings
+    };
+  }
+
+  validatePrompt(prompt: string, constraints: PromptConstraints): PromptValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const suggestions: string[] = [];
+
+    // Check token limit
+    const tokenCount = this.estimateTokens(prompt);
+    if (tokenCount > constraints.maxTokens) {
+      errors.push(`Prompt exceeds token limit: ${tokenCount} > ${constraints.maxTokens}`);
+    } else if (tokenCount > constraints.maxTokens * 0.9) {
+      warnings.push('Prompt is close to token limit, consider optimization');
+    }
+
+    // Check required sections
+    if (constraints.requiredSections) {
+      const missingSections = constraints.requiredSections.filter(section =>
+        !prompt.toLowerCase().includes(section.toLowerCase())
+      );
+      if (missingSections.length > 0) {
+        errors.push(`Missing required sections: ${missingSections.join(', ')}`);
+      }
+    }
+
+    // Check forbidden terms
+    if (constraints.forbiddenTerms) {
+      const foundTerms = constraints.forbiddenTerms.filter(term =>
+        prompt.toLowerCase().includes(term.toLowerCase())
+      );
+      if (foundTerms.length > 0) {
+        errors.push(`Contains forbidden terms: ${foundTerms.join(', ')}`);
+      }
+    }
+
+    // Quality suggestions
+    if (prompt.length < 100) {
+      suggestions.push('Prompt might be too short for effective guidance');
+    }
+    if (prompt.length > 10000) {
+      suggestions.push('Prompt might be too long, consider breaking into sections');
+    }
+    if (!prompt.includes('task') && !prompt.includes('Task')) {
+      suggestions.push('Consider making the task description more explicit');
+    }
+
+    return {
+      isValid: errors.length === 0,
+      errors,
+      warnings,
+      suggestions
+    };
+  }
+
+  // estimateTokensメソッドは、複数のクラスで共通のロジックを使用しています。
+  // 実際の開発時には、このロジックを src/create-prompt/utils.ts のような共通ユーティリティファイルに集約し、
+  // 各クラスからインポートして使用することを推奨します。
+  // これにより、コードの重複を避け、メンテナンス性を向上させることができます。
+  estimateTokens(text: string): number {
+    const words = text.split(/\s+/).length;
+    const chars = text.length;
+    const wordBasedTokens = words * 0.75;
+    const charBasedTokens = chars / 4;
+    return Math.ceil((wordBasedTokens + charBasedTokens) / 2);
+  }
+
+  private truncateToTokenLimit(prompt: string, maxTokens: number): string {
+    const targetChars = maxTokens * 4; // Rough estimation
+
+    if (prompt.length <= targetChars) {
+      return prompt;
+    }
+
+    // Truncate at sentence boundaries when possible
+    const sentences = prompt.split(/[.!?]+/);
+    let result = '';
+
+    for (const sentence of sentences) {
+      if ((result + sentence).length > targetChars - 100) { // Leave buffer
+        break;
+      }
+      result += sentence + '.';
+    }
+
+    return result + '\n\n[Content truncated to fit token limit]';
+  }
+
+  private ensureRequiredSections(prompt: string, requiredSections: string[]): string {
+    let enhanced = prompt;
+
+    const missingSections = requiredSections.filter(section =>
+      !prompt.toLowerCase().includes(section.toLowerCase())
+    );
+
+    if (missingSections.length > 0) {
+      enhanced += '\n\n## Required Sections\n';
+      enhanced += 'Please ensure your response includes:\n';
+      missingSections.forEach(section => {
+        enhanced += `- ${section}\n`;
+      });
+    }
+
+    return enhanced;
+  }
+
+  private applyOutputFormat(prompt: string, format: string): string {
+    switch (format) {
+      case 'json':
+        return `${prompt}\n\nPlease provide your response in valid JSON format.`;
+      case 'yaml':
+        return `${prompt}\n\nPlease provide your response in YAML format.`;
+      case 'code':
+        return `${prompt}\n\nPlease provide your response primarily as code with minimal explanatory text.`;
+      case 'markdown':
+      default:
+        return `${prompt}\n\nPlease provide your response in well-formatted Markdown.`;
+    }
+  }
+
+  private combinePrompts(existing: string, enhancement: string): string {
+    return `${existing}\n\n---\n\n## Additional Context\n\n${enhancement}`;
+  }
+}
+```
+
+## コミット計画
+
+### コミット1: プロンプト拡張型定義
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/create-prompt/types.ts
+git commit -m "feat(create-prompt): add prompt extension type definitions"
+```
+
+### コミット2: モード別プロンプト生成エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/create-prompt/mode-prompt-generator.ts test/create-prompt/mode-prompt-generator.test.ts
+git commit -m "feat(create-prompt): implement mode-specific prompt generation engine with tests"
+```
+
+### コミット3: サブタスクプロンプト生成エンジン
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/create-prompt/subtask-prompt-generator.ts test/create-prompt/subtask-prompt-generator.test.ts
+git commit -m "feat(create-prompt): implement subtask prompt generation engine with tests"
+```
+
+### コミット4: プロンプト拡張統合クラス
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/create-prompt/prompt-extension.ts test/create-prompt/prompt-extension.test.ts
+git commit -m "feat(create-prompt): implement prompt extension integration class with tests"
+```
+
+### コミット5: エクスポート更新
+```bash
+# プリコミットチェック
+bun test
+bun run format:check
+bun run typecheck
+
+# 全てのチェックが通った場合のみコミット
+git add src/create-prompt/index.ts
+git commit -m "feat(create-prompt): add prompt extension exports"
+```
+
+## ディレクトリ構造
+
+```
+src/
+└── create-prompt/
+    ├── index.ts                     # 既存のプロンプト生成（拡張）
+    ├── types.ts                     # プロンプト拡張型定義
+    ├── mode-prompt-generator.ts     # モード別プロンプト生成エンジン
+    ├── subtask-prompt-generator.ts  # サブタスクプロンプト生成エンジン
+    └── prompt-extension.ts          # プロンプト拡張統合クラス
+
+test/
+└── create-prompt/
+    ├── mode-prompt-generator.test.ts
+    ├── subtask-prompt-generator.test.ts
+    └── prompt-extension.test.ts
+```
+
+## index.tsの更新
+
+```typescript
+// src/create-prompt/index.ts
+
+// 既存のエクスポート（変更なし）
+export { createPrompt } from './prompt-creator'; // 既存の関数
+
+// 新しいプロンプト拡張エクスポート
+export type {
+  PromptTemplate,
+  PromptConstraints,
+  QualityScore,
+  ModePromptContext,
+  SubtaskPromptContext,
+  PromptGenerationResult,
+  PromptMetadata,
+  PromptValidationResult
+} from './types';
+
+export { ModePromptGenerator } from './mode-prompt-generator';
+export { SubtaskPromptGenerator } from './subtask-prompt-generator';
+export { PromptExtension } from './prompt-extension';
+```
+
+## 統合テスト
+
+```typescript
+// test/create-prompt/integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { PromptExtension } from '../../src/create-prompt/prompt-extension';
+import { TaskAnalyzer } from '../../src/orchestration/task-analyzer';
+
+describe('Prompt Extension Integration', () => {
+  test('should integrate with orchestration system', () => {
+    const promptExtension = new PromptExtension();
+    const taskAnalyzer = new TaskAnalyzer();
+
+    // Analyze a complex task
+    const complexTask = `
+      Create a complete user management system with:
+      1. User registration and authentication
+      2. Profile management
+      3. Admin dashboard
+      4. Email notifications
+    `;
+
+    const analysis = taskAnalyzer.analyzeTask(complexTask);
+    expect(analysis.requiresOrchestration).toBe(true);
+
+    // Generate prompts for each required mode
+    analysis.requiredModes.forEach(mode => {
+      const context = {
+        mode,
+        taskDescription: complexTask,
+        globalContext: { framework: 'React', backend: 'Node.js' },
+        previousResults: [],
+        constraints: {
+          maxTokens: 4000,
+          requiredSections: ['implementation', 'testing'],
+          forbiddenTerms: [],
+          outputFormat: 'markdown' as const
+        }
+      };
+
+      const modeObj = { slug: mode, name: mode, roleDefinition: '', groups: [] };
+      const result = promptExtension.createPromptForMode(context, modeObj);
+
+      expect(result.prompt).toBeTruthy();
+      expect(result.metadata.mode).toBe(mode);
+      expect(result.qualityScore.overall).toBeGreaterThan(0.6);
+    });
+  });
+
+  test('should optimize prompts for token constraints', () => {
+    const promptExtension = new PromptExtension();
+
+    const longContext = {
+      mode: 'code',
+      taskDescription: 'Implement feature ' + 'with many details '.repeat(100),
+      globalContext: { detail: 'very long context '.repeat(50) },
+      previousResults: ['result '.repeat(30)],
+      constraints: {
+        maxTokens: 1000,
+        requiredSections: ['implementation'],
+        forbiddenTerms: [],
+        outputFormat: 'markdown' as const
+      }
+    };
+
+    const modeObj = { slug: 'code', name: 'Code', roleDefinition: '', groups: [] };
+    const result = promptExtension.createPromptForMode(longContext, modeObj);
+
+    expect(promptExtension.estimateTokens(result.prompt)).toBeLessThan(1000);
+    expect(result.metadata.optimizationApplied).toContain('token_optimization');
+  });
+});
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase2-context-optimizer から作業ブランチを作成
+git checkout phase2-context-optimizer
+git pull origin phase2-context-optimizer # 念のため最新化
+git checkout -b phase3-prompt-extension phase2-context-optimizer
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファイトで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(prompt-extension): implement prompt extension" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase3-prompt-extension
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase2-context-optimizer とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase2-context-optimizer
+git pull origin phase2-context-optimizer
+git branch -d phase3-prompt-extension
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase2-context-optimizer から作業ブランチ作成
+git checkout phase2-context-optimizer
+git pull origin phase2-context-optimizer # 念のため最新化
+git checkout -b phase3-prompt-extension phase2-context-optimizer
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(prompt-extension): implement prompt extension" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase3-prompt-extension
+# GitHub上で phase2-context-optimizer をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase2-context-optimizer
+git pull origin phase2-context-optimizer
+git branch -d phase3-prompt-extension
+```
+
+## 依存関係
+
+このフェーズはフェーズ2（タスク分析、コンテキスト最適化）完了後に実装してください。以下のフェーズに必要となります：
+- フェーズ3.2: GitHub Actions統合（拡張されたプロンプト生成の活用）
+- フェーズ4: MCP拡張（プロンプト生成ツール）
+
+## 次のステップ
+
+1. フェーズ3.2でGitHub Actionsとの統合（この拡張プロンプト生成を活用）
+2. フェーズ4でMCPツールの拡張
+
+**💡 重要な点**: 既存のプロンプト生成システムとの互換性を保ちながら、モード別・サブタスク別の最適化を提供することで、AI応答の精度と効率を向上させることが重要です。

--- a/predev-docs/07-phase3-github-actions-design.md
+++ b/predev-docs/07-phase3-github-actions-design.md
@@ -5,6 +5,7 @@
 GitHub Actions統合では、オーケストレーション機能をGitHub Actionsワークフローに組み込み、サブタスクの実行管理とプログレストラッキングを実装します。既存のGitHub Actionsインフラを拡張し、複雑なタスクの分解と並列/順次実行を可能にします。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -113,7 +114,7 @@ classDiagram
 
 ```typescript
 // test/github/operations/orchestration-types.test.ts
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect } from "bun:test";
 import type {
   OrchestrationResult,
   ExecutionPlan,
@@ -122,26 +123,26 @@ import type {
   BoomerangRequest,
   BoomerangResult,
   ErrorRecoveryInfo,
-  ExecutionMetrics
-} from '../../../src/github/operations/orchestration-types';
+  ExecutionMetrics,
+} from "../../../src/github/operations/orchestration-types";
 
-describe('Orchestration Types', () => {
-  test('should define OrchestrationResult correctly', () => {
+describe("Orchestration Types", () => {
+  test("should define OrchestrationResult correctly", () => {
     const result: OrchestrationResult = {
       success: true,
-      taskId: 'main-task-1',
+      taskId: "main-task-1",
       subtaskResults: [
         {
-          taskId: 'subtask-1',
+          taskId: "subtask-1",
           success: true,
-          output: 'Component implemented',
+          output: "Component implemented",
           duration: 120,
-          tokensUsed: 1500
-        }
+          tokensUsed: 1500,
+        },
       ],
       totalDuration: 300,
       totalTokensUsed: 5000,
-      summary: 'All subtasks completed successfully'
+      summary: "All subtasks completed successfully",
     };
 
     expect(result.success).toBe(true);
@@ -149,85 +150,85 @@ describe('Orchestration Types', () => {
     expect(result.totalTokensUsed).toBe(5000);
   });
 
-  test('should define ExecutionPlan correctly', () => {
+  test("should define ExecutionPlan correctly", () => {
     const plan: ExecutionPlan = {
       phases: [
         {
-          phaseId: 'phase-1',
-          name: 'Initial Setup',
-          subtasks: ['subtask-1', 'subtask-2'],
-          executionType: 'parallel',
-          estimatedDuration: 60
-        }
+          phaseId: "phase-1",
+          name: "Initial Setup",
+          subtasks: ["subtask-1", "subtask-2"],
+          executionType: "parallel",
+          estimatedDuration: 60,
+        },
       ],
       dependencies: {
-        'subtask-3': ['subtask-1', 'subtask-2'],
-        'subtask-4': ['subtask-3']
+        "subtask-3": ["subtask-1", "subtask-2"],
+        "subtask-4": ["subtask-3"],
       },
       estimatedTotalDuration: 180,
-      criticalPath: ['subtask-1', 'subtask-3', 'subtask-4']
+      criticalPath: ["subtask-1", "subtask-3", "subtask-4"],
     };
 
     expect(plan.phases.length).toBe(1);
-    expect(plan.phases[0].executionType).toBe('parallel');
+    expect(plan.phases[0].executionType).toBe("parallel");
     expect(plan.criticalPath.length).toBe(3);
   });
 
-  test('should define ProgressUpdate correctly', () => {
+  test("should define ProgressUpdate correctly", () => {
     const progress: ProgressUpdate = {
-      taskId: 'subtask-1',
-      status: 'in_progress',
+      taskId: "subtask-1",
+      status: "in_progress",
       percentComplete: 75,
-      currentStep: 'Running tests',
+      currentStep: "Running tests",
       startTime: new Date(),
-      estimatedTimeRemaining: 30
+      estimatedTimeRemaining: 30,
     };
 
-    expect(progress.status).toBe('in_progress');
+    expect(progress.status).toBe("in_progress");
     expect(progress.percentComplete).toBe(75);
-    expect(progress.currentStep).toBe('Running tests');
+    expect(progress.currentStep).toBe("Running tests");
   });
 
-  test('should define BoomerangRequest correctly', () => {
+  test("should define BoomerangRequest correctly", () => {
     const request: BoomerangRequest = {
-      task: 'Refactor component X',
-      targetMode: 'code-refactor',
+      task: "Refactor component X",
+      targetMode: "code-refactor",
       returnContext: true,
-      preserveResults: false
+      preserveResults: false,
     };
-    expect(request.targetMode).toBe('code-refactor');
+    expect(request.targetMode).toBe("code-refactor");
     expect(request.preserveResults).toBe(false);
   });
 
-  test('should define BoomerangResult correctly', () => {
+  test("should define BoomerangResult correctly", () => {
     const result: BoomerangResult = {
       success: true,
-      delegatedMode: 'code-refactor',
-      result: 'Component X refactored successfully.',
+      delegatedMode: "code-refactor",
+      result: "Component X refactored successfully.",
       tokensUsed: 250,
-      duration: 60
+      duration: 60,
     };
     expect(result.success).toBe(true);
     expect(result.tokensUsed).toBe(250);
   });
 
-  test('should define ErrorRecoveryInfo correctly', () => {
+  test("should define ErrorRecoveryInfo correctly", () => {
     const recoveryInfo: ErrorRecoveryInfo = {
-      strategy: 'retry',
+      strategy: "retry",
       attempts: 3,
-      recoveredTasks: ['task-A'],
-      unrecoverableTasks: ['task-B']
+      recoveredTasks: ["task-A"],
+      unrecoverableTasks: ["task-B"],
     };
-    expect(recoveryInfo.strategy).toBe('retry');
+    expect(recoveryInfo.strategy).toBe("retry");
     expect(recoveryInfo.recoveredTasks.length).toBe(1);
   });
 
-  test('should define ExecutionMetrics correctly', () => {
+  test("should define ExecutionMetrics correctly", () => {
     const metrics: ExecutionMetrics = {
       startTime: new Date(),
       tokensUsed: 1200,
       subtasksCompleted: 3,
-      subtasksFailed: 0
+      subtasksFailed: 0,
     };
     // endTime, duration, parallelizationEfficiency はオプショナルなので、必須項目のみテスト
     expect(metrics.tokensUsed).toBe(1200);
@@ -239,7 +240,7 @@ describe('Orchestration Types', () => {
 #### 実装: src/github/operations/orchestration-types.ts
 
 ```typescript
-import type { TaskResult } from '../../tasks/types';
+import type { TaskResult } from "../../tasks/types";
 
 export interface OrchestrationResult {
   success: boolean;
@@ -266,13 +267,13 @@ export interface ExecutionPhase {
   phaseId: string;
   name: string;
   subtasks: string[];
-  executionType: 'parallel' | 'sequential';
+  executionType: "parallel" | "sequential";
   estimatedDuration: number;
 }
 
 export interface ProgressUpdate {
   taskId: string;
-  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  status: "pending" | "in_progress" | "completed" | "failed";
   percentComplete: number;
   currentStep?: string;
   startTime?: Date;
@@ -307,7 +308,7 @@ export interface BoomerangResult {
 }
 
 export interface ErrorRecoveryInfo {
-  strategy: 'retry' | 'skip' | 'fallback';
+  strategy: "retry" | "skip" | "fallback";
   attempts: number;
   recoveredTasks: string[];
   unrecoverableTasks: string[];
@@ -330,34 +331,34 @@ export interface ExecutionMetrics {
 
 ```typescript
 // test/entrypoints/orchestrate.test.ts
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
-import { OrchestrationEntrypoint } from '../../src/entrypoints/orchestrate';
-import type { GitHubContext } from '../../src/github/context';
-import { ProgressTracker } from '../../src/github/operations/progress-tracker';
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { OrchestrationEntrypoint } from "../../src/entrypoints/orchestrate";
+import type { GitHubContext } from "../../src/github/context";
+import { ProgressTracker } from "../../src/github/operations/progress-tracker";
 
-describe('OrchestrationEntrypoint', () => {
+describe("OrchestrationEntrypoint", () => {
   let entrypoint: OrchestrationEntrypoint;
   let mockContext: GitHubContext;
 
   beforeEach(() => {
     mockContext = {
-      eventType: 'issue_comment',
-      repository: { owner: 'test', name: 'repo' },
-      issue: { number: 1, title: 'Test Issue' },
-      comment: { id: 123, body: '/claude orchestrate complex task' }
+      eventType: "issue_comment",
+      repository: { owner: "test", name: "repo" },
+      issue: { number: 1, title: "Test Issue" },
+      comment: { id: 123, body: "/claude orchestrate complex task" },
     } as GitHubContext;
 
     entrypoint = new OrchestrationEntrypoint(mockContext);
   });
 
-  test('should prepare orchestration environment', async () => {
+  test("should prepare orchestration environment", async () => {
     await entrypoint.prepare();
 
     // Verify MCP server installation, mode system initialization, etc.
     expect(entrypoint.isReady()).toBe(true);
   });
 
-  test('should execute orchestration for complex task', async () => {
+  test("should execute orchestration for complex task", async () => {
     await entrypoint.prepare();
 
     const result = await entrypoint.execute();
@@ -366,30 +367,31 @@ describe('OrchestrationEntrypoint', () => {
     expect(result.subtaskResults.length).toBeGreaterThan(0);
   });
 
-  test('should update comment with progress', async () => {
+  test("should update comment with progress", async () => {
     const progressUpdatePayload = {
-      taskId: 'subtask-1',
-      status: 'completed' as const,
-      percentComplete: 100
+      taskId: "subtask-1",
+      status: "completed" as const,
+      percentComplete: 100,
     };
     await entrypoint.updateProgress(progressUpdatePayload);
 
-    const mockedProgressTrackerInstance = ProgressTracker.mock.results[0]?.value;
+    const mockedProgressTrackerInstance =
+      ProgressTracker.mock.results[0]?.value;
     if (mockedProgressTrackerInstance) {
       expect(mockedProgressTrackerInstance.updateProgress).toHaveBeenCalledWith(
         progressUpdatePayload.taskId,
-        progressUpdatePayload
+        progressUpdatePayload,
       );
     }
   });
 
-  test('should handle errors gracefully', async () => {
-    const error = new Error('Orchestration failed');
+  test("should handle errors gracefully", async () => {
+    const error = new Error("Orchestration failed");
 
     await entrypoint.handleError(error);
 
     // Should update comment with error message
-    expect(entrypoint.getLastComment()).toContain('Error');
+    expect(entrypoint.getLastComment()).toContain("Error");
   });
 });
 ```
@@ -397,14 +399,17 @@ describe('OrchestrationEntrypoint', () => {
 #### 実装: src/entrypoints/orchestrate.ts
 
 ```typescript
-import { GitHubContext } from '../github/context';
-import { TaskManager } from '../tasks/task-manager';
-import { TaskAnalyzer } from '../orchestration/task-analyzer';
-import { ContextOptimizer } from '../orchestration/context-optimizer';
-import { modeManager } from '../modes/mode-manager';
-import { SubtaskExecutionManager } from '../github/operations/subtask-execution';
-import { ProgressTracker } from '../github/operations/progress-tracker';
-import type { OrchestrationResult, ProgressUpdate } from '../github/operations/orchestration-types';
+import { GitHubContext } from "../github/context";
+import { TaskManager } from "../tasks/task-manager";
+import { TaskAnalyzer } from "../orchestration/task-analyzer";
+import { ContextOptimizer } from "../orchestration/context-optimizer";
+import { modeManager } from "../modes/mode-manager";
+import { SubtaskExecutionManager } from "../github/operations/subtask-execution";
+import { ProgressTracker } from "../github/operations/progress-tracker";
+import type {
+  OrchestrationResult,
+  ProgressUpdate,
+} from "../github/operations/orchestration-types";
 
 export class OrchestrationEntrypoint {
   private githubContext: GitHubContext;
@@ -428,9 +433,9 @@ export class OrchestrationEntrypoint {
       this.taskManager,
       new TaskAnalyzer(),
       new ContextOptimizer(),
-      modeManager // Note: When testing AutoOrchestrator, modeManager will need to be mocked
-                  // or a test-specific instance provided to control its behavior and
-                  // dependencies, especially for methods like getModeBySlug.
+      modeManager, // Note: When testing AutoOrchestrator, modeManager will need to be mocked
+      // or a test-specific instance provided to control its behavior and
+      // dependencies, especially for methods like getModeBySlug.
     );
 
     this.isInitialized = true;
@@ -438,7 +443,7 @@ export class OrchestrationEntrypoint {
 
   async execute(): Promise<OrchestrationResult> {
     if (!this.isInitialized) {
-      throw new Error('Orchestration not initialized. Call prepare() first.');
+      throw new Error("Orchestration not initialized. Call prepare() first.");
     }
 
     try {
@@ -491,19 +496,19 @@ export class OrchestrationEntrypoint {
   private extractTaskInfo(): TaskInfo {
     return {
       id: `task-${Date.now()}`,
-      title: this.githubContext.issue?.title || 'Task',
-      description: this.githubContext.issue?.body || '',
+      title: this.githubContext.issue?.title || "Task",
+      description: this.githubContext.issue?.body || "",
       issueNumber: this.githubContext.issue?.number || 0,
       repository: {
         owner: this.githubContext.repository.owner,
-        name: this.githubContext.repository.name
-      }
+        name: this.githubContext.repository.name,
+      },
     };
   }
 
   private extractTaskDescription(): string {
-    const issueBody = this.githubContext.issue?.body || '';
-    const commentBody = this.githubContext.comment?.body || '';
+    const issueBody = this.githubContext.issue?.body || "";
+    const commentBody = this.githubContext.comment?.body || "";
     return `${issueBody}\n\n${commentBody}`;
   }
 }
@@ -513,7 +518,7 @@ export class AutoOrchestrator {
     private taskManager: TaskManager,
     private taskAnalyzer: TaskAnalyzer,
     private contextOptimizer: ContextOptimizer,
-    private modeManager: typeof modeManager
+    private modeManager: typeof modeManager,
   ) {}
 
   async orchestrateTask(taskDescription: string): Promise<OrchestrationResult> {
@@ -533,16 +538,16 @@ export class AutoOrchestrator {
     const executionManager = new SubtaskExecutionManager();
     const results = await executionManager.executeDependencyGraph({
       nodes: subtasks,
-      edges: this.createDependencyEdges(executionPlan)
+      edges: this.createDependencyEdges(executionPlan),
     });
 
     return {
-      success: results.every(r => r.success),
+      success: results.every((r) => r.success),
       taskId: `main-${Date.now()}`,
       subtaskResults: results,
       totalDuration: Date.now() - startTime,
       totalTokensUsed: results.reduce((sum, r) => sum + (r.tokensUsed || 0), 0),
-      summary: this.generateSummary(results)
+      summary: this.generateSummary(results),
     };
   }
 
@@ -551,14 +556,18 @@ export class AutoOrchestrator {
     const executionManager = new SubtaskExecutionManager();
 
     // Group subtasks by dependencies
-    const independentTasks = subtasks.filter(t => t.dependencies.length === 0);
-    const dependentTasks = subtasks.filter(t => t.dependencies.length > 0);
+    const independentTasks = subtasks.filter(
+      (t) => t.dependencies.length === 0,
+    );
+    const dependentTasks = subtasks.filter((t) => t.dependencies.length > 0);
 
     // Execute independent tasks in parallel
-    const independentResults = await executionManager.executeParallel(independentTasks);
+    const independentResults =
+      await executionManager.executeParallel(independentTasks);
 
     // Execute dependent tasks sequentially
-    const dependentResults = await executionManager.executeSequential(dependentTasks);
+    const dependentResults =
+      await executionManager.executeSequential(dependentTasks);
 
     return [...independentResults, ...dependentResults];
   }
@@ -570,7 +579,7 @@ export class AutoOrchestrator {
       taskDescription: request.task,
       previousResults: [],
       globalContext: {},
-      maxTokens: 4000
+      maxTokens: 4000,
     });
 
     // Execute task in specified mode
@@ -581,7 +590,7 @@ export class AutoOrchestrator {
       success: true,
       output: result,
       duration: 0,
-      tokensUsed: 0
+      tokensUsed: 0,
     };
   }
 
@@ -594,7 +603,7 @@ export class AutoOrchestrator {
       phases,
       dependencies: this.extractDependencies(subtasks),
       estimatedTotalDuration: this.estimateTotalDuration(phases),
-      criticalPath
+      criticalPath,
     };
   }
 
@@ -615,35 +624,35 @@ export class AutoOrchestrator {
 
 ```typescript
 // test/github/operations/subtask-execution.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { SubtaskExecutionManager } from '../../../src/github/operations/subtask-execution';
-import type { SubTask } from '../../../src/orchestration/types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { SubtaskExecutionManager } from "../../../src/github/operations/subtask-execution";
+import type { SubTask } from "../../../src/orchestration/types";
 
-describe('SubtaskExecutionManager', () => {
+describe("SubtaskExecutionManager", () => {
   let manager: SubtaskExecutionManager;
 
   beforeEach(() => {
     manager = new SubtaskExecutionManager();
   });
 
-  test('should execute independent subtasks in parallel', async () => {
+  test("should execute independent subtasks in parallel", async () => {
     const subtasks: SubTask[] = [
       {
-        id: 'subtask-1',
-        description: 'Task 1',
-        mode: 'code',
+        id: "subtask-1",
+        description: "Task 1",
+        mode: "code",
         priority: 1,
         dependencies: [],
-        estimatedComplexity: 3
+        estimatedComplexity: 3,
       },
       {
-        id: 'subtask-2',
-        description: 'Task 2',
-        mode: 'code',
+        id: "subtask-2",
+        description: "Task 2",
+        mode: "code",
         priority: 1,
         dependencies: [],
-        estimatedComplexity: 3
-      }
+        estimatedComplexity: 3,
+      },
     ];
 
     const startTime = Date.now();
@@ -651,76 +660,76 @@ describe('SubtaskExecutionManager', () => {
     const duration = Date.now() - startTime;
 
     expect(results.length).toBe(2);
-    expect(results.every(r => r.success)).toBe(true);
+    expect(results.every((r) => r.success)).toBe(true);
     // Parallel execution should be faster than sequential
     expect(duration).toBeLessThan(subtasks.length * 1000);
   });
 
-  test('should execute dependent subtasks sequentially', async () => {
+  test("should execute dependent subtasks sequentially", async () => {
     const subtasks: SubTask[] = [
       {
-        id: 'subtask-1',
-        description: 'Base task',
-        mode: 'code',
+        id: "subtask-1",
+        description: "Base task",
+        mode: "code",
         priority: 1,
         dependencies: [],
-        estimatedComplexity: 3
+        estimatedComplexity: 3,
       },
       {
-        id: 'subtask-2',
-        description: 'Dependent task',
-        mode: 'code',
+        id: "subtask-2",
+        description: "Dependent task",
+        mode: "code",
         priority: 2,
-        dependencies: ['subtask-1'],
-        estimatedComplexity: 3
-      }
+        dependencies: ["subtask-1"],
+        estimatedComplexity: 3,
+      },
     ];
 
     const results = await manager.executeSequential(subtasks);
 
     expect(results.length).toBe(2);
-    expect(results[0].taskId).toBe('subtask-1');
-    expect(results[1].taskId).toBe('subtask-2');
+    expect(results[0].taskId).toBe("subtask-1");
+    expect(results[1].taskId).toBe("subtask-2");
   });
 
-  test('should execute dependency graph correctly', async () => {
+  test("should execute dependency graph correctly", async () => {
     const graph = {
       nodes: [
-        { id: 'A', mode: 'code', dependencies: [] },
-        { id: 'B', mode: 'code', dependencies: ['A'] },
-        { id: 'C', mode: 'code', dependencies: ['A'] },
-        { id: 'D', mode: 'code', dependencies: ['B', 'C'] }
+        { id: "A", mode: "code", dependencies: [] },
+        { id: "B", mode: "code", dependencies: ["A"] },
+        { id: "C", mode: "code", dependencies: ["A"] },
+        { id: "D", mode: "code", dependencies: ["B", "C"] },
       ],
       edges: [
-        { from: 'A', to: 'B', type: 'sequential' },
-        { from: 'A', to: 'C', type: 'sequential' },
-        { from: 'B', to: 'D', type: 'sequential' },
-        { from: 'C', to: 'D', type: 'sequential' }
-      ]
+        { from: "A", to: "B", type: "sequential" },
+        { from: "A", to: "C", type: "sequential" },
+        { from: "B", to: "D", type: "sequential" },
+        { from: "C", to: "D", type: "sequential" },
+      ],
     };
 
     const results = await manager.executeDependencyGraph(graph);
 
     expect(results.length).toBe(4);
     // A should complete before B and C
-    const aIndex = results.findIndex(r => r.taskId === 'A');
-    const bIndex = results.findIndex(r => r.taskId === 'B');
-    const cIndex = results.findIndex(r => r.taskId === 'C');
-    const dIndex = results.findIndex(r => r.taskId === 'D');
+    const aIndex = results.findIndex((r) => r.taskId === "A");
+    const bIndex = results.findIndex((r) => r.taskId === "B");
+    const cIndex = results.findIndex((r) => r.taskId === "C");
+    const dIndex = results.findIndex((r) => r.taskId === "D");
 
     expect(aIndex).toBeLessThan(bIndex);
     expect(aIndex).toBeLessThan(cIndex);
     expect(dIndex).toBe(3); // D should be last
   });
 
-  test('should monitor progress during execution', async () => {
+  test("should monitor progress during execution", async () => {
     const subtask: SubTask = {
-      id: 'subtask-1',
-      description: 'Monitored task',
-      mode: 'code',
+      id: "subtask-1",
+      description: "Monitored task",
+      mode: "code",
       priority: 1,
       dependencies: [],
-      estimatedComplexity: 5
+      estimatedComplexity: 5,
     };
 
     let progressUpdates: ProgressUpdate[] = [];
@@ -731,8 +740,8 @@ describe('SubtaskExecutionManager', () => {
     await manager.executeParallel([subtask]);
 
     expect(progressUpdates.length).toBeGreaterThan(0);
-    expect(progressUpdates.some(u => u.status === 'in_progress')).toBe(true);
-    expect(progressUpdates.some(u => u.status === 'completed')).toBe(true);
+    expect(progressUpdates.some((u) => u.status === "in_progress")).toBe(true);
+    expect(progressUpdates.some((u) => u.status === "completed")).toBe(true);
   });
 });
 ```
@@ -740,10 +749,14 @@ describe('SubtaskExecutionManager', () => {
 #### 実装: src/github/operations/subtask-execution.ts
 
 ```typescript
-import type { SubTask, TaskResult, DependencyGraph } from '../../orchestration/types';
-import type { ProgressUpdate } from './orchestration-types';
-import { PromptExtension } from '../../create-prompt/prompt-extension';
-import { taskManager } from '../../tasks/task-manager';
+import type {
+  SubTask,
+  TaskResult,
+  DependencyGraph,
+} from "../../orchestration/types";
+import type { ProgressUpdate } from "./orchestration-types";
+import { PromptExtension } from "../../create-prompt/prompt-extension";
+import { taskManager } from "../../tasks/task-manager";
 
 export class SubtaskExecutionManager {
   private executionQueue: ExecutionQueue;
@@ -758,7 +771,7 @@ export class SubtaskExecutionManager {
   }
 
   async executeParallel(subtasks: SubTask[]): Promise<TaskResult[]> {
-    const promises = subtasks.map(subtask => this.executeSubtask(subtask));
+    const promises = subtasks.map((subtask) => this.executeSubtask(subtask));
     return Promise.all(promises);
   }
 
@@ -784,7 +797,7 @@ export class SubtaskExecutionManager {
     const executing = new Map<string, Promise<TaskResult>>();
 
     const executeNode = async (nodeId: string): Promise<TaskResult> => {
-      const node = graph.nodes.find(n => n.id === nodeId);
+      const node = graph.nodes.find((n) => n.id === nodeId);
       if (!node) throw new Error(`Node ${nodeId} not found`);
 
       // Wait for dependencies
@@ -810,8 +823,8 @@ export class SubtaskExecutionManager {
     };
 
     // Execute all nodes
-    const rootNodes = graph.nodes.filter(n => n.dependencies.length === 0);
-    await Promise.all(rootNodes.map(n => executeNode(n.id)));
+    const rootNodes = graph.nodes.filter((n) => n.dependencies.length === 0);
+    await Promise.all(rootNodes.map((n) => executeNode(n.id)));
 
     // Execute remaining nodes
     for (const node of graph.nodes) {
@@ -833,7 +846,7 @@ export class SubtaskExecutionManager {
       currentStep: this.getCurrentStep(task),
       startTime: task.createdAt,
       endTime: task.result ? task.updatedAt : undefined,
-      estimatedTimeRemaining: this.estimateTimeRemaining(task)
+      estimatedTimeRemaining: this.estimateTimeRemaining(task),
     };
   }
 
@@ -847,9 +860,9 @@ export class SubtaskExecutionManager {
     // Update progress: starting
     this.notifyProgress({
       taskId: subtask.id,
-      status: 'in_progress',
+      status: "in_progress",
       percentComplete: 0,
-      currentStep: 'Initializing'
+      currentStep: "Initializing",
     });
 
     try {
@@ -861,20 +874,23 @@ export class SubtaskExecutionManager {
           previousResults: this.getPreviousResults(subtask.dependencies),
           globalContext: {},
           modeSpecificContext: {},
-          maxTokens: 4000
-        }
+          maxTokens: 4000,
+        },
       });
 
       // Generate prompt
       const promptExtension = new PromptExtension();
-      const promptResult = promptExtension.createPromptForSubtask(subtask, task.context);
+      const promptResult = promptExtension.createPromptForSubtask(
+        subtask,
+        task.context,
+      );
 
       // Update progress: executing
       this.notifyProgress({
         taskId: subtask.id,
-        status: 'in_progress',
+        status: "in_progress",
         percentComplete: 50,
-        currentStep: 'Executing'
+        currentStep: "Executing",
       });
 
       // Execute (simulated - in real implementation, this would call Claude API)
@@ -886,7 +902,7 @@ export class SubtaskExecutionManager {
         success: true,
         output,
         duration: Date.now() - startTime,
-        tokensUsed: promptResult.metadata.tokensUsed
+        tokensUsed: promptResult.metadata.tokensUsed,
       };
 
       taskManager.updateTaskResult(task.id, result);
@@ -894,9 +910,9 @@ export class SubtaskExecutionManager {
       // Update progress: completed
       this.notifyProgress({
         taskId: subtask.id,
-        status: 'completed',
+        status: "completed",
         percentComplete: 100,
-        currentStep: 'Completed'
+        currentStep: "Completed",
       });
 
       return result;
@@ -904,38 +920,43 @@ export class SubtaskExecutionManager {
       // Update progress: failed
       this.notifyProgress({
         taskId: subtask.id,
-        status: 'failed',
+        status: "failed",
         percentComplete: 0,
-        currentStep: 'Failed'
+        currentStep: "Failed",
       });
 
       return {
         taskId: subtask.id,
         success: false,
         error: error.message,
-        duration: Date.now() - startTime
+        duration: Date.now() - startTime,
       };
     }
   }
 
   private getPreviousResults(dependencies: string[]): string[] {
-    return dependencies.map(depId => {
+    return dependencies.map((depId) => {
       const result = this.resultAggregator.getResult(depId);
       return result?.output || `Result from ${depId}`;
     });
   }
 
-  private async simulateExecution(prompt: string, subtask: SubTask): Promise<string> {
+  private async simulateExecution(
+    prompt: string,
+    subtask: SubTask,
+  ): Promise<string> {
     // Simulate API call delay
-    await new Promise(resolve => setTimeout(resolve, 500 + Math.random() * 500));
+    await new Promise((resolve) =>
+      setTimeout(resolve, 500 + Math.random() * 500),
+    );
 
     // Return simulated result based on mode
     switch (subtask.mode) {
-      case 'architect':
+      case "architect":
         return `Architecture design for: ${subtask.description}`;
-      case 'code':
+      case "code":
         return `Implementation completed for: ${subtask.description}`;
-      case 'debug':
+      case "debug":
         return `Debugging analysis for: ${subtask.description}`;
       default:
         return `Task completed: ${subtask.description}`;
@@ -943,22 +964,22 @@ export class SubtaskExecutionManager {
   }
 
   private notifyProgress(update: ProgressUpdate): void {
-    this.progressCallbacks.forEach(callback => callback(update));
+    this.progressCallbacks.forEach((callback) => callback(update));
   }
 
   private calculateProgress(task: any): number {
-    if (task.status === 'completed') return 100;
-    if (task.status === 'failed') return 0;
-    if (task.status === 'in_progress') return 50;
+    if (task.status === "completed") return 100;
+    if (task.status === "failed") return 0;
+    if (task.status === "in_progress") return 50;
     return 0;
   }
 
   private getCurrentStep(task: any): string {
-    return task.status === 'in_progress' ? 'Processing' : task.status;
+    return task.status === "in_progress" ? "Processing" : task.status;
   }
 
   private estimateTimeRemaining(task: any): number {
-    if (task.status === 'completed' || task.status === 'failed') return 0;
+    if (task.status === "completed" || task.status === "failed") return 0;
     return 30; // seconds
   }
 }
@@ -992,13 +1013,13 @@ class DependencyResolver {
     const visit = (task: SubTask) => {
       if (visited.has(task.id)) return;
       if (visiting.has(task.id)) {
-        throw new Error('Circular dependency detected');
+        throw new Error("Circular dependency detected");
       }
 
       visiting.add(task.id);
 
       for (const depId of task.dependencies) {
-        const dep = subtasks.find(t => t.id === depId);
+        const dep = subtasks.find((t) => t.id === depId);
         if (dep) visit(dep);
       }
 
@@ -1032,30 +1053,35 @@ class ResultAggregator {
 ## コミット計画
 
 ### コミット1: GitHub統合型定義
+
 ```bash
 git add src/github/operations/orchestration-types.ts test/github/operations/orchestration-types.test.ts
 git commit -m "feat(github): add orchestration type definitions with tests"
 ```
 
 ### コミット2: オーケストレーションエントリーポイント
+
 ```bash
 git add src/entrypoints/orchestrate.ts test/entrypoints/orchestrate.test.ts
 git commit -m "feat(github): implement orchestration entrypoint with tests"
 ```
 
 ### コミット3: サブタスク実行管理
+
 ```bash
 git add src/github/operations/subtask-execution.ts test/github/operations/subtask-execution.test.ts
 git commit -m "feat(github): implement subtask execution manager with tests"
 ```
 
 ### コミット4: プログレストラッキング
+
 ```bash
 git add src/github/operations/progress-tracker.ts test/github/operations/progress-tracker.test.ts
 git commit -m "feat(github): implement progress tracking for orchestration"
 ```
 
 ### コミット5: 統合テスト
+
 ```bash
 git add test/github/operations/orchestration-integration.test.ts
 git commit -m "test(github): add orchestration integration tests"
@@ -1089,30 +1115,30 @@ test/
 
 ```typescript
 // test/github/operations/orchestration-integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { OrchestrationEntrypoint } from '../../../src/entrypoints/orchestrate';
-import { TaskAnalyzer } from '../../../src/orchestration';
+import { describe, test, expect } from "bun:test";
+import { OrchestrationEntrypoint } from "../../../src/entrypoints/orchestrate";
+import { TaskAnalyzer } from "../../../src/orchestration";
 
-describe('GitHub Actions Orchestration Integration', () => {
-  test('should handle complete orchestration workflow', async () => {
+describe("GitHub Actions Orchestration Integration", () => {
+  test("should handle complete orchestration workflow", async () => {
     const context = {
-      eventType: 'issue_comment',
-      repository: { owner: 'test', name: 'repo' },
+      eventType: "issue_comment",
+      repository: { owner: "test", name: "repo" },
       issue: {
         number: 1,
-        title: 'Implement user authentication system',
+        title: "Implement user authentication system",
         body: `
           Create a complete authentication system with:
           - User registration and login
           - Password reset functionality
           - JWT token management
           - Rate limiting
-        `
+        `,
       },
       comment: {
         id: 123,
-        body: '/claude orchestrate'
-      }
+        body: "/claude orchestrate",
+      },
     };
 
     const entrypoint = new OrchestrationEntrypoint(context);
@@ -1125,25 +1151,25 @@ describe('GitHub Actions Orchestration Integration', () => {
 
     expect(result.success).toBe(true);
     expect(result.subtaskResults.length).toBeGreaterThan(2);
-    expect(result.summary).toContain('authentication');
+    expect(result.summary).toContain("authentication");
 
     // Verify comment was updated with progress
     const finalComment = entrypoint.getLastComment();
-    expect(finalComment).toContain('✅');
-    expect(finalComment).toContain('Completed');
+    expect(finalComment).toContain("✅");
+    expect(finalComment).toContain("Completed");
   });
 
-  test('should show progress in GitHub comment', async () => {
+  test("should show progress in GitHub comment", async () => {
     const context = {
-      eventType: 'issue_comment',
-      repository: { owner: 'test', name: 'repo' },
+      eventType: "issue_comment",
+      repository: { owner: "test", name: "repo" },
       issue: {
         number: 1,
-        title: 'Complex feature request'
+        title: "Complex feature request",
       },
       comment: {
-        body: '/claude orchestrate'
-      }
+        body: "/claude orchestrate",
+      },
     };
 
     const entrypoint = new OrchestrationEntrypoint(context);
@@ -1158,8 +1184,8 @@ describe('GitHub Actions Orchestration Integration', () => {
 
     // Should have multiple comment updates showing progress
     expect(commentUpdates.length).toBeGreaterThan(2);
-    expect(commentUpdates[0]).toContain('Analyzing task complexity');
-    expect(commentUpdates[commentUpdates.length - 1]).toContain('✅ Completed');
+    expect(commentUpdates[0]).toContain("Analyzing task complexity");
+    expect(commentUpdates[commentUpdates.length - 1]).toContain("✅ Completed");
   });
 });
 ```
@@ -1167,6 +1193,7 @@ describe('GitHub Actions Orchestration Integration', () => {
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase3-prompt-extension から作業ブランチを作成
 git checkout phase3-prompt-extension
@@ -1197,6 +1224,7 @@ git branch -d phase3-github-actions # ローカルの作業ブランチを削除
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase3-prompt-extension から作業ブランチ作成
 git checkout phase3-prompt-extension
@@ -1228,6 +1256,7 @@ git branch -d phase3-github-actions
 ## 依存関係
 
 このフェーズはフェーズ3.1（プロンプト拡張）完了後に実装してください。以下のフェーズで活用されます：
+
 - フェーズ4: MCP拡張（オーケストレーションツールとの連携）
 
 ## 次のステップ

--- a/predev-docs/07-phase3-github-actions-design.md
+++ b/predev-docs/07-phase3-github-actions-design.md
@@ -1,0 +1,1236 @@
+# フェーズ3.2: GitHub Actions統合 - 詳細設計
+
+## 概要
+
+GitHub Actions統合では、オーケストレーション機能をGitHub Actionsワークフローに組み込み、サブタスクの実行管理とプログレストラッキングを実装します。既存のGitHub Actionsインフラを拡張し、複雑なタスクの分解と並列/順次実行を可能にします。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class OrchestrationEntrypoint {
+        -githubContext: GitHubContext
+        -taskManager: TaskManager
+        -orchestrator: AutoOrchestrator
+        -progressTracker: ProgressTracker
+        +prepare(): Promise<void>
+        +execute(): Promise<void>
+        +updateComment(result: OrchestrationResult): Promise<void>
+        +handleError(error: Error): Promise<void>
+    }
+
+    class TaskManager {
+        // TaskManagerのフィールドやメソッド (必要に応じて追記)
+    }
+
+    class AutoOrchestrator {
+        -taskManager: TaskManager
+        -taskAnalyzer: TaskAnalyzer
+        -contextOptimizer: ContextOptimizer
+        -modeManager: ModeManager
+        -executionManager: SubtaskExecutionManager
+        +orchestrateTask(taskDescription: string): Promise<OrchestrationResult>
+        +executeSubTasks(analysis: TaskAnalysis): Promise<TaskResult[]>
+        +handleBoomerangTask(request: BoomerangRequest): Promise<TaskResult>
+        +coordinateExecution(subtasks: SubTask[]): Promise<ExecutionPlan>
+    }
+
+    class TaskAnalyzer {
+        // TaskAnalyzerのフィールドやメソッド (必要に応じて追記)
+    }
+    class ContextOptimizer {
+        // ContextOptimizerのフィールドやメソッド (必要に応じて追記)
+    }
+    class ModeManager {
+        // ModeManagerのフィールドやメソッド (必要に応じて追記)
+    }
+
+    class SubtaskExecutionManager {
+        -executionQueue: ExecutionQueue
+        -dependencyResolver: DependencyResolver
+        -resultAggregator: ResultAggregator
+        +executeParallel(subtasks: SubTask[]): Promise<TaskResult[]>
+        +executeSequential(subtasks: SubTask[]): Promise<TaskResult[]>
+        +executeDependencyGraph(graph: DependencyGraph): Promise<TaskResult[]>
+        +monitorProgress(taskId: string): ProgressUpdate
+    }
+
+    class ExecutionQueue {
+        // ExecutionQueueのフィールドやメソッド (必要に応じて追記)
+    }
+    class DependencyResolver {
+        // DependencyResolverのフィールドやメソッド (必要に応じて追記)
+    }
+    class ResultAggregator {
+        // ResultAggregatorのフィールドやメソッド (必要に応じて追記)
+    }
+
+    class ProgressTracker {
+        -commentManager: CommentManager
+        -statusFormatter: StatusFormatter
+        +createInitialComment(taskInfo: TaskInfo): Promise<string>
+        +updateProgress(taskId: string, progress: ProgressUpdate): Promise<void>
+        +finalizeComment(result: OrchestrationResult): Promise<void>
+    }
+
+    class CommentManager {
+        -githubClient: GitHubClient
+        -templateEngine: TemplateEngine
+        +createComment(content: string): Promise<number>
+        +updateComment(commentId: number, content: string): Promise<void>
+        +formatProgressCheckboxes(tasks: SubTask[]): string
+    }
+
+    OrchestrationEntrypoint o-- TaskManager : aggregates
+    OrchestrationEntrypoint --> AutoOrchestrator : uses
+    OrchestrationEntrypoint --> ProgressTracker : uses
+
+    AutoOrchestrator o-- TaskManager : aggregates
+    AutoOrchestrator o-- TaskAnalyzer : aggregates
+    AutoOrchestrator o-- ContextOptimizer : aggregates
+    AutoOrchestrator o-- ModeManager : aggregates
+    AutoOrchestrator --> SubtaskExecutionManager : delegates
+
+    SubtaskExecutionManager *-- ExecutionQueue : composes
+    SubtaskExecutionManager *-- DependencyResolver : composes
+    SubtaskExecutionManager *-- ResultAggregator : composes
+
+    ProgressTracker --> CommentManager : uses
+```
+
+## TDD実装計画
+
+### タスク3.2.1: GitHub統合型定義の作成
+
+#### テストファースト: src/github/operations/orchestration-types.ts
+
+```typescript
+// test/github/operations/orchestration-types.test.ts
+import { describe, test, expect } from 'bun:test';
+import type {
+  OrchestrationResult,
+  ExecutionPlan,
+  ProgressUpdate,
+  TaskInfo,
+  BoomerangRequest,
+  BoomerangResult,
+  ErrorRecoveryInfo,
+  ExecutionMetrics
+} from '../../../src/github/operations/orchestration-types';
+
+describe('Orchestration Types', () => {
+  test('should define OrchestrationResult correctly', () => {
+    const result: OrchestrationResult = {
+      success: true,
+      taskId: 'main-task-1',
+      subtaskResults: [
+        {
+          taskId: 'subtask-1',
+          success: true,
+          output: 'Component implemented',
+          duration: 120,
+          tokensUsed: 1500
+        }
+      ],
+      totalDuration: 300,
+      totalTokensUsed: 5000,
+      summary: 'All subtasks completed successfully'
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.subtaskResults.length).toBe(1);
+    expect(result.totalTokensUsed).toBe(5000);
+  });
+
+  test('should define ExecutionPlan correctly', () => {
+    const plan: ExecutionPlan = {
+      phases: [
+        {
+          phaseId: 'phase-1',
+          name: 'Initial Setup',
+          subtasks: ['subtask-1', 'subtask-2'],
+          executionType: 'parallel',
+          estimatedDuration: 60
+        }
+      ],
+      dependencies: {
+        'subtask-3': ['subtask-1', 'subtask-2'],
+        'subtask-4': ['subtask-3']
+      },
+      estimatedTotalDuration: 180,
+      criticalPath: ['subtask-1', 'subtask-3', 'subtask-4']
+    };
+
+    expect(plan.phases.length).toBe(1);
+    expect(plan.phases[0].executionType).toBe('parallel');
+    expect(plan.criticalPath.length).toBe(3);
+  });
+
+  test('should define ProgressUpdate correctly', () => {
+    const progress: ProgressUpdate = {
+      taskId: 'subtask-1',
+      status: 'in_progress',
+      percentComplete: 75,
+      currentStep: 'Running tests',
+      startTime: new Date(),
+      estimatedTimeRemaining: 30
+    };
+
+    expect(progress.status).toBe('in_progress');
+    expect(progress.percentComplete).toBe(75);
+    expect(progress.currentStep).toBe('Running tests');
+  });
+
+  test('should define BoomerangRequest correctly', () => {
+    const request: BoomerangRequest = {
+      task: 'Refactor component X',
+      targetMode: 'code-refactor',
+      returnContext: true,
+      preserveResults: false
+    };
+    expect(request.targetMode).toBe('code-refactor');
+    expect(request.preserveResults).toBe(false);
+  });
+
+  test('should define BoomerangResult correctly', () => {
+    const result: BoomerangResult = {
+      success: true,
+      delegatedMode: 'code-refactor',
+      result: 'Component X refactored successfully.',
+      tokensUsed: 250,
+      duration: 60
+    };
+    expect(result.success).toBe(true);
+    expect(result.tokensUsed).toBe(250);
+  });
+
+  test('should define ErrorRecoveryInfo correctly', () => {
+    const recoveryInfo: ErrorRecoveryInfo = {
+      strategy: 'retry',
+      attempts: 3,
+      recoveredTasks: ['task-A'],
+      unrecoverableTasks: ['task-B']
+    };
+    expect(recoveryInfo.strategy).toBe('retry');
+    expect(recoveryInfo.recoveredTasks.length).toBe(1);
+  });
+
+  test('should define ExecutionMetrics correctly', () => {
+    const metrics: ExecutionMetrics = {
+      startTime: new Date(),
+      tokensUsed: 1200,
+      subtasksCompleted: 3,
+      subtasksFailed: 0
+    };
+    // endTime, duration, parallelizationEfficiency はオプショナルなので、必須項目のみテスト
+    expect(metrics.tokensUsed).toBe(1200);
+    expect(metrics.subtasksFailed).toBe(0);
+  });
+});
+```
+
+#### 実装: src/github/operations/orchestration-types.ts
+
+```typescript
+import type { TaskResult } from '../../tasks/types';
+
+export interface OrchestrationResult {
+  success: boolean;
+  taskId: string;
+  subtaskResults: TaskResult[];
+  totalDuration: number;
+  totalTokensUsed: number;
+  summary: string;
+  errors?: string[];
+  partialSuccess?: boolean;
+  completedSubtasks?: TaskResult[];
+  failedSubtasks?: TaskResult[];
+  errorRecovery?: ErrorRecoveryInfo;
+}
+
+export interface ExecutionPlan {
+  phases: ExecutionPhase[];
+  dependencies: Record<string, string[]>;
+  estimatedTotalDuration: number;
+  criticalPath: string[];
+}
+
+export interface ExecutionPhase {
+  phaseId: string;
+  name: string;
+  subtasks: string[];
+  executionType: 'parallel' | 'sequential';
+  estimatedDuration: number;
+}
+
+export interface ProgressUpdate {
+  taskId: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  percentComplete: number;
+  currentStep?: string;
+  startTime?: Date;
+  endTime?: Date;
+  estimatedTimeRemaining?: number;
+}
+
+export interface TaskInfo {
+  id: string;
+  title: string;
+  description: string;
+  issueNumber: number;
+  repository: {
+    owner: string;
+    name: string;
+  };
+}
+
+export interface BoomerangRequest {
+  task: string;
+  targetMode: string;
+  returnContext: boolean;
+  preserveResults?: boolean;
+}
+
+export interface BoomerangResult {
+  success: boolean;
+  delegatedMode: string;
+  result: string;
+  tokensUsed: number;
+  duration: number;
+}
+
+export interface ErrorRecoveryInfo {
+  strategy: 'retry' | 'skip' | 'fallback';
+  attempts: number;
+  recoveredTasks: string[];
+  unrecoverableTasks: string[];
+}
+
+export interface ExecutionMetrics {
+  startTime: Date;
+  endTime?: Date;
+  duration?: number;
+  tokensUsed: number;
+  subtasksCompleted: number;
+  subtasksFailed: number;
+  parallelizationEfficiency?: number;
+}
+```
+
+### タスク3.2.2: オーケストレーションエントリーポイントの実装
+
+#### テストファースト: src/entrypoints/orchestrate.ts
+
+```typescript
+// test/entrypoints/orchestrate.test.ts
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { OrchestrationEntrypoint } from '../../src/entrypoints/orchestrate';
+import type { GitHubContext } from '../../src/github/context';
+import { ProgressTracker } from '../../src/github/operations/progress-tracker';
+
+describe('OrchestrationEntrypoint', () => {
+  let entrypoint: OrchestrationEntrypoint;
+  let mockContext: GitHubContext;
+
+  beforeEach(() => {
+    mockContext = {
+      eventType: 'issue_comment',
+      repository: { owner: 'test', name: 'repo' },
+      issue: { number: 1, title: 'Test Issue' },
+      comment: { id: 123, body: '/claude orchestrate complex task' }
+    } as GitHubContext;
+
+    entrypoint = new OrchestrationEntrypoint(mockContext);
+  });
+
+  test('should prepare orchestration environment', async () => {
+    await entrypoint.prepare();
+
+    // Verify MCP server installation, mode system initialization, etc.
+    expect(entrypoint.isReady()).toBe(true);
+  });
+
+  test('should execute orchestration for complex task', async () => {
+    await entrypoint.prepare();
+
+    const result = await entrypoint.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.subtaskResults.length).toBeGreaterThan(0);
+  });
+
+  test('should update comment with progress', async () => {
+    const progressUpdatePayload = {
+      taskId: 'subtask-1',
+      status: 'completed' as const,
+      percentComplete: 100
+    };
+    await entrypoint.updateProgress(progressUpdatePayload);
+
+    const mockedProgressTrackerInstance = ProgressTracker.mock.results[0]?.value;
+    if (mockedProgressTrackerInstance) {
+      expect(mockedProgressTrackerInstance.updateProgress).toHaveBeenCalledWith(
+        progressUpdatePayload.taskId,
+        progressUpdatePayload
+      );
+    }
+  });
+
+  test('should handle errors gracefully', async () => {
+    const error = new Error('Orchestration failed');
+
+    await entrypoint.handleError(error);
+
+    // Should update comment with error message
+    expect(entrypoint.getLastComment()).toContain('Error');
+  });
+});
+```
+
+#### 実装: src/entrypoints/orchestrate.ts
+
+```typescript
+import { GitHubContext } from '../github/context';
+import { TaskManager } from '../tasks/task-manager';
+import { TaskAnalyzer } from '../orchestration/task-analyzer';
+import { ContextOptimizer } from '../orchestration/context-optimizer';
+import { modeManager } from '../modes/mode-manager';
+import { SubtaskExecutionManager } from '../github/operations/subtask-execution';
+import { ProgressTracker } from '../github/operations/progress-tracker';
+import type { OrchestrationResult, ProgressUpdate } from '../github/operations/orchestration-types';
+
+export class OrchestrationEntrypoint {
+  private githubContext: GitHubContext;
+  private taskManager: TaskManager;
+  private orchestrator: AutoOrchestrator;
+  private progressTracker: ProgressTracker;
+  private isInitialized: boolean = false;
+
+  constructor(context: GitHubContext) {
+    this.githubContext = context;
+    this.taskManager = new TaskManager();
+    this.progressTracker = new ProgressTracker(context);
+  }
+
+  async prepare(): Promise<void> {
+    // Initialize MCP server
+    await this.initializeMCPServer();
+
+    // Initialize orchestrator
+    this.orchestrator = new AutoOrchestrator(
+      this.taskManager,
+      new TaskAnalyzer(),
+      new ContextOptimizer(),
+      modeManager // Note: When testing AutoOrchestrator, modeManager will need to be mocked
+                  // or a test-specific instance provided to control its behavior and
+                  // dependencies, especially for methods like getModeBySlug.
+    );
+
+    this.isInitialized = true;
+  }
+
+  async execute(): Promise<OrchestrationResult> {
+    if (!this.isInitialized) {
+      throw new Error('Orchestration not initialized. Call prepare() first.');
+    }
+
+    try {
+      // Create initial progress comment
+      const taskInfo = this.extractTaskInfo();
+      await this.progressTracker.createInitialComment(taskInfo);
+
+      // Extract task description from issue/comment
+      const taskDescription = this.extractTaskDescription();
+
+      // Orchestrate the task
+      const result = await this.orchestrator.orchestrateTask(taskDescription);
+
+      // Update final comment
+      await this.progressTracker.finalizeComment(result);
+
+      return result;
+    } catch (error) {
+      await this.handleError(error as Error);
+      throw error;
+    }
+  }
+
+  async updateProgress(progress: ProgressUpdate): Promise<void> {
+    await this.progressTracker.updateProgress(progress.taskId, progress);
+  }
+
+  async handleError(error: Error): Promise<void> {
+    const errorMessage = `❌ Orchestration failed: ${error.message}`;
+    await this.progressTracker.updateWithError(errorMessage);
+  }
+
+  isReady(): boolean {
+    return this.isInitialized;
+  }
+
+  setCommentUpdater(updater: (content: string) => void): void {
+    this.progressTracker.setCommentUpdater(updater);
+  }
+
+  getLastComment(): string {
+    return this.progressTracker.getLastComment();
+  }
+
+  private async initializeMCPServer(): Promise<void> {
+    // Initialize MCP server with orchestration tools
+    // Implementation details...
+  }
+
+  private extractTaskInfo(): TaskInfo {
+    return {
+      id: `task-${Date.now()}`,
+      title: this.githubContext.issue?.title || 'Task',
+      description: this.githubContext.issue?.body || '',
+      issueNumber: this.githubContext.issue?.number || 0,
+      repository: {
+        owner: this.githubContext.repository.owner,
+        name: this.githubContext.repository.name
+      }
+    };
+  }
+
+  private extractTaskDescription(): string {
+    const issueBody = this.githubContext.issue?.body || '';
+    const commentBody = this.githubContext.comment?.body || '';
+    return `${issueBody}\n\n${commentBody}`;
+  }
+}
+
+export class AutoOrchestrator {
+  constructor(
+    private taskManager: TaskManager,
+    private taskAnalyzer: TaskAnalyzer,
+    private contextOptimizer: ContextOptimizer,
+    private modeManager: typeof modeManager
+  ) {}
+
+  async orchestrateTask(taskDescription: string): Promise<OrchestrationResult> {
+    const startTime = Date.now();
+    const analysis = this.taskAnalyzer.analyzeTask(taskDescription);
+
+    if (!analysis.requiresOrchestration) {
+      // Simple task - execute directly
+      return this.executeSingleTask(taskDescription, analysis.requiredModes[0]);
+    }
+
+    // Complex task - create subtasks and execution plan
+    const subtasks = await this.generateSubtasks(analysis);
+    const executionPlan = await this.coordinateExecution(subtasks);
+
+    // Execute subtasks according to plan
+    const executionManager = new SubtaskExecutionManager();
+    const results = await executionManager.executeDependencyGraph({
+      nodes: subtasks,
+      edges: this.createDependencyEdges(executionPlan)
+    });
+
+    return {
+      success: results.every(r => r.success),
+      taskId: `main-${Date.now()}`,
+      subtaskResults: results,
+      totalDuration: Date.now() - startTime,
+      totalTokensUsed: results.reduce((sum, r) => sum + (r.tokensUsed || 0), 0),
+      summary: this.generateSummary(results)
+    };
+  }
+
+  async executeSubTasks(analysis: TaskAnalysis): Promise<TaskResult[]> {
+    const subtasks = await this.generateSubtasks(analysis);
+    const executionManager = new SubtaskExecutionManager();
+
+    // Group subtasks by dependencies
+    const independentTasks = subtasks.filter(t => t.dependencies.length === 0);
+    const dependentTasks = subtasks.filter(t => t.dependencies.length > 0);
+
+    // Execute independent tasks in parallel
+    const independentResults = await executionManager.executeParallel(independentTasks);
+
+    // Execute dependent tasks sequentially
+    const dependentResults = await executionManager.executeSequential(dependentTasks);
+
+    return [...independentResults, ...dependentResults];
+  }
+
+  async handleBoomerangTask(request: BoomerangRequest): Promise<TaskResult> {
+    const mode = this.modeManager.getModeBySlug(request.targetMode);
+    const context = this.contextOptimizer.createContextForSubTask({
+      mode: request.targetMode,
+      taskDescription: request.task,
+      previousResults: [],
+      globalContext: {},
+      maxTokens: 4000
+    });
+
+    // Execute task in specified mode
+    const result = await this.executeInMode(request.task, mode, context);
+
+    return {
+      taskId: `boomerang-${Date.now()}`,
+      success: true,
+      output: result,
+      duration: 0,
+      tokensUsed: 0
+    };
+  }
+
+  async coordinateExecution(subtasks: SubTask[]): Promise<ExecutionPlan> {
+    // Analyze dependencies and create execution phases
+    const phases = this.createExecutionPhases(subtasks);
+    const criticalPath = this.calculateCriticalPath(subtasks);
+
+    return {
+      phases,
+      dependencies: this.extractDependencies(subtasks),
+      estimatedTotalDuration: this.estimateTotalDuration(phases),
+      criticalPath
+    };
+  }
+
+  // Private helper methods...
+  // Note: The following private methods (executeSingleTask, generateSubtasks,
+  // createDependencyEdges, generateSummary, executeInMode, createExecutionPhases,
+  // calculateCriticalPath, extractDependencies, estimateTotalDuration) may contain
+  // complex logic. Consider strategies for testing these methods, such as:
+  // 1. Making them package-private or protected if language allows, for direct testing.
+  // 2. Refactoring them into separate, testable helper classes.
+  // 3. Ensuring comprehensive coverage through AutoOrchestrator's public methods tests.
+}
+```
+
+### タスク3.2.3: サブタスク実行管理の実装
+
+#### テストファースト: src/github/operations/subtask-execution.ts
+
+```typescript
+// test/github/operations/subtask-execution.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { SubtaskExecutionManager } from '../../../src/github/operations/subtask-execution';
+import type { SubTask } from '../../../src/orchestration/types';
+
+describe('SubtaskExecutionManager', () => {
+  let manager: SubtaskExecutionManager;
+
+  beforeEach(() => {
+    manager = new SubtaskExecutionManager();
+  });
+
+  test('should execute independent subtasks in parallel', async () => {
+    const subtasks: SubTask[] = [
+      {
+        id: 'subtask-1',
+        description: 'Task 1',
+        mode: 'code',
+        priority: 1,
+        dependencies: [],
+        estimatedComplexity: 3
+      },
+      {
+        id: 'subtask-2',
+        description: 'Task 2',
+        mode: 'code',
+        priority: 1,
+        dependencies: [],
+        estimatedComplexity: 3
+      }
+    ];
+
+    const startTime = Date.now();
+    const results = await manager.executeParallel(subtasks);
+    const duration = Date.now() - startTime;
+
+    expect(results.length).toBe(2);
+    expect(results.every(r => r.success)).toBe(true);
+    // Parallel execution should be faster than sequential
+    expect(duration).toBeLessThan(subtasks.length * 1000);
+  });
+
+  test('should execute dependent subtasks sequentially', async () => {
+    const subtasks: SubTask[] = [
+      {
+        id: 'subtask-1',
+        description: 'Base task',
+        mode: 'code',
+        priority: 1,
+        dependencies: [],
+        estimatedComplexity: 3
+      },
+      {
+        id: 'subtask-2',
+        description: 'Dependent task',
+        mode: 'code',
+        priority: 2,
+        dependencies: ['subtask-1'],
+        estimatedComplexity: 3
+      }
+    ];
+
+    const results = await manager.executeSequential(subtasks);
+
+    expect(results.length).toBe(2);
+    expect(results[0].taskId).toBe('subtask-1');
+    expect(results[1].taskId).toBe('subtask-2');
+  });
+
+  test('should execute dependency graph correctly', async () => {
+    const graph = {
+      nodes: [
+        { id: 'A', mode: 'code', dependencies: [] },
+        { id: 'B', mode: 'code', dependencies: ['A'] },
+        { id: 'C', mode: 'code', dependencies: ['A'] },
+        { id: 'D', mode: 'code', dependencies: ['B', 'C'] }
+      ],
+      edges: [
+        { from: 'A', to: 'B', type: 'sequential' },
+        { from: 'A', to: 'C', type: 'sequential' },
+        { from: 'B', to: 'D', type: 'sequential' },
+        { from: 'C', to: 'D', type: 'sequential' }
+      ]
+    };
+
+    const results = await manager.executeDependencyGraph(graph);
+
+    expect(results.length).toBe(4);
+    // A should complete before B and C
+    const aIndex = results.findIndex(r => r.taskId === 'A');
+    const bIndex = results.findIndex(r => r.taskId === 'B');
+    const cIndex = results.findIndex(r => r.taskId === 'C');
+    const dIndex = results.findIndex(r => r.taskId === 'D');
+
+    expect(aIndex).toBeLessThan(bIndex);
+    expect(aIndex).toBeLessThan(cIndex);
+    expect(dIndex).toBe(3); // D should be last
+  });
+
+  test('should monitor progress during execution', async () => {
+    const subtask: SubTask = {
+      id: 'subtask-1',
+      description: 'Monitored task',
+      mode: 'code',
+      priority: 1,
+      dependencies: [],
+      estimatedComplexity: 5
+    };
+
+    let progressUpdates: ProgressUpdate[] = [];
+    manager.onProgress((update) => {
+      progressUpdates.push(update);
+    });
+
+    await manager.executeParallel([subtask]);
+
+    expect(progressUpdates.length).toBeGreaterThan(0);
+    expect(progressUpdates.some(u => u.status === 'in_progress')).toBe(true);
+    expect(progressUpdates.some(u => u.status === 'completed')).toBe(true);
+  });
+});
+```
+
+#### 実装: src/github/operations/subtask-execution.ts
+
+```typescript
+import type { SubTask, TaskResult, DependencyGraph } from '../../orchestration/types';
+import type { ProgressUpdate } from './orchestration-types';
+import { PromptExtension } from '../../create-prompt/prompt-extension';
+import { taskManager } from '../../tasks/task-manager';
+
+export class SubtaskExecutionManager {
+  private executionQueue: ExecutionQueue;
+  private dependencyResolver: DependencyResolver;
+  private resultAggregator: ResultAggregator;
+  private progressCallbacks: ((update: ProgressUpdate) => void)[] = [];
+
+  constructor() {
+    this.executionQueue = new ExecutionQueue();
+    this.dependencyResolver = new DependencyResolver();
+    this.resultAggregator = new ResultAggregator();
+  }
+
+  async executeParallel(subtasks: SubTask[]): Promise<TaskResult[]> {
+    const promises = subtasks.map(subtask => this.executeSubtask(subtask));
+    return Promise.all(promises);
+  }
+
+  async executeSequential(subtasks: SubTask[]): Promise<TaskResult[]> {
+    const results: TaskResult[] = [];
+
+    for (const subtask of subtasks) {
+      const result = await this.executeSubtask(subtask);
+      results.push(result);
+
+      // Pass result to next subtask's context
+      if (subtask.dependencies.length > 0) {
+        this.resultAggregator.addResult(subtask.id, result);
+      }
+    }
+
+    return results;
+  }
+
+  async executeDependencyGraph(graph: DependencyGraph): Promise<TaskResult[]> {
+    const results: TaskResult[] = [];
+    const completed = new Set<string>();
+    const executing = new Map<string, Promise<TaskResult>>();
+
+    const executeNode = async (nodeId: string): Promise<TaskResult> => {
+      const node = graph.nodes.find(n => n.id === nodeId);
+      if (!node) throw new Error(`Node ${nodeId} not found`);
+
+      // Wait for dependencies
+      for (const dep of node.dependencies) {
+        if (!completed.has(dep)) {
+          if (executing.has(dep)) {
+            await executing.get(dep);
+          } else {
+            await executeNode(dep);
+          }
+        }
+      }
+
+      // Execute this node
+      const promise = this.executeSubtask(node as SubTask);
+      executing.set(nodeId, promise);
+
+      const result = await promise;
+      completed.add(nodeId);
+      results.push(result);
+
+      return result;
+    };
+
+    // Execute all nodes
+    const rootNodes = graph.nodes.filter(n => n.dependencies.length === 0);
+    await Promise.all(rootNodes.map(n => executeNode(n.id)));
+
+    // Execute remaining nodes
+    for (const node of graph.nodes) {
+      if (!completed.has(node.id)) {
+        await executeNode(node.id);
+      }
+    }
+
+    return results;
+  }
+
+  monitorProgress(taskId: string): ProgressUpdate {
+    const task = taskManager.getTask(taskId);
+
+    return {
+      taskId,
+      status: task.status,
+      percentComplete: this.calculateProgress(task),
+      currentStep: this.getCurrentStep(task),
+      startTime: task.createdAt,
+      endTime: task.result ? task.updatedAt : undefined,
+      estimatedTimeRemaining: this.estimateTimeRemaining(task)
+    };
+  }
+
+  onProgress(callback: (update: ProgressUpdate) => void): void {
+    this.progressCallbacks.push(callback);
+  }
+
+  private async executeSubtask(subtask: SubTask): Promise<TaskResult> {
+    const startTime = Date.now();
+
+    // Update progress: starting
+    this.notifyProgress({
+      taskId: subtask.id,
+      status: 'in_progress',
+      percentComplete: 0,
+      currentStep: 'Initializing'
+    });
+
+    try {
+      // Create task in task manager
+      const task = taskManager.createTask({
+        mode: subtask.mode,
+        message: subtask.description,
+        context: {
+          previousResults: this.getPreviousResults(subtask.dependencies),
+          globalContext: {},
+          modeSpecificContext: {},
+          maxTokens: 4000
+        }
+      });
+
+      // Generate prompt
+      const promptExtension = new PromptExtension();
+      const promptResult = promptExtension.createPromptForSubtask(subtask, task.context);
+
+      // Update progress: executing
+      this.notifyProgress({
+        taskId: subtask.id,
+        status: 'in_progress',
+        percentComplete: 50,
+        currentStep: 'Executing'
+      });
+
+      // Execute (simulated - in real implementation, this would call Claude API)
+      const output = await this.simulateExecution(promptResult.prompt, subtask);
+
+      // Update task result
+      const result: TaskResult = {
+        taskId: subtask.id,
+        success: true,
+        output,
+        duration: Date.now() - startTime,
+        tokensUsed: promptResult.metadata.tokensUsed
+      };
+
+      taskManager.updateTaskResult(task.id, result);
+
+      // Update progress: completed
+      this.notifyProgress({
+        taskId: subtask.id,
+        status: 'completed',
+        percentComplete: 100,
+        currentStep: 'Completed'
+      });
+
+      return result;
+    } catch (error) {
+      // Update progress: failed
+      this.notifyProgress({
+        taskId: subtask.id,
+        status: 'failed',
+        percentComplete: 0,
+        currentStep: 'Failed'
+      });
+
+      return {
+        taskId: subtask.id,
+        success: false,
+        error: error.message,
+        duration: Date.now() - startTime
+      };
+    }
+  }
+
+  private getPreviousResults(dependencies: string[]): string[] {
+    return dependencies.map(depId => {
+      const result = this.resultAggregator.getResult(depId);
+      return result?.output || `Result from ${depId}`;
+    });
+  }
+
+  private async simulateExecution(prompt: string, subtask: SubTask): Promise<string> {
+    // Simulate API call delay
+    await new Promise(resolve => setTimeout(resolve, 500 + Math.random() * 500));
+
+    // Return simulated result based on mode
+    switch (subtask.mode) {
+      case 'architect':
+        return `Architecture design for: ${subtask.description}`;
+      case 'code':
+        return `Implementation completed for: ${subtask.description}`;
+      case 'debug':
+        return `Debugging analysis for: ${subtask.description}`;
+      default:
+        return `Task completed: ${subtask.description}`;
+    }
+  }
+
+  private notifyProgress(update: ProgressUpdate): void {
+    this.progressCallbacks.forEach(callback => callback(update));
+  }
+
+  private calculateProgress(task: any): number {
+    if (task.status === 'completed') return 100;
+    if (task.status === 'failed') return 0;
+    if (task.status === 'in_progress') return 50;
+    return 0;
+  }
+
+  private getCurrentStep(task: any): string {
+    return task.status === 'in_progress' ? 'Processing' : task.status;
+  }
+
+  private estimateTimeRemaining(task: any): number {
+    if (task.status === 'completed' || task.status === 'failed') return 0;
+    return 30; // seconds
+  }
+}
+
+class ExecutionQueue {
+  private queue: SubTask[] = [];
+  private executing = new Set<string>();
+  private maxConcurrent = 3;
+
+  async add(subtask: SubTask): Promise<void> {
+    this.queue.push(subtask);
+  }
+
+  async processQueue(): Promise<void> {
+    while (this.queue.length > 0 && this.executing.size < this.maxConcurrent) {
+      const task = this.queue.shift()!;
+      this.executing.add(task.id);
+      // Process task...
+      this.executing.delete(task.id);
+    }
+  }
+}
+
+class DependencyResolver {
+  resolveDependencies(subtasks: SubTask[]): SubTask[] {
+    // Topological sort
+    const sorted: SubTask[] = [];
+    const visited = new Set<string>();
+    const visiting = new Set<string>();
+
+    const visit = (task: SubTask) => {
+      if (visited.has(task.id)) return;
+      if (visiting.has(task.id)) {
+        throw new Error('Circular dependency detected');
+      }
+
+      visiting.add(task.id);
+
+      for (const depId of task.dependencies) {
+        const dep = subtasks.find(t => t.id === depId);
+        if (dep) visit(dep);
+      }
+
+      visiting.delete(task.id);
+      visited.add(task.id);
+      sorted.push(task);
+    };
+
+    subtasks.forEach(visit);
+    return sorted;
+  }
+}
+
+class ResultAggregator {
+  private results = new Map<string, TaskResult>();
+
+  addResult(taskId: string, result: TaskResult): void {
+    this.results.set(taskId, result);
+  }
+
+  getResult(taskId: string): TaskResult | undefined {
+    return this.results.get(taskId);
+  }
+
+  getAllResults(): TaskResult[] {
+    return Array.from(this.results.values());
+  }
+}
+```
+
+## コミット計画
+
+### コミット1: GitHub統合型定義
+```bash
+git add src/github/operations/orchestration-types.ts test/github/operations/orchestration-types.test.ts
+git commit -m "feat(github): add orchestration type definitions with tests"
+```
+
+### コミット2: オーケストレーションエントリーポイント
+```bash
+git add src/entrypoints/orchestrate.ts test/entrypoints/orchestrate.test.ts
+git commit -m "feat(github): implement orchestration entrypoint with tests"
+```
+
+### コミット3: サブタスク実行管理
+```bash
+git add src/github/operations/subtask-execution.ts test/github/operations/subtask-execution.test.ts
+git commit -m "feat(github): implement subtask execution manager with tests"
+```
+
+### コミット4: プログレストラッキング
+```bash
+git add src/github/operations/progress-tracker.ts test/github/operations/progress-tracker.test.ts
+git commit -m "feat(github): implement progress tracking for orchestration"
+```
+
+### コミット5: 統合テスト
+```bash
+git add test/github/operations/orchestration-integration.test.ts
+git commit -m "test(github): add orchestration integration tests"
+```
+
+## ディレクトリ構造
+
+```
+src/
+├── entrypoints/
+│   ├── prepare.ts          # 既存
+│   └── orchestrate.ts      # 新規: オーケストレーションエントリーポイント
+└── github/
+    └── operations/
+        ├── orchestration-types.ts      # 新規: 型定義
+        ├── subtask-execution.ts        # 新規: サブタスク実行管理
+        └── progress-tracker.ts         # 新規: プログレストラッキング
+
+test/
+├── entrypoints/
+│   └── orchestrate.test.ts
+└── github/
+    └── operations/
+        ├── orchestration-types.test.ts
+        ├── subtask-execution.test.ts
+        ├── progress-tracker.test.ts
+        └── orchestration-integration.test.ts
+```
+
+## 統合テスト
+
+```typescript
+// test/github/operations/orchestration-integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { OrchestrationEntrypoint } from '../../../src/entrypoints/orchestrate';
+import { TaskAnalyzer } from '../../../src/orchestration';
+
+describe('GitHub Actions Orchestration Integration', () => {
+  test('should handle complete orchestration workflow', async () => {
+    const context = {
+      eventType: 'issue_comment',
+      repository: { owner: 'test', name: 'repo' },
+      issue: {
+        number: 1,
+        title: 'Implement user authentication system',
+        body: `
+          Create a complete authentication system with:
+          - User registration and login
+          - Password reset functionality
+          - JWT token management
+          - Rate limiting
+        `
+      },
+      comment: {
+        id: 123,
+        body: '/claude orchestrate'
+      }
+    };
+
+    const entrypoint = new OrchestrationEntrypoint(context);
+
+    // Prepare environment
+    await entrypoint.prepare();
+
+    // Execute orchestration
+    const result = await entrypoint.execute();
+
+    expect(result.success).toBe(true);
+    expect(result.subtaskResults.length).toBeGreaterThan(2);
+    expect(result.summary).toContain('authentication');
+
+    // Verify comment was updated with progress
+    const finalComment = entrypoint.getLastComment();
+    expect(finalComment).toContain('✅');
+    expect(finalComment).toContain('Completed');
+  });
+
+  test('should show progress in GitHub comment', async () => {
+    const context = {
+      eventType: 'issue_comment',
+      repository: { owner: 'test', name: 'repo' },
+      issue: {
+        number: 1,
+        title: 'Complex feature request'
+      },
+      comment: {
+        body: '/claude orchestrate'
+      }
+    };
+
+    const entrypoint = new OrchestrationEntrypoint(context);
+    await entrypoint.prepare();
+
+    let commentUpdates: string[] = [];
+    entrypoint.setCommentUpdater((content) => {
+      commentUpdates.push(content);
+    });
+
+    await entrypoint.execute();
+
+    // Should have multiple comment updates showing progress
+    expect(commentUpdates.length).toBeGreaterThan(2);
+    expect(commentUpdates[0]).toContain('Analyzing task complexity');
+    expect(commentUpdates[commentUpdates.length - 1]).toContain('✅ Completed');
+  });
+});
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase3-prompt-extension から作業ブランチを作成
+git checkout phase3-prompt-extension
+git pull origin phase3-prompt-extension # 念のため最新化
+git checkout -b phase3-github-actions phase3-prompt-extension
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(github-actions): implement github actions integration" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase3-github-actions
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase3-prompt-extension とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase3-prompt-extension
+git pull origin phase3-prompt-extension # リモートの変更を取り込み最新化
+git branch -d phase3-github-actions # ローカルの作業ブランチを削除
+# git push origin --delete phase3-github-actions # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase3-prompt-extension から作業ブランチ作成
+git checkout phase3-prompt-extension
+git pull origin phase3-prompt-extension # 念のため最新化
+git checkout -b phase3-github-actions phase3-prompt-extension
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(github-actions): implement github actions integration" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase3-github-actions
+# GitHub上で phase3-prompt-extension をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase3-prompt-extension
+git pull origin phase3-prompt-extension
+git branch -d phase3-github-actions
+```
+
+## 依存関係
+
+このフェーズはフェーズ3.1（プロンプト拡張）完了後に実装してください。以下のフェーズで活用されます：
+- フェーズ4: MCP拡張（オーケストレーションツールとの連携）
+
+## 次のステップ
+
+1. フェーズ4でMCPツールを拡張
+2. フェーズ5で統合テストと最適化を実施

--- a/predev-docs/08-phase4-mcp-extension-design.md
+++ b/predev-docs/08-phase4-mcp-extension-design.md
@@ -5,6 +5,7 @@
 MCP（Model Context Protocol）拡張では、オーケストレーション機能をMCPツールとして提供し、タスク分解、モード切り替え、コンテキスト最適化などの機能を統合します。既存のMCPサーバーインフラストラクチャを拡張し、高度なタスク管理機能を提供します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -70,8 +71,8 @@ classDiagram
 #### 実装: src/mcp/orchestration-types.ts
 
 ```typescript
-import type { TaskAnalysis, SubTask } from '../orchestration/types';
-import type { Mode } from '../modes/types';
+import type { TaskAnalysis, SubTask } from "../orchestration/types";
+import type { Mode } from "../modes/types";
 
 export interface MCPTool {
   name: string;
@@ -157,54 +158,57 @@ export interface MCPToolInfo {
 
 ```typescript
 // test/mcp/orchestration-tools.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { OrchestrationTools } from '../../src/mcp/orchestration-tools';
-import type { AnalyzeTaskArgs, SwitchModeArgs } from '../../src/mcp/orchestration-types';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { OrchestrationTools } from "../../src/mcp/orchestration-tools";
+import type {
+  AnalyzeTaskArgs,
+  SwitchModeArgs,
+} from "../../src/mcp/orchestration-types";
 
-describe('OrchestrationTools', () => {
+describe("OrchestrationTools", () => {
   let tools: OrchestrationTools;
 
   beforeEach(() => {
     tools = new OrchestrationTools();
   });
 
-  test('should analyze task complexity', async () => {
+  test("should analyze task complexity", async () => {
     const args: AnalyzeTaskArgs = {
-      task: 'Implement user authentication with OAuth2 and JWT tokens',
-      context: { framework: 'Express.js' }
+      task: "Implement user authentication with OAuth2 and JWT tokens",
+      context: { framework: "Express.js" },
     };
 
     const analysis = await tools.analyzeTask(args);
 
     expect(analysis.complexity).toBeGreaterThan(5);
-    expect(analysis.requiredModes).toContain('code');
+    expect(analysis.requiredModes).toContain("code");
     expect(analysis.requiresOrchestration).toBe(true);
   });
 
-  test('should switch mode with context preservation', async () => {
+  test("should switch mode with context preservation", async () => {
     const args: SwitchModeArgs = {
-      mode: 'architect',
-      preserveContext: true
+      mode: "architect",
+      preserveContext: true,
     };
 
     const result = await tools.switchMode(args);
 
-    expect(result.mode.slug).toBe('architect');
+    expect(result.mode.slug).toBe("architect");
     expect(result.previousMode).toBeDefined();
     expect(result.contextPreserved).toBe(true);
   });
 
-  test('should optimize context for token limit', async () => {
+  test("should optimize context for token limit", async () => {
     const largeContext = {
-      fileContents: 'Large file content...'.repeat(1000),
-      history: ['Previous command 1', 'Previous command 2'],
-      metadata: { timestamp: new Date(), user: 'test' }
+      fileContents: "Large file content...".repeat(1000),
+      history: ["Previous command 1", "Previous command 2"],
+      metadata: { timestamp: new Date(), user: "test" },
     };
 
     const args = {
       context: largeContext,
       maxTokens: 1000,
-      priorityKeys: ['fileContents']
+      priorityKeys: ["fileContents"],
     };
 
     const optimized = await tools.optimizeContext(args);
@@ -214,7 +218,7 @@ describe('OrchestrationTools', () => {
     expect(optimized.compressionRatio).toBeGreaterThan(0.5);
   });
 
-  test('should decompose complex task into subtasks', async () => {
+  test("should decompose complex task into subtasks", async () => {
     const args = {
       task: `Build a complete e-commerce platform with:
         - User authentication system
@@ -223,28 +227,28 @@ describe('OrchestrationTools', () => {
         - Payment processing
         - Order tracking`,
       maxSubtasks: 10,
-      autoAssignModes: true
+      autoAssignModes: true,
     };
 
     const subtasks = await tools.decomposeTask(args);
 
     expect(subtasks.length).toBeGreaterThan(3);
     expect(subtasks.length).toBeLessThanOrEqual(10);
-    expect(subtasks.every(st => st.mode)).toBe(true);
-    expect(subtasks.some(st => st.dependencies.length > 0)).toBe(true);
+    expect(subtasks.every((st) => st.mode)).toBe(true);
+    expect(subtasks.some((st) => st.dependencies.length > 0)).toBe(true);
   });
 
-  test('should handle boomerang pattern for mode delegation', async () => {
+  test("should handle boomerang pattern for mode delegation", async () => {
     const args = {
-      task: 'Debug memory leak in payment processor',
-      targetMode: 'debug',
-      returnContext: true
+      task: "Debug memory leak in payment processor",
+      targetMode: "debug",
+      returnContext: true,
     };
 
     const result = await tools.boomerang(args);
 
-    expect(result.mode).toBe('debug');
-    expect(result.result).toContain('memory');
+    expect(result.mode).toBe("debug");
+    expect(result.result).toContain("memory");
     expect(result.tokensUsed).toBeGreaterThan(0);
   });
 });
@@ -253,10 +257,10 @@ describe('OrchestrationTools', () => {
 #### 実装: src/mcp/orchestration-tools.ts
 
 ```typescript
-import { TaskAnalyzer } from '../orchestration/task-analyzer';
-import { modeManager } from '../modes/mode-manager';
-import { ContextOptimizer } from '../orchestration/context-optimizer';
-import { SubtaskGenerator } from '../orchestration/subtask-generator';
+import { TaskAnalyzer } from "../orchestration/task-analyzer";
+import { modeManager } from "../modes/mode-manager";
+import { ContextOptimizer } from "../orchestration/context-optimizer";
+import { SubtaskGenerator } from "../orchestration/subtask-generator";
 import type {
   AnalyzeTaskArgs,
   SwitchModeArgs,
@@ -264,10 +268,10 @@ import type {
   DecomposeTaskArgs,
   BoomerangArgs,
   OptimizedContext,
-  BoomerangResult
-} from './orchestration-types';
-import type { TaskAnalysis, SubTask } from '../orchestration/types';
-import type { Mode } from '../modes/types';
+  BoomerangResult,
+} from "./orchestration-types";
+import type { TaskAnalysis, SubTask } from "../orchestration/types";
+import type { Mode } from "../modes/types";
 
 export class OrchestrationTools {
   private taskAnalyzer: TaskAnalyzer;
@@ -292,7 +296,7 @@ export class OrchestrationTools {
     if (context) {
       analysis.suggestedApproach = this.enhanceApproachWithContext(
         analysis.suggestedApproach,
-        context
+        context,
       );
     }
 
@@ -314,7 +318,7 @@ export class OrchestrationTools {
     return {
       mode: newMode,
       previousMode,
-      contextPreserved: preserveContext
+      contextPreserved: preserveContext,
     };
   }
 
@@ -324,7 +328,7 @@ export class OrchestrationTools {
     return this.contextOptimizer.optimizeContext({
       context,
       maxTokens,
-      priorityKeys
+      priorityKeys,
     });
   }
 
@@ -342,9 +346,9 @@ export class OrchestrationTools {
 
     // Auto-assign modes if requested
     if (autoAssignModes) {
-      return limitedSubtasks.map(subtask => ({
+      return limitedSubtasks.map((subtask) => ({
         ...subtask,
-        mode: subtask.mode || this.selectOptimalMode(subtask.description)
+        mode: subtask.mode || this.selectOptimalMode(subtask.description),
       }));
     }
 
@@ -358,7 +362,7 @@ export class OrchestrationTools {
     // Switch to target mode
     const switchResult = await this.switchMode({
       mode: targetMode,
-      preserveContext: returnContext
+      preserveContext: returnContext,
     });
 
     // Execute task in target mode (simulated)
@@ -368,7 +372,7 @@ export class OrchestrationTools {
     if (returnContext) {
       await this.switchMode({
         mode: switchResult.previousMode.slug,
-        preserveContext: true
+        preserveContext: true,
       });
     }
 
@@ -376,29 +380,30 @@ export class OrchestrationTools {
       result: result.output,
       mode: targetMode,
       tokensUsed: result.tokensUsed,
-      duration: Date.now() - startTime
+      duration: Date.now() - startTime,
     };
   }
 
   private enhanceApproachWithContext(
     approach: string,
-    context: Record<string, any>
+    context: Record<string, any>,
   ): string {
     const contextInfo = Object.entries(context)
       .map(([key, value]) => `${key}: ${value}`)
-      .join(', ');
+      .join(", ");
 
     return `${approach} Context: ${contextInfo}`;
   }
 
   private selectOptimalMode(taskDescription: string): string {
-    const modeSelector = new (require('../orchestration/mode-selector').ModeSelector)();
+    const modeSelector =
+      new (require("../orchestration/mode-selector").ModeSelector)();
     return modeSelector.selectOptimalMode(taskDescription);
   }
 
   private async executeInMode(
     task: string,
-    mode: Mode
+    mode: Mode,
   ): Promise<{ output: string; tokensUsed: number }> {
     // Simulate execution in specific mode
     const baseTokens = 500;
@@ -406,7 +411,7 @@ export class OrchestrationTools {
 
     return {
       output: `Executed "${task}" in ${mode.name} mode. ${mode.roleDefinition}`,
-      tokensUsed: Math.floor(baseTokens * complexityMultiplier)
+      tokensUsed: Math.floor(baseTokens * complexityMultiplier),
     };
   }
 }
@@ -418,73 +423,73 @@ export class OrchestrationTools {
 
 ```typescript
 // test/mcp/orchestration-server.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { MCPOrchestrationServer } from '../../src/mcp/orchestration-server';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { MCPOrchestrationServer } from "../../src/mcp/orchestration-server";
 
-describe('MCPOrchestrationServer', () => {
+describe("MCPOrchestrationServer", () => {
   let server: MCPOrchestrationServer;
 
   beforeEach(() => {
     server = new MCPOrchestrationServer();
   });
 
-  test('should register orchestration tools', () => {
+  test("should register orchestration tools", () => {
     server.registerOrchestrationTools();
 
     const tools = server.listTools();
-    const toolNames = tools.map(t => t.name);
+    const toolNames = tools.map((t) => t.name);
 
-    expect(toolNames).toContain('analyze_task');
-    expect(toolNames).toContain('switch_mode');
-    expect(toolNames).toContain('optimize_context');
-    expect(toolNames).toContain('decompose_task');
-    expect(toolNames).toContain('boomerang');
+    expect(toolNames).toContain("analyze_task");
+    expect(toolNames).toContain("switch_mode");
+    expect(toolNames).toContain("optimize_context");
+    expect(toolNames).toContain("decompose_task");
+    expect(toolNames).toContain("boomerang");
   });
 
-  test('should handle analyze_task tool call', async () => {
+  test("should handle analyze_task tool call", async () => {
     server.registerOrchestrationTools();
 
-    const result = await server.handleToolCall('analyze_task', {
-      task: 'Implement user authentication'
+    const result = await server.handleToolCall("analyze_task", {
+      task: "Implement user authentication",
     });
 
-    expect(result).toHaveProperty('complexity');
-    expect(result).toHaveProperty('requiredModes');
+    expect(result).toHaveProperty("complexity");
+    expect(result).toHaveProperty("requiredModes");
   });
 
-  test('should handle switch_mode tool call', async () => {
+  test("should handle switch_mode tool call", async () => {
     server.registerOrchestrationTools();
 
-    const result = await server.handleToolCall('switch_mode', {
-      mode: 'architect'
+    const result = await server.handleToolCall("switch_mode", {
+      mode: "architect",
     });
 
-    expect(result.mode.slug).toBe('architect');
+    expect(result.mode.slug).toBe("architect");
   });
 
-  test('should handle optimize_context tool call', async () => {
+  test("should handle optimize_context tool call", async () => {
     server.registerOrchestrationTools();
 
-    const result = await server.handleToolCall('optimize_context', {
-      context: { data: 'Large context data'.repeat(100) },
-      maxTokens: 500
+    const result = await server.handleToolCall("optimize_context", {
+      context: { data: "Large context data".repeat(100) },
+      maxTokens: 500,
     });
 
     expect(result.tokensUsed).toBeLessThanOrEqual(500);
   });
 
-  test('should validate tool arguments', async () => {
+  test("should validate tool arguments", async () => {
     server.registerOrchestrationTools();
 
-    await expect(
-      server.handleToolCall('analyze_task', {})
-    ).rejects.toThrow('Missing required argument: task');
+    await expect(server.handleToolCall("analyze_task", {})).rejects.toThrow(
+      "Missing required argument: task",
+    );
   });
 
-  test('should handle unknown tool gracefully', async () => {
-    await expect(
-      server.handleToolCall('unknown_tool', {})
-    ).rejects.toThrow('Unknown tool: unknown_tool');
+  test("should handle unknown tool gracefully", async () => {
+    await expect(server.handleToolCall("unknown_tool", {})).rejects.toThrow(
+      "Unknown tool: unknown_tool",
+    );
   });
 });
 ```
@@ -492,9 +497,9 @@ describe('MCPOrchestrationServer', () => {
 #### 実装: src/mcp/orchestration-server.ts
 
 ```typescript
-import { OrchestrationTools } from './orchestration-tools';
-import { MCPToolRegistry } from './tool-registry';
-import type { MCPTool, MCPToolInfo } from './orchestration-types';
+import { OrchestrationTools } from "./orchestration-tools";
+import { MCPToolRegistry } from "./tool-registry";
+import type { MCPTool, MCPToolInfo } from "./orchestration-types";
 
 export class MCPOrchestrationServer {
   private toolRegistry: MCPToolRegistry;
@@ -508,123 +513,141 @@ export class MCPOrchestrationServer {
   registerOrchestrationTools(): void {
     // Register analyze_task tool
     this.toolRegistry.registerTool({
-      name: 'analyze_task',
-      description: 'Analyze task complexity and determine required modes',
+      name: "analyze_task",
+      description: "Analyze task complexity and determine required modes",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
-          task: { type: 'string', description: 'Task description to analyze' },
-          context: { type: 'object', description: 'Optional context information' }
+          task: { type: "string", description: "Task description to analyze" },
+          context: {
+            type: "object",
+            description: "Optional context information",
+          },
         },
-        required: ['task'],
-        additionalProperties: false
+        required: ["task"],
+        additionalProperties: false,
       },
-      handler: async (args) => this.orchestrationTools.analyzeTask(args)
+      handler: async (args) => this.orchestrationTools.analyzeTask(args),
     });
 
     // Register switch_mode tool
     this.toolRegistry.registerTool({
-      name: 'switch_mode',
-      description: 'Switch to a different AI mode',
+      name: "switch_mode",
+      description: "Switch to a different AI mode",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
-          mode: { type: 'string', description: 'Target mode slug' },
-          preserveContext: { type: 'boolean', description: 'Preserve current context' }
+          mode: { type: "string", description: "Target mode slug" },
+          preserveContext: {
+            type: "boolean",
+            description: "Preserve current context",
+          },
         },
-        required: ['mode'],
-        additionalProperties: false
+        required: ["mode"],
+        additionalProperties: false,
       },
-      handler: async (args) => this.orchestrationTools.switchMode(args)
+      handler: async (args) => this.orchestrationTools.switchMode(args),
     });
 
     // Register optimize_context tool
     this.toolRegistry.registerTool({
-      name: 'optimize_context',
-      description: 'Optimize context to fit within token limits',
+      name: "optimize_context",
+      description: "Optimize context to fit within token limits",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
-          context: { type: 'object', description: 'Context to optimize' },
-          maxTokens: { type: 'number', description: 'Maximum token limit' },
+          context: { type: "object", description: "Context to optimize" },
+          maxTokens: { type: "number", description: "Maximum token limit" },
           priorityKeys: {
-            type: 'array',
-            items: { type: 'string' },
-            description: 'Keys to prioritize'
-          }
+            type: "array",
+            items: { type: "string" },
+            description: "Keys to prioritize",
+          },
         },
-        required: ['context', 'maxTokens'],
-        additionalProperties: false
+        required: ["context", "maxTokens"],
+        additionalProperties: false,
       },
-      handler: async (args) => this.orchestrationTools.optimizeContext(args)
+      handler: async (args) => this.orchestrationTools.optimizeContext(args),
     });
 
     // Register decompose_task tool
     this.toolRegistry.registerTool({
-      name: 'decompose_task',
-      description: 'Decompose a complex task into subtasks',
+      name: "decompose_task",
+      description: "Decompose a complex task into subtasks",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
-          task: { type: 'string', description: 'Task to decompose' },
-          maxSubtasks: { type: 'number', description: 'Maximum number of subtasks' },
-          autoAssignModes: { type: 'boolean', description: 'Auto-assign modes to subtasks' }
+          task: { type: "string", description: "Task to decompose" },
+          maxSubtasks: {
+            type: "number",
+            description: "Maximum number of subtasks",
+          },
+          autoAssignModes: {
+            type: "boolean",
+            description: "Auto-assign modes to subtasks",
+          },
         },
-        required: ['task'],
-        additionalProperties: false
+        required: ["task"],
+        additionalProperties: false,
       },
-      handler: async (args) => this.orchestrationTools.decomposeTask(args)
+      handler: async (args) => this.orchestrationTools.decomposeTask(args),
     });
 
     // Register boomerang tool
     this.toolRegistry.registerTool({
-      name: 'boomerang',
-      description: 'Delegate task to specific mode and return',
+      name: "boomerang",
+      description: "Delegate task to specific mode and return",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {
-          task: { type: 'string', description: 'Task to delegate' },
-          targetMode: { type: 'string', description: 'Target mode for delegation' },
-          returnContext: { type: 'boolean', description: 'Return to original mode after' }
+          task: { type: "string", description: "Task to delegate" },
+          targetMode: {
+            type: "string",
+            description: "Target mode for delegation",
+          },
+          returnContext: {
+            type: "boolean",
+            description: "Return to original mode after",
+          },
         },
-        required: ['task', 'targetMode'],
-        additionalProperties: false
+        required: ["task", "targetMode"],
+        additionalProperties: false,
       },
-      handler: async (args) => this.orchestrationTools.boomerang(args)
+      handler: async (args) => this.orchestrationTools.boomerang(args),
     });
 
     // Register list_modes tool
     this.toolRegistry.registerTool({
-      name: 'list_modes',
-      description: 'List all available AI modes',
+      name: "list_modes",
+      description: "List all available AI modes",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {},
-        additionalProperties: false
+        additionalProperties: false,
       },
       handler: async () => {
-        const modeManager = require('../modes/mode-manager').modeManager;
+        const modeManager = require("../modes/mode-manager").modeManager;
         return modeManager.getAllModes();
-      }
+      },
     });
 
     // Register get_context_usage tool
     this.toolRegistry.registerTool({
-      name: 'get_context_usage',
-      description: 'Get current context token usage',
+      name: "get_context_usage",
+      description: "Get current context token usage",
       inputSchema: {
-        type: 'object',
+        type: "object",
         properties: {},
-        additionalProperties: false
+        additionalProperties: false,
       },
       handler: async () => {
         // Simulate context usage tracking
         return {
           current: 2500,
           max: 4000,
-          percentage: 62.5
+          percentage: 62.5,
         };
-      }
+      },
     });
   }
 
@@ -666,13 +689,13 @@ export class MCPOrchestrationServer {
           const value = args[key];
           const expectedType = (prop as any).type;
 
-          if (expectedType === 'string' && typeof value !== 'string') {
+          if (expectedType === "string" && typeof value !== "string") {
             throw new Error(`Invalid type for ${key}: expected string`);
-          } else if (expectedType === 'number' && typeof value !== 'number') {
+          } else if (expectedType === "number" && typeof value !== "number") {
             throw new Error(`Invalid type for ${key}: expected number`);
-          } else if (expectedType === 'boolean' && typeof value !== 'boolean') {
+          } else if (expectedType === "boolean" && typeof value !== "boolean") {
             throw new Error(`Invalid type for ${key}: expected boolean`);
-          } else if (expectedType === 'object' && typeof value !== 'object') {
+          } else if (expectedType === "object" && typeof value !== "object") {
             throw new Error(`Invalid type for ${key}: expected object`);
           }
         }
@@ -698,11 +721,11 @@ class MCPToolRegistry {
   }
 
   listTools(): MCPToolInfo[] {
-    return Array.from(this.tools.values()).map(tool => ({
+    return Array.from(this.tools.values()).map((tool) => ({
       name: tool.name,
       description: tool.description,
-      category: 'orchestration',
-      version: '1.0.0'
+      category: "orchestration",
+      version: "1.0.0",
     }));
   }
 }
@@ -713,7 +736,7 @@ class MCPToolRegistry {
 #### 実装: src/mcp/context-window.ts
 
 ```typescript
-import type { ContextItem, TokenUsage } from './orchestration-types';
+import type { ContextItem, TokenUsage } from "./orchestration-types";
 
 export class ContextWindow {
   private maxTokens: number;
@@ -739,7 +762,7 @@ export class ContextWindow {
       value,
       tokens,
       priority,
-      timestamp: new Date()
+      timestamp: new Date(),
     });
   }
 
@@ -770,13 +793,15 @@ export class ContextWindow {
     return {
       current,
       max: this.maxTokens,
-      percentage: (current / this.maxTokens) * 100
+      percentage: (current / this.maxTokens) * 100,
     };
   }
 
   private getCurrentTokens(): number {
-    return Array.from(this.content.values())
-      .reduce((sum, item) => sum + item.tokens, 0);
+    return Array.from(this.content.values()).reduce(
+      (sum, item) => sum + item.tokens,
+      0,
+    );
   }
 
   private makeSpace(neededTokens: number): void {
@@ -807,10 +832,10 @@ export class ContextWindow {
 
 class TokenCalculator {
   calculateTokens(value: any): number {
-    if (typeof value === 'string') {
+    if (typeof value === "string") {
       // Rough approximation: 1 token per 4 characters
       return Math.ceil(value.length / 4);
-    } else if (typeof value === 'object') {
+    } else if (typeof value === "object") {
       const jsonString = JSON.stringify(value);
       return Math.ceil(jsonString.length / 4);
     } else {
@@ -823,30 +848,35 @@ class TokenCalculator {
 ## コミット計画
 
 ### コミット1: MCP型定義
+
 ```bash
 git add src/mcp/orchestration-types.ts
 git commit -m "feat(mcp): add MCP orchestration type definitions"
 ```
 
 ### コミット2: オーケストレーションツール
+
 ```bash
 git add src/mcp/orchestration-tools.ts test/mcp/orchestration-tools.test.ts
 git commit -m "feat(mcp): implement orchestration tools with tests"
 ```
 
 ### コミット3: MCPサーバー統合
+
 ```bash
 git add src/mcp/orchestration-server.ts test/mcp/orchestration-server.test.ts
 git commit -m "feat(mcp): implement MCP server integration with tool registry"
 ```
 
 ### コミット4: コンテキストウィンドウ管理
+
 ```bash
 git add src/mcp/context-window.ts test/mcp/context-window.test.ts
 git commit -m "feat(mcp): implement context window management"
 ```
 
 ### コミット5: エクスポートと統合
+
 ```bash
 git add src/mcp/index.ts test/mcp/integration.test.ts
 git commit -m "feat(mcp): add exports and integration tests"
@@ -876,83 +906,83 @@ test/
 
 ```typescript
 // test/mcp/integration.test.ts
-import { describe, test, expect } from 'bun:test';
-import { MCPOrchestrationServer } from '../../src/mcp/orchestration-server';
+import { describe, test, expect } from "bun:test";
+import { MCPOrchestrationServer } from "../../src/mcp/orchestration-server";
 
-describe('MCP Orchestration Integration', () => {
-  test('should handle complete orchestration workflow via MCP', async () => {
+describe("MCP Orchestration Integration", () => {
+  test("should handle complete orchestration workflow via MCP", async () => {
     const server = new MCPOrchestrationServer();
     server.registerOrchestrationTools();
 
     // 1. Analyze complex task
-    const analysis = await server.handleToolCall('analyze_task', {
+    const analysis = await server.handleToolCall("analyze_task", {
       task: `Create a complete user management system with:
         - Authentication and authorization
         - User profile management
         - Admin dashboard
-        - Email notifications`
+        - Email notifications`,
     });
 
     expect(analysis.requiresOrchestration).toBe(true);
 
     // 2. Decompose into subtasks
-    const subtasks = await server.handleToolCall('decompose_task', {
+    const subtasks = await server.handleToolCall("decompose_task", {
       task: analysis.suggestedApproach,
       maxSubtasks: 5,
-      autoAssignModes: true
+      autoAssignModes: true,
     });
 
     expect(subtasks.length).toBeGreaterThan(2);
-    expect(subtasks.every(st => st.mode)).toBe(true);
+    expect(subtasks.every((st) => st.mode)).toBe(true);
 
     // 3. Switch modes for different subtasks
     for (const subtask of subtasks) {
-      const modeResult = await server.handleToolCall('switch_mode', {
+      const modeResult = await server.handleToolCall("switch_mode", {
         mode: subtask.mode,
-        preserveContext: true
+        preserveContext: true,
       });
 
       expect(modeResult.mode.slug).toBe(subtask.mode);
     }
 
     // 4. Use boomerang for specific task
-    const debugResult = await server.handleToolCall('boomerang', {
-      task: 'Debug authentication issues',
-      targetMode: 'debug',
-      returnContext: true
+    const debugResult = await server.handleToolCall("boomerang", {
+      task: "Debug authentication issues",
+      targetMode: "debug",
+      returnContext: true,
     });
 
-    expect(debugResult.mode).toBe('debug');
-    expect(debugResult.result).toContain('Debug');
+    expect(debugResult.mode).toBe("debug");
+    expect(debugResult.result).toContain("Debug");
 
     // 5. Check context usage
-    const usage = await server.handleToolCall('get_context_usage', {});
+    const usage = await server.handleToolCall("get_context_usage", {});
     expect(usage.percentage).toBeLessThanOrEqual(100);
   });
 
-  test('should optimize large contexts effectively', async () => {
+  test("should optimize large contexts effectively", async () => {
     const server = new MCPOrchestrationServer();
     server.registerOrchestrationTools();
 
     const largeContext = {
-      files: Array(50).fill('Large file content...').join('\n'),
-      history: Array(100).fill('Command history').join('\n'),
+      files: Array(50).fill("Large file content...").join("\n"),
+      history: Array(100).fill("Command history").join("\n"),
       metadata: {
         timestamp: new Date(),
-        user: 'test',
-        environment: 'development'
-      }
+        user: "test",
+        environment: "development",
+      },
     };
 
-    const optimized = await server.handleToolCall('optimize_context', {
+    const optimized = await server.handleToolCall("optimize_context", {
       context: largeContext,
       maxTokens: 1000,
-      priorityKeys: ['files']
+      priorityKeys: ["files"],
     });
 
     expect(optimized.tokensUsed).toBeLessThanOrEqual(1000);
     expect(optimized.compressionRatio).toBeGreaterThan(0);
-    expect(optimized.context).toHaveProperty('files');
+    expect(optimized.context).toHaveProperty("files");
   });
 });
 ```
@@ -983,6 +1013,7 @@ describe('MCP Orchestration Integration', () => {
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase3-github-actions から作業ブランチを作成
 git checkout phase3-github-actions
@@ -1013,6 +1044,7 @@ git branch -d phase4-mcp-extension # ローカルの作業ブランチを削除
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase3-github-actions から作業ブランチ作成
 git checkout phase3-github-actions
@@ -1044,6 +1076,7 @@ git branch -d phase4-mcp-extension
 ## 依存関係
 
 このフェーズは以下のフェーズ完了後に実装してください：
+
 - フェーズ1: モードシステム（モード管理）
 - フェーズ2: オーケストレーション（タスク分析、コンテキスト最適化）
 - フェーズ3.2: GitHub Actions統合（実行基盤）

--- a/predev-docs/08-phase4-mcp-extension-design.md
+++ b/predev-docs/08-phase4-mcp-extension-design.md
@@ -1,0 +1,1057 @@
+# フェーズ4: MCP拡張 - 詳細設計
+
+## 概要
+
+MCP（Model Context Protocol）拡張では、オーケストレーション機能をMCPツールとして提供し、タスク分解、モード切り替え、コンテキスト最適化などの機能を統合します。既存のMCPサーバーインフラストラクチャを拡張し、高度なタスク管理機能を提供します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class MCPOrchestrationServer {
+        -taskAnalyzer: TaskAnalyzer
+        -modeManager: ModeManager
+        -contextOptimizer: ContextOptimizer
+        -toolRegistry: MCPToolRegistry
+        +registerOrchestrationTools(): void
+        +handleToolCall(tool: string, args: any): Promise<any>
+    }
+
+    class OrchestrationTools {
+        +analyzeTask(args: AnalyzeTaskArgs): TaskAnalysis
+        +switchMode(args: SwitchModeArgs): ModeContext
+        +optimizeContext(args: OptimizeContextArgs): OptimizedContext
+        +decomposeTask(args: DecomposeTaskArgs): SubTask[]
+        +boomerang(args: BoomerangArgs): BoomerangResult
+    }
+
+    class MCPToolRegistry {
+        -tools: Map<string, MCPTool>
+        +registerTool(tool: MCPTool): void
+        +getTool(name: string): MCPTool
+        +listTools(): MCPToolInfo[]
+    }
+
+    class MCPTool {
+        <<interface>>
+        +name: string
+        +description: string
+        +inputSchema: JSONSchema
+        +handler: Function
+    }
+
+    class ContextWindow {
+        -maxTokens: number
+        -currentTokens: number
+        -content: Map<string, ContextItem>
+        +addContext(key: string, value: any): void
+        +removeContext(key: string): void
+        +getOptimizedContext(): any
+        +getTokenUsage(): TokenUsage
+    }
+
+    MCPOrchestrationServer --> OrchestrationTools : provides
+    MCPOrchestrationServer --> MCPToolRegistry : uses
+    MCPToolRegistry --> MCPTool : manages
+    OrchestrationTools --> ContextWindow : uses
+```
+
+## TDD実装計画
+
+### タスク5.1: MCP型定義の作成
+
+#### 実装: src/mcp/orchestration-types.ts
+
+```typescript
+import type { TaskAnalysis, SubTask } from '../orchestration/types';
+import type { Mode } from '../modes/types';
+
+export interface MCPTool {
+  name: string;
+  description: string;
+  inputSchema: JSONSchema;
+  handler: (args: any) => Promise<any>;
+}
+
+export interface JSONSchema {
+  type: string;
+  properties?: Record<string, any>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export interface AnalyzeTaskArgs {
+  task: string;
+  context?: Record<string, any>;
+}
+
+export interface SwitchModeArgs {
+  mode: string;
+  preserveContext?: boolean;
+}
+
+export interface OptimizeContextArgs {
+  context: Record<string, any>;
+  maxTokens: number;
+  priorityKeys?: string[];
+}
+
+export interface DecomposeTaskArgs {
+  task: string;
+  maxSubtasks?: number;
+  autoAssignModes?: boolean;
+}
+
+export interface BoomerangArgs {
+  task: string;
+  targetMode: string;
+  returnContext?: boolean;
+}
+
+export interface OptimizedContext {
+  context: Record<string, any>;
+  tokensUsed: number;
+  removedKeys: string[];
+  compressionRatio: number;
+}
+
+export interface BoomerangResult {
+  result: string;
+  mode: string;
+  tokensUsed: number;
+  duration: number;
+}
+
+export interface TokenUsage {
+  current: number;
+  max: number;
+  percentage: number;
+}
+
+export interface ContextItem {
+  key: string;
+  value: any;
+  tokens: number;
+  priority: number;
+  timestamp: Date;
+}
+
+export interface MCPToolInfo {
+  name: string;
+  description: string;
+  category: string;
+  version: string;
+}
+```
+
+### タスク5.2: オーケストレーションツールの実装
+
+#### テストファースト: src/mcp/orchestration-tools.ts
+
+```typescript
+// test/mcp/orchestration-tools.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { OrchestrationTools } from '../../src/mcp/orchestration-tools';
+import type { AnalyzeTaskArgs, SwitchModeArgs } from '../../src/mcp/orchestration-types';
+
+describe('OrchestrationTools', () => {
+  let tools: OrchestrationTools;
+
+  beforeEach(() => {
+    tools = new OrchestrationTools();
+  });
+
+  test('should analyze task complexity', async () => {
+    const args: AnalyzeTaskArgs = {
+      task: 'Implement user authentication with OAuth2 and JWT tokens',
+      context: { framework: 'Express.js' }
+    };
+
+    const analysis = await tools.analyzeTask(args);
+
+    expect(analysis.complexity).toBeGreaterThan(5);
+    expect(analysis.requiredModes).toContain('code');
+    expect(analysis.requiresOrchestration).toBe(true);
+  });
+
+  test('should switch mode with context preservation', async () => {
+    const args: SwitchModeArgs = {
+      mode: 'architect',
+      preserveContext: true
+    };
+
+    const result = await tools.switchMode(args);
+
+    expect(result.mode.slug).toBe('architect');
+    expect(result.previousMode).toBeDefined();
+    expect(result.contextPreserved).toBe(true);
+  });
+
+  test('should optimize context for token limit', async () => {
+    const largeContext = {
+      fileContents: 'Large file content...'.repeat(1000),
+      history: ['Previous command 1', 'Previous command 2'],
+      metadata: { timestamp: new Date(), user: 'test' }
+    };
+
+    const args = {
+      context: largeContext,
+      maxTokens: 1000,
+      priorityKeys: ['fileContents']
+    };
+
+    const optimized = await tools.optimizeContext(args);
+
+    expect(optimized.tokensUsed).toBeLessThanOrEqual(1000);
+    expect(optimized.removedKeys.length).toBeGreaterThan(0);
+    expect(optimized.compressionRatio).toBeGreaterThan(0.5);
+  });
+
+  test('should decompose complex task into subtasks', async () => {
+    const args = {
+      task: `Build a complete e-commerce platform with:
+        - User authentication system
+        - Product catalog management
+        - Shopping cart functionality
+        - Payment processing
+        - Order tracking`,
+      maxSubtasks: 10,
+      autoAssignModes: true
+    };
+
+    const subtasks = await tools.decomposeTask(args);
+
+    expect(subtasks.length).toBeGreaterThan(3);
+    expect(subtasks.length).toBeLessThanOrEqual(10);
+    expect(subtasks.every(st => st.mode)).toBe(true);
+    expect(subtasks.some(st => st.dependencies.length > 0)).toBe(true);
+  });
+
+  test('should handle boomerang pattern for mode delegation', async () => {
+    const args = {
+      task: 'Debug memory leak in payment processor',
+      targetMode: 'debug',
+      returnContext: true
+    };
+
+    const result = await tools.boomerang(args);
+
+    expect(result.mode).toBe('debug');
+    expect(result.result).toContain('memory');
+    expect(result.tokensUsed).toBeGreaterThan(0);
+  });
+});
+```
+
+#### 実装: src/mcp/orchestration-tools.ts
+
+```typescript
+import { TaskAnalyzer } from '../orchestration/task-analyzer';
+import { modeManager } from '../modes/mode-manager';
+import { ContextOptimizer } from '../orchestration/context-optimizer';
+import { SubtaskGenerator } from '../orchestration/subtask-generator';
+import type {
+  AnalyzeTaskArgs,
+  SwitchModeArgs,
+  OptimizeContextArgs,
+  DecomposeTaskArgs,
+  BoomerangArgs,
+  OptimizedContext,
+  BoomerangResult
+} from './orchestration-types';
+import type { TaskAnalysis, SubTask } from '../orchestration/types';
+import type { Mode } from '../modes/types';
+
+export class OrchestrationTools {
+  private taskAnalyzer: TaskAnalyzer;
+  private contextOptimizer: ContextOptimizer;
+  private subtaskGenerator: SubtaskGenerator;
+  private currentMode: Mode;
+
+  constructor() {
+    this.taskAnalyzer = new TaskAnalyzer();
+    this.contextOptimizer = new ContextOptimizer();
+    this.subtaskGenerator = new SubtaskGenerator();
+    this.currentMode = modeManager.getDefaultMode();
+  }
+
+  async analyzeTask(args: AnalyzeTaskArgs): Promise<TaskAnalysis> {
+    const { task, context } = args;
+
+    // Analyze task complexity
+    const analysis = this.taskAnalyzer.analyzeTask(task);
+
+    // Enhance analysis with context if provided
+    if (context) {
+      analysis.suggestedApproach = this.enhanceApproachWithContext(
+        analysis.suggestedApproach,
+        context
+      );
+    }
+
+    return analysis;
+  }
+
+  async switchMode(args: SwitchModeArgs): Promise<{
+    mode: Mode;
+    previousMode: Mode;
+    contextPreserved: boolean;
+  }> {
+    const { mode: modeSlug, preserveContext = false } = args;
+
+    const previousMode = this.currentMode;
+    const newMode = modeManager.getModeBySlug(modeSlug);
+
+    this.currentMode = newMode;
+
+    return {
+      mode: newMode,
+      previousMode,
+      contextPreserved: preserveContext
+    };
+  }
+
+  async optimizeContext(args: OptimizeContextArgs): Promise<OptimizedContext> {
+    const { context, maxTokens, priorityKeys = [] } = args;
+
+    return this.contextOptimizer.optimizeContext({
+      context,
+      maxTokens,
+      priorityKeys
+    });
+  }
+
+  async decomposeTask(args: DecomposeTaskArgs): Promise<SubTask[]> {
+    const { task, maxSubtasks = 10, autoAssignModes = true } = args;
+
+    // Analyze task first
+    const analysis = await this.analyzeTask({ task });
+
+    // Generate subtasks
+    const subtasks = this.subtaskGenerator.generateSubtasks(analysis);
+
+    // Limit number of subtasks
+    const limitedSubtasks = subtasks.slice(0, maxSubtasks);
+
+    // Auto-assign modes if requested
+    if (autoAssignModes) {
+      return limitedSubtasks.map(subtask => ({
+        ...subtask,
+        mode: subtask.mode || this.selectOptimalMode(subtask.description)
+      }));
+    }
+
+    return limitedSubtasks;
+  }
+
+  async boomerang(args: BoomerangArgs): Promise<BoomerangResult> {
+    const { task, targetMode, returnContext = false } = args;
+    const startTime = Date.now();
+
+    // Switch to target mode
+    const switchResult = await this.switchMode({
+      mode: targetMode,
+      preserveContext: returnContext
+    });
+
+    // Execute task in target mode (simulated)
+    const result = await this.executeInMode(task, switchResult.mode);
+
+    // Return to previous mode if context was preserved
+    if (returnContext) {
+      await this.switchMode({
+        mode: switchResult.previousMode.slug,
+        preserveContext: true
+      });
+    }
+
+    return {
+      result: result.output,
+      mode: targetMode,
+      tokensUsed: result.tokensUsed,
+      duration: Date.now() - startTime
+    };
+  }
+
+  private enhanceApproachWithContext(
+    approach: string,
+    context: Record<string, any>
+  ): string {
+    const contextInfo = Object.entries(context)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ');
+
+    return `${approach} Context: ${contextInfo}`;
+  }
+
+  private selectOptimalMode(taskDescription: string): string {
+    const modeSelector = new (require('../orchestration/mode-selector').ModeSelector)();
+    return modeSelector.selectOptimalMode(taskDescription);
+  }
+
+  private async executeInMode(
+    task: string,
+    mode: Mode
+  ): Promise<{ output: string; tokensUsed: number }> {
+    // Simulate execution in specific mode
+    const baseTokens = 500;
+    const complexityMultiplier = task.length / 100;
+
+    return {
+      output: `Executed "${task}" in ${mode.name} mode. ${mode.roleDefinition}`,
+      tokensUsed: Math.floor(baseTokens * complexityMultiplier)
+    };
+  }
+}
+```
+
+### タスク5.3: MCPサーバー統合の実装
+
+#### テストファースト: src/mcp/orchestration-server.ts
+
+```typescript
+// test/mcp/orchestration-server.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { MCPOrchestrationServer } from '../../src/mcp/orchestration-server';
+
+describe('MCPOrchestrationServer', () => {
+  let server: MCPOrchestrationServer;
+
+  beforeEach(() => {
+    server = new MCPOrchestrationServer();
+  });
+
+  test('should register orchestration tools', () => {
+    server.registerOrchestrationTools();
+
+    const tools = server.listTools();
+    const toolNames = tools.map(t => t.name);
+
+    expect(toolNames).toContain('analyze_task');
+    expect(toolNames).toContain('switch_mode');
+    expect(toolNames).toContain('optimize_context');
+    expect(toolNames).toContain('decompose_task');
+    expect(toolNames).toContain('boomerang');
+  });
+
+  test('should handle analyze_task tool call', async () => {
+    server.registerOrchestrationTools();
+
+    const result = await server.handleToolCall('analyze_task', {
+      task: 'Implement user authentication'
+    });
+
+    expect(result).toHaveProperty('complexity');
+    expect(result).toHaveProperty('requiredModes');
+  });
+
+  test('should handle switch_mode tool call', async () => {
+    server.registerOrchestrationTools();
+
+    const result = await server.handleToolCall('switch_mode', {
+      mode: 'architect'
+    });
+
+    expect(result.mode.slug).toBe('architect');
+  });
+
+  test('should handle optimize_context tool call', async () => {
+    server.registerOrchestrationTools();
+
+    const result = await server.handleToolCall('optimize_context', {
+      context: { data: 'Large context data'.repeat(100) },
+      maxTokens: 500
+    });
+
+    expect(result.tokensUsed).toBeLessThanOrEqual(500);
+  });
+
+  test('should validate tool arguments', async () => {
+    server.registerOrchestrationTools();
+
+    await expect(
+      server.handleToolCall('analyze_task', {})
+    ).rejects.toThrow('Missing required argument: task');
+  });
+
+  test('should handle unknown tool gracefully', async () => {
+    await expect(
+      server.handleToolCall('unknown_tool', {})
+    ).rejects.toThrow('Unknown tool: unknown_tool');
+  });
+});
+```
+
+#### 実装: src/mcp/orchestration-server.ts
+
+```typescript
+import { OrchestrationTools } from './orchestration-tools';
+import { MCPToolRegistry } from './tool-registry';
+import type { MCPTool, MCPToolInfo } from './orchestration-types';
+
+export class MCPOrchestrationServer {
+  private toolRegistry: MCPToolRegistry;
+  private orchestrationTools: OrchestrationTools;
+
+  constructor() {
+    this.toolRegistry = new MCPToolRegistry();
+    this.orchestrationTools = new OrchestrationTools();
+  }
+
+  registerOrchestrationTools(): void {
+    // Register analyze_task tool
+    this.toolRegistry.registerTool({
+      name: 'analyze_task',
+      description: 'Analyze task complexity and determine required modes',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          task: { type: 'string', description: 'Task description to analyze' },
+          context: { type: 'object', description: 'Optional context information' }
+        },
+        required: ['task'],
+        additionalProperties: false
+      },
+      handler: async (args) => this.orchestrationTools.analyzeTask(args)
+    });
+
+    // Register switch_mode tool
+    this.toolRegistry.registerTool({
+      name: 'switch_mode',
+      description: 'Switch to a different AI mode',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          mode: { type: 'string', description: 'Target mode slug' },
+          preserveContext: { type: 'boolean', description: 'Preserve current context' }
+        },
+        required: ['mode'],
+        additionalProperties: false
+      },
+      handler: async (args) => this.orchestrationTools.switchMode(args)
+    });
+
+    // Register optimize_context tool
+    this.toolRegistry.registerTool({
+      name: 'optimize_context',
+      description: 'Optimize context to fit within token limits',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          context: { type: 'object', description: 'Context to optimize' },
+          maxTokens: { type: 'number', description: 'Maximum token limit' },
+          priorityKeys: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Keys to prioritize'
+          }
+        },
+        required: ['context', 'maxTokens'],
+        additionalProperties: false
+      },
+      handler: async (args) => this.orchestrationTools.optimizeContext(args)
+    });
+
+    // Register decompose_task tool
+    this.toolRegistry.registerTool({
+      name: 'decompose_task',
+      description: 'Decompose a complex task into subtasks',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          task: { type: 'string', description: 'Task to decompose' },
+          maxSubtasks: { type: 'number', description: 'Maximum number of subtasks' },
+          autoAssignModes: { type: 'boolean', description: 'Auto-assign modes to subtasks' }
+        },
+        required: ['task'],
+        additionalProperties: false
+      },
+      handler: async (args) => this.orchestrationTools.decomposeTask(args)
+    });
+
+    // Register boomerang tool
+    this.toolRegistry.registerTool({
+      name: 'boomerang',
+      description: 'Delegate task to specific mode and return',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          task: { type: 'string', description: 'Task to delegate' },
+          targetMode: { type: 'string', description: 'Target mode for delegation' },
+          returnContext: { type: 'boolean', description: 'Return to original mode after' }
+        },
+        required: ['task', 'targetMode'],
+        additionalProperties: false
+      },
+      handler: async (args) => this.orchestrationTools.boomerang(args)
+    });
+
+    // Register list_modes tool
+    this.toolRegistry.registerTool({
+      name: 'list_modes',
+      description: 'List all available AI modes',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      },
+      handler: async () => {
+        const modeManager = require('../modes/mode-manager').modeManager;
+        return modeManager.getAllModes();
+      }
+    });
+
+    // Register get_context_usage tool
+    this.toolRegistry.registerTool({
+      name: 'get_context_usage',
+      description: 'Get current context token usage',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false
+      },
+      handler: async () => {
+        // Simulate context usage tracking
+        return {
+          current: 2500,
+          max: 4000,
+          percentage: 62.5
+        };
+      }
+    });
+  }
+
+  async handleToolCall(toolName: string, args: any): Promise<any> {
+    const tool = this.toolRegistry.getTool(toolName);
+
+    if (!tool) {
+      throw new Error(`Unknown tool: ${toolName}`);
+    }
+
+    // Validate arguments
+    this.validateArguments(tool, args);
+
+    // Execute tool handler
+    return await tool.handler(args);
+  }
+
+  listTools(): MCPToolInfo[] {
+    return this.toolRegistry.listTools();
+  }
+
+  private validateArguments(tool: MCPTool, args: any): void {
+    const schema = tool.inputSchema;
+
+    // Check required properties
+    if (schema.required) {
+      for (const required of schema.required) {
+        if (!(required in args)) {
+          throw new Error(`Missing required argument: ${required}`);
+        }
+      }
+    }
+
+    // Type validation could be more comprehensive
+    // This is a simplified version
+    if (schema.properties) {
+      for (const [key, prop] of Object.entries(schema.properties)) {
+        if (key in args) {
+          const value = args[key];
+          const expectedType = (prop as any).type;
+
+          if (expectedType === 'string' && typeof value !== 'string') {
+            throw new Error(`Invalid type for ${key}: expected string`);
+          } else if (expectedType === 'number' && typeof value !== 'number') {
+            throw new Error(`Invalid type for ${key}: expected number`);
+          } else if (expectedType === 'boolean' && typeof value !== 'boolean') {
+            throw new Error(`Invalid type for ${key}: expected boolean`);
+          } else if (expectedType === 'object' && typeof value !== 'object') {
+            throw new Error(`Invalid type for ${key}: expected object`);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Tool Registry implementation
+class MCPToolRegistry {
+  private tools: Map<string, MCPTool>;
+
+  constructor() {
+    this.tools = new Map();
+  }
+
+  registerTool(tool: MCPTool): void {
+    this.tools.set(tool.name, tool);
+  }
+
+  getTool(name: string): MCPTool | undefined {
+    return this.tools.get(name);
+  }
+
+  listTools(): MCPToolInfo[] {
+    return Array.from(this.tools.values()).map(tool => ({
+      name: tool.name,
+      description: tool.description,
+      category: 'orchestration',
+      version: '1.0.0'
+    }));
+  }
+}
+```
+
+### タスク5.4: コンテキストウィンドウ管理の実装
+
+#### 実装: src/mcp/context-window.ts
+
+```typescript
+import type { ContextItem, TokenUsage } from './orchestration-types';
+
+export class ContextWindow {
+  private maxTokens: number;
+  private content: Map<string, ContextItem>;
+  private tokenCalculator: TokenCalculator;
+
+  constructor(maxTokens: number = 4000) {
+    this.maxTokens = maxTokens;
+    this.content = new Map();
+    this.tokenCalculator = new TokenCalculator();
+  }
+
+  addContext(key: string, value: any, priority: number = 1): void {
+    const tokens = this.tokenCalculator.calculateTokens(value);
+
+    // Check if adding would exceed limit
+    if (this.getCurrentTokens() + tokens > this.maxTokens) {
+      this.makeSpace(tokens);
+    }
+
+    this.content.set(key, {
+      key,
+      value,
+      tokens,
+      priority,
+      timestamp: new Date()
+    });
+  }
+
+  removeContext(key: string): void {
+    this.content.delete(key);
+  }
+
+  getOptimizedContext(): any {
+    const context: Record<string, any> = {};
+
+    // Sort by priority (descending) and timestamp (newer first)
+    const sortedItems = Array.from(this.content.values()).sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return b.priority - a.priority;
+      }
+      return b.timestamp.getTime() - a.timestamp.getTime();
+    });
+
+    for (const item of sortedItems) {
+      context[item.key] = item.value;
+    }
+
+    return context;
+  }
+
+  getTokenUsage(): TokenUsage {
+    const current = this.getCurrentTokens();
+    return {
+      current,
+      max: this.maxTokens,
+      percentage: (current / this.maxTokens) * 100
+    };
+  }
+
+  private getCurrentTokens(): number {
+    return Array.from(this.content.values())
+      .reduce((sum, item) => sum + item.tokens, 0);
+  }
+
+  private makeSpace(neededTokens: number): void {
+    const currentTokens = this.getCurrentTokens();
+    const targetTokens = this.maxTokens - neededTokens;
+
+    if (currentTokens <= targetTokens) return;
+
+    // Sort by priority (ascending) and timestamp (older first) for removal
+    const itemsToRemove = Array.from(this.content.values()).sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority;
+      }
+      return a.timestamp.getTime() - b.timestamp.getTime();
+    });
+
+    let removedTokens = 0;
+    for (const item of itemsToRemove) {
+      this.content.delete(item.key);
+      removedTokens += item.tokens;
+
+      if (currentTokens - removedTokens <= targetTokens) {
+        break;
+      }
+    }
+  }
+}
+
+class TokenCalculator {
+  calculateTokens(value: any): number {
+    if (typeof value === 'string') {
+      // Rough approximation: 1 token per 4 characters
+      return Math.ceil(value.length / 4);
+    } else if (typeof value === 'object') {
+      const jsonString = JSON.stringify(value);
+      return Math.ceil(jsonString.length / 4);
+    } else {
+      return 10; // Default for simple values
+    }
+  }
+}
+```
+
+## コミット計画
+
+### コミット1: MCP型定義
+```bash
+git add src/mcp/orchestration-types.ts
+git commit -m "feat(mcp): add MCP orchestration type definitions"
+```
+
+### コミット2: オーケストレーションツール
+```bash
+git add src/mcp/orchestration-tools.ts test/mcp/orchestration-tools.test.ts
+git commit -m "feat(mcp): implement orchestration tools with tests"
+```
+
+### コミット3: MCPサーバー統合
+```bash
+git add src/mcp/orchestration-server.ts test/mcp/orchestration-server.test.ts
+git commit -m "feat(mcp): implement MCP server integration with tool registry"
+```
+
+### コミット4: コンテキストウィンドウ管理
+```bash
+git add src/mcp/context-window.ts test/mcp/context-window.test.ts
+git commit -m "feat(mcp): implement context window management"
+```
+
+### コミット5: エクスポートと統合
+```bash
+git add src/mcp/index.ts test/mcp/integration.test.ts
+git commit -m "feat(mcp): add exports and integration tests"
+```
+
+## ディレクトリ構造
+
+```
+src/
+├── mcp/
+│   ├── orchestration-types.ts    # MCP型定義
+│   ├── orchestration-tools.ts    # オーケストレーションツール実装
+│   ├── orchestration-server.ts   # MCPサーバー統合
+│   ├── context-window.ts         # コンテキストウィンドウ管理
+│   ├── tool-registry.ts          # ツールレジストリ
+│   └── index.ts                  # エクスポート
+
+test/
+└── mcp/
+    ├── orchestration-tools.test.ts
+    ├── orchestration-server.test.ts
+    ├── context-window.test.ts
+    └── integration.test.ts
+```
+
+## 統合テスト
+
+```typescript
+// test/mcp/integration.test.ts
+import { describe, test, expect } from 'bun:test';
+import { MCPOrchestrationServer } from '../../src/mcp/orchestration-server';
+
+describe('MCP Orchestration Integration', () => {
+  test('should handle complete orchestration workflow via MCP', async () => {
+    const server = new MCPOrchestrationServer();
+    server.registerOrchestrationTools();
+
+    // 1. Analyze complex task
+    const analysis = await server.handleToolCall('analyze_task', {
+      task: `Create a complete user management system with:
+        - Authentication and authorization
+        - User profile management
+        - Admin dashboard
+        - Email notifications`
+    });
+
+    expect(analysis.requiresOrchestration).toBe(true);
+
+    // 2. Decompose into subtasks
+    const subtasks = await server.handleToolCall('decompose_task', {
+      task: analysis.suggestedApproach,
+      maxSubtasks: 5,
+      autoAssignModes: true
+    });
+
+    expect(subtasks.length).toBeGreaterThan(2);
+    expect(subtasks.every(st => st.mode)).toBe(true);
+
+    // 3. Switch modes for different subtasks
+    for (const subtask of subtasks) {
+      const modeResult = await server.handleToolCall('switch_mode', {
+        mode: subtask.mode,
+        preserveContext: true
+      });
+
+      expect(modeResult.mode.slug).toBe(subtask.mode);
+    }
+
+    // 4. Use boomerang for specific task
+    const debugResult = await server.handleToolCall('boomerang', {
+      task: 'Debug authentication issues',
+      targetMode: 'debug',
+      returnContext: true
+    });
+
+    expect(debugResult.mode).toBe('debug');
+    expect(debugResult.result).toContain('Debug');
+
+    // 5. Check context usage
+    const usage = await server.handleToolCall('get_context_usage', {});
+    expect(usage.percentage).toBeLessThanOrEqual(100);
+  });
+
+  test('should optimize large contexts effectively', async () => {
+    const server = new MCPOrchestrationServer();
+    server.registerOrchestrationTools();
+
+    const largeContext = {
+      files: Array(50).fill('Large file content...').join('\n'),
+      history: Array(100).fill('Command history').join('\n'),
+      metadata: {
+        timestamp: new Date(),
+        user: 'test',
+        environment: 'development'
+      }
+    };
+
+    const optimized = await server.handleToolCall('optimize_context', {
+      context: largeContext,
+      maxTokens: 1000,
+      priorityKeys: ['files']
+    });
+
+    expect(optimized.tokensUsed).toBeLessThanOrEqual(1000);
+    expect(optimized.compressionRatio).toBeGreaterThan(0);
+    expect(optimized.context).toHaveProperty('files');
+  });
+});
+```
+
+## MCPサーバー設定
+
+```json
+// mcp-config.json
+{
+  "mcpServers": {
+    "orchestration": {
+      "command": "node",
+      "args": ["./dist/mcp/server.js"],
+      "tools": [
+        "analyze_task",
+        "switch_mode",
+        "optimize_context",
+        "decompose_task",
+        "boomerang",
+        "list_modes",
+        "get_context_usage"
+      ]
+    }
+  }
+}
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase3-github-actions から作業ブランチを作成
+git checkout phase3-github-actions
+git pull origin phase3-github-actions # 念のため最新化
+git checkout -b phase4-mcp-extension phase3-github-actions
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(mcp-extension): implement MCP extension" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase4-mcp-extension
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase3-github-actions とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase3-github-actions
+git pull origin phase3-github-actions # リモートの変更を取り込み最新化
+git branch -d phase4-mcp-extension # ローカルの作業ブランチを削除
+# git push origin --delete phase4-mcp-extension # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase3-github-actions から作業ブランチ作成
+git checkout phase3-github-actions
+git pull origin phase3-github-actions # 念のため最新化
+git checkout -b phase4-mcp-extension phase3-github-actions
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(mcp-extension): implement MCP extension" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase4-mcp-extension
+# GitHub上で phase3-github-actions をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase3-github-actions
+git pull origin phase3-github-actions
+git branch -d phase4-mcp-extension
+```
+
+## 依存関係
+
+このフェーズは以下のフェーズ完了後に実装してください：
+- フェーズ1: モードシステム（モード管理）
+- フェーズ2: オーケストレーション（タスク分析、コンテキスト最適化）
+- フェーズ3.2: GitHub Actions統合（実行基盤）
+
+## 次のステップ
+
+1. フェーズ5で統合テストと最適化を実施
+2. MCPツールのドキュメントを作成
+3. Claude CodeエディタとのMCP統合をテスト
+
+**💡 重要な点**: MCPツールとして提供することで、オーケストレーション機能を他のMCP対応ツールからも利用可能にし、エコシステム全体の価値を高めることが重要です。

--- a/predev-docs/09-phase5-integration-testing-design.md
+++ b/predev-docs/09-phase5-integration-testing-design.md
@@ -1,0 +1,1175 @@
+# フェーズ5: 統合テストと最適化 - 詳細設計
+
+## 概要
+
+統合テストと最適化フェーズでは、実装された全コンポーネントの統合テスト、パフォーマンス最適化、エラーハンドリング強化、およびドキュメント作成を行います。システム全体の品質保証と本番環境での安定稼働を目指します。
+
+**📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+- GitHub: https://github.com/RooCodeInc/Roo-Code
+- UIthub: https://uithub.com/RooCodeInc/Roo-Code
+- DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
+
+**💡 重要な点**: RooCodeの実装パターンを参考にしつつ、Claude Code Actionの環境に適応させることが重要です。
+
+## アーキテクチャ
+
+```mermaid
+classDiagram
+    class IntegrationTestSuite {
+        -e2eTests: E2ETestRunner
+        -performanceTests: PerformanceTestRunner
+        -loadTests: LoadTestRunner
+        +runAllTests(): TestReport
+        +runE2ETests(): E2ETestResults
+        +runPerformanceTests(): PerformanceMetrics
+        +runLoadTests(): LoadTestResults
+    }
+
+    class PerformanceOptimizer {
+        -metricsCollector: MetricsCollector
+        -cacheManager: CacheManager
+        -tokenOptimizer: TokenOptimizer
+        +analyzePerformance(): PerformanceAnalysis
+        +optimizeTokenUsage(): OptimizationResult
+        +implementCaching(): CacheConfiguration
+        +reduceLatency(): LatencyReport
+    }
+
+    class ErrorHandlingFramework {
+        -errorRecovery: ErrorRecovery
+        -fallbackStrategies: FallbackStrategies
+        -errorReporter: ErrorReporter
+        +handleOrchestrationError(error: Error): RecoveryResult
+        +implementFallback(context: ErrorContext): FallbackResult
+        +reportError(error: ErrorInfo): void
+    }
+
+    class DocumentationGenerator {
+        -apiDocGen: APIDocumentationGenerator
+        -userGuideGen: UserGuideGenerator
+        -exampleGen: ExampleGenerator
+        +generateAPIDocs(): APIDocumentation
+        +generateUserGuide(): UserGuide
+        +generateExamples(): ExampleCollection
+    }
+
+    class MetricsCollector {
+        -performanceMetrics: Map<string, Metric>
+        -usageMetrics: Map<string, UsageData>
+        +collectMetric(name: string, value: number): void
+        +getMetricSummary(): MetricsSummary
+        +exportMetrics(): MetricsExport
+    }
+
+    IntegrationTestSuite --> PerformanceOptimizer : validates
+    PerformanceOptimizer --> MetricsCollector : uses
+    IntegrationTestSuite --> ErrorHandlingFramework : tests
+    DocumentationGenerator --> IntegrationTestSuite : documents
+```
+
+## TDD実装計画
+
+### タスク6.1: 統合テスト型定義の作成
+
+#### 実装: src/testing/integration-types.ts
+
+```typescript
+export interface TestReport {
+  summary: TestSummary;
+  e2eResults: E2ETestResults;
+  performanceResults: PerformanceMetrics;
+  loadTestResults: LoadTestResults;
+  recommendations: string[];
+}
+
+export interface TestSummary {
+  totalTests: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  duration: number;
+  timestamp: Date;
+}
+
+export interface E2ETestResults {
+  scenarios: TestScenario[];
+  coverage: CoverageReport;
+  criticalPaths: CriticalPath[];
+  targetCoveragePercentage?: number;
+}
+
+export interface TestScenario {
+  name: string;
+  description: string;
+  steps: TestStep[];
+  result: 'passed' | 'failed' | 'skipped';
+  duration: number;
+  errors?: string[];
+}
+
+export interface TestStep {
+  action: string;
+  expected: string;
+  actual?: string;
+  passed: boolean;
+}
+
+export interface PerformanceMetrics {
+  avgResponseTime: number;
+  p95ResponseTime: number;
+  p99ResponseTime: number;
+  tokenUsage: TokenMetrics;
+  memoryUsage: MemoryMetrics;
+  throughput: number;
+}
+
+export interface TokenMetrics {
+  avgTokensPerRequest: number;
+  maxTokensPerRequest: number;
+  tokenEfficiency: number;
+  compressionRatio: number;
+}
+
+export interface LoadTestResults {
+  concurrentUsers: number;
+  requestsPerSecond: number;
+  errorRate: number;
+  avgLatency: number;
+  peakMemoryUsage: number;
+}
+
+export interface PerformanceAnalysis {
+  bottlenecks: Bottleneck[];
+  optimizationOpportunities: OptimizationOpportunity[];
+  resourceUtilization: ResourceMetrics;
+}
+
+export interface Bottleneck {
+  component: string;
+  metric: string;
+  currentValue: number;
+  threshold: number;
+  impact: 'high' | 'medium' | 'low';
+}
+
+export interface OptimizationOpportunity {
+  area: string;
+  description: string;
+  expectedImprovement: number;
+  effort: 'low' | 'medium' | 'high';
+  priority: number;
+}
+```
+
+### タスク6.2: E2E統合テストスイートの実装
+
+E2E統合テストスイートは、システム全体の動作をユーザーシナリオに基づいて検証します。タスクの受付から分析、サブタスクへの分解、各モードでの処理、結果の統合、GitHub Actions連携による進捗通知まで、一連のフローを網羅的にテストします。**全てのコンポーネントおよび機能において、テストカバレッジ100%を達成することを目指します。**
+
+#### テストファースト: src/testing/e2e-test-runner.ts
+
+```typescript
+// test/testing/e2e-test-runner.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { E2ETestRunner } from '../../src/testing/e2e-test-runner';
+
+describe('E2ETestRunner', () => {
+  let runner: E2ETestRunner;
+
+  beforeEach(() => {
+    runner = new E2ETestRunner();
+  });
+
+  test('should run simple task orchestration scenario', async () => {
+    const scenario = {
+      name: 'Simple Task Orchestration',
+      description: 'Test basic task analysis and execution',
+      steps: [
+        {
+          action: 'Analyze simple task',
+          input: 'Fix typo in README',
+          expectedMode: 'code',
+          expectedComplexity: 'low'
+        }
+      ]
+    };
+
+    const result = await runner.runScenario(scenario);
+
+    expect(result.result).toBe('passed');
+    expect(result.steps[0].passed).toBe(true);
+  });
+
+  test('should run complex orchestration scenario', async () => {
+    const scenario = {
+      name: 'Complex Task Orchestration',
+      description: 'Test complex task decomposition and multi-mode execution',
+      steps: [
+        {
+          action: 'Analyze complex task',
+          input: 'Build complete authentication system',
+          expectedMode: 'orchestrator',
+          expectedSubtasks: 4
+        },
+        {
+          action: 'Execute subtasks',
+          expectParallelExecution: true,
+          expectedModes: ['architect', 'code', 'debug']
+        }
+      ]
+    };
+
+    const result = await runner.runScenario(scenario);
+
+    expect(result.result).toBe('passed');
+    expect(result.duration).toBeGreaterThan(0);
+  });
+
+  test('should test mode switching workflow', async () => {
+    const result = await runner.runModeSwitchingTest();
+
+    expect(result.passed).toBe(true);
+    expect(result.modeSwitches).toBeGreaterThan(3);
+    expect(result.contextPreserved).toBe(true);
+  });
+
+  test('should test error recovery', async () => {
+    const scenario = {
+      name: 'Error Recovery Test',
+      description: 'Test error handling and recovery',
+      steps: [
+        {
+          action: 'Trigger error',
+          errorType: 'TokenLimitExceeded',
+          expectedRecovery: 'context_optimization'
+        }
+      ]
+    };
+
+    const result = await runner.runScenario(scenario);
+
+    expect(result.steps[0].passed).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+});
+```
+
+#### 実装: src/testing/e2e-test-runner.ts
+
+```typescript
+import { MCPOrchestrationServer } from '../mcp/orchestration-server';
+import { OrchestrationEntrypoint } from '../entrypoints/orchestrate';
+import type { TestScenario, E2ETestResults, TestStep } from './integration-types';
+
+export class E2ETestRunner {
+  private mcpServer: MCPOrchestrationServer;
+  private orchestrationEntrypoint: OrchestrationEntrypoint;
+
+  constructor() {
+    this.mcpServer = new MCPOrchestrationServer();
+    this.mcpServer.registerOrchestrationTools();
+  }
+
+  async runAllScenarios(): Promise<E2ETestResults> {
+    const scenarios = this.getTestScenarios();
+    const results: TestScenario[] = [];
+
+    for (const scenario of scenarios) {
+      const result = await this.runScenario(scenario);
+      results.push(result);
+    }
+
+    const coverage = await this.calculateCoverage();
+    const criticalPaths = this.identifyCriticalPaths(results);
+
+    return {
+      scenarios: results,
+      coverage,
+      criticalPaths
+    };
+  }
+
+  async runScenario(scenario: any): Promise<TestScenario> {
+    const startTime = Date.now();
+    const steps: TestStep[] = [];
+    let result: 'passed' | 'failed' | 'skipped' = 'passed';
+    const errors: string[] = [];
+
+    try {
+      for (const step of scenario.steps) {
+        const stepResult = await this.executeStep(step);
+        steps.push(stepResult);
+
+        if (!stepResult.passed) {
+          result = 'failed';
+          break;
+        }
+      }
+    } catch (error) {
+      result = 'failed';
+      errors.push(error.message);
+    }
+
+    return {
+      name: scenario.name,
+      description: scenario.description,
+      steps,
+      result,
+      duration: Date.now() - startTime,
+      errors: errors.length > 0 ? errors : undefined
+    };
+  }
+
+  async runModeSwitchingTest(): Promise<{
+    passed: boolean;
+    modeSwitches: number;
+    contextPreserved: boolean;
+  }> {
+    let modeSwitches = 0;
+    let contextPreserved = true;
+
+    try {
+      // Test mode switches
+      const modes = ['architect', 'code', 'debug', 'ask'];
+
+      for (const mode of modes) {
+        const result = await this.mcpServer.handleToolCall('switch_mode', {
+          mode,
+          preserveContext: true
+        });
+
+        if (result.mode.slug === mode) {
+          modeSwitches++;
+        }
+
+        if (!result.contextPreserved) {
+          contextPreserved = false;
+        }
+      }
+
+      return {
+        passed: modeSwitches === modes.length,
+        modeSwitches,
+        contextPreserved
+      };
+    } catch (error) {
+      return {
+        passed: false,
+        modeSwitches,
+        contextPreserved: false
+      };
+    }
+  }
+
+  private async executeStep(step: any): Promise<TestStep> {
+    const action = step.action;
+    let passed = true;
+    let actual: string | undefined;
+
+    try {
+      switch (action) {
+        case 'Analyze simple task':
+        case 'Analyze complex task':
+          const analysis = await this.mcpServer.handleToolCall('analyze_task', {
+            task: step.input
+          });
+
+          if (step.expectedMode && analysis.requiredModes[0] !== step.expectedMode) {
+            passed = false;
+            actual = `Mode: ${analysis.requiredModes[0]}`;
+          }
+
+          if (step.expectedComplexity) {
+            const complexityLevel = analysis.complexity < 3 ? 'low' : 'high';
+            if (complexityLevel !== step.expectedComplexity) {
+              passed = false;
+              actual = `Complexity: ${complexityLevel}`;
+            }
+          }
+
+          if (step.expectedSubtasks && analysis.estimatedSubtasks < step.expectedSubtasks) {
+            passed = false;
+            actual = `Subtasks: ${analysis.estimatedSubtasks}`;
+          }
+          break;
+
+        case 'Execute subtasks':
+          // Simulate subtask execution
+          passed = true;
+          actual = 'Subtasks executed successfully';
+          break;
+
+        case 'Trigger error':
+          // Simulate error and recovery
+          if (step.errorType === 'TokenLimitExceeded') {
+            // Should trigger context optimization
+            const optimized = await this.mcpServer.handleToolCall('optimize_context', {
+              context: { large: 'data'.repeat(1000) },
+              maxTokens: 1000
+            });
+
+            passed = optimized.tokensUsed <= 1000;
+            actual = `Recovery: ${step.expectedRecovery}`;
+          }
+          break;
+      }
+    } catch (error) {
+      passed = false;
+      actual = error.message;
+    }
+
+    return {
+      action,
+      expected: this.getExpectedFromStep(step),
+      actual,
+      passed
+    };
+  }
+
+  private getExpectedFromStep(step: any): string {
+    if (step.expectedMode) return `Mode: ${step.expectedMode}`;
+    if (step.expectedComplexity) return `Complexity: ${step.expectedComplexity}`;
+    if (step.expectedSubtasks) return `Subtasks: >= ${step.expectedSubtasks}`;
+    if (step.expectedRecovery) return `Recovery: ${step.expectedRecovery}`;
+    return 'Success';
+  }
+
+  private getTestScenarios(): any[] {
+    return [
+      {
+        name: 'Basic Task Analysis',
+        description: 'Test basic task analysis functionality',
+        steps: [
+          {
+            action: 'Analyze simple task',
+            input: 'Update package version',
+            expectedMode: 'code',
+            expectedComplexity: 'low'
+          }
+        ]
+      },
+      {
+        name: 'Complex Orchestration',
+        description: 'Test complex task orchestration',
+        steps: [
+          {
+            action: 'Analyze complex task',
+            input: 'Implement complete e-commerce platform',
+            expectedMode: 'orchestrator',
+            expectedSubtasks: 5
+          },
+          {
+            action: 'Execute subtasks',
+            expectParallelExecution: true
+          }
+        ]
+      },
+      {
+        name: 'Context Optimization',
+        description: 'Test context optimization under token pressure',
+        steps: [
+          {
+            action: 'Trigger error',
+            errorType: 'TokenLimitExceeded',
+            expectedRecovery: 'context_optimization'
+          }
+        ]
+      }
+    ];
+  }
+
+  private async calculateCoverage(): Promise<any> {
+    // Simulate coverage calculation
+    return {
+      components: 0.85,
+      modes: 1.0,
+      tools: 0.9,
+      overall: 0.88
+    };
+  }
+
+  private identifyCriticalPaths(results: TestScenario[]): any[] {
+    return [
+      {
+        name: 'Task Analysis Path',
+        steps: ['Receive task', 'Analyze complexity', 'Determine modes'],
+        coverage: 1.0
+      },
+      {
+        name: 'Orchestration Path',
+        steps: ['Decompose task', 'Assign modes', 'Execute subtasks', 'Aggregate results'],
+        coverage: 0.9
+      }
+    ];
+  }
+}
+```
+
+### タスク6.3: パフォーマンス最適化の実装
+
+#### テストファースト: src/optimization/performance-optimizer.ts
+
+```typescript
+// test/optimization/performance-optimizer.test.ts
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { PerformanceOptimizer } from '../../src/optimization/performance-optimizer';
+
+describe('PerformanceOptimizer', () => {
+  let optimizer: PerformanceOptimizer;
+
+  beforeEach(() => {
+    optimizer = new PerformanceOptimizer();
+  });
+
+  test('should analyze performance bottlenecks', async () => {
+    const analysis = await optimizer.analyzePerformance();
+
+    expect(analysis.bottlenecks).toBeDefined();
+    expect(analysis.optimizationOpportunities).toBeDefined();
+    expect(analysis.resourceUtilization).toBeDefined();
+  });
+
+  test('should optimize token usage', async () => {
+    const context = {
+      largeData: 'x'.repeat(10000),
+      metadata: { timestamp: new Date() },
+      history: Array(100).fill('command')
+    };
+
+    const result = await optimizer.optimizeTokenUsage(context, 2000);
+
+    expect(result.optimizedTokens).toBeLessThanOrEqual(2000);
+    expect(result.compressionRatio).toBeGreaterThan(0.5);
+    expect(result.preservedKeys).toContain('metadata');
+  });
+
+  test('should implement effective caching', async () => {
+    const cacheConfig = await optimizer.implementCaching();
+
+    expect(cacheConfig.strategy).toBe('lru');
+    expect(cacheConfig.maxSize).toBeGreaterThan(0);
+    expect(cacheConfig.ttl).toBeGreaterThan(0);
+  });
+
+  test('should reduce latency through optimization', async () => {
+    const latencyReport = await optimizer.reduceLatency();
+
+    expect(latencyReport.originalLatency).toBeGreaterThan(latencyReport.optimizedLatency);
+    expect(latencyReport.improvement).toBeGreaterThan(20); // 20% improvement
+  });
+});
+```
+
+#### 実装: src/optimization/performance-optimizer.ts
+
+```typescript
+import type {
+  PerformanceAnalysis,
+  Bottleneck,
+  OptimizationOpportunity,
+  TokenMetrics
+} from '../testing/integration-types';
+
+export class PerformanceOptimizer {
+  private metricsCollector: MetricsCollector;
+  private cacheManager: CacheManager;
+  private tokenOptimizer: TokenOptimizer;
+
+  constructor() {
+    this.metricsCollector = new MetricsCollector();
+    this.cacheManager = new CacheManager();
+    this.tokenOptimizer = new TokenOptimizer();
+  }
+
+  async analyzePerformance(): Promise<PerformanceAnalysis> {
+    const metrics = await this.metricsCollector.collectAllMetrics();
+    const bottlenecks = this.identifyBottlenecks(metrics);
+    const opportunities = this.findOptimizationOpportunities(metrics);
+    const resourceUtilization = this.calculateResourceUtilization(metrics);
+
+    return {
+      bottlenecks,
+      optimizationOpportunities: opportunities,
+      resourceUtilization
+    };
+  }
+
+  async optimizeTokenUsage(
+    context: any,
+    maxTokens: number
+  ): Promise<{
+    optimizedTokens: number;
+    compressionRatio: number;
+    preservedKeys: string[];
+  }> {
+    return this.tokenOptimizer.optimize(context, maxTokens);
+  }
+
+  async implementCaching(): Promise<{
+    strategy: string;
+    maxSize: number;
+    ttl: number;
+  }> {
+    return this.cacheManager.configure();
+  }
+
+  async reduceLatency(): Promise<{
+    originalLatency: number;
+    optimizedLatency: number;
+    improvement: number;
+  }> {
+    const original = await this.measureCurrentLatency();
+
+    // Apply optimizations
+    await this.applyLatencyOptimizations();
+
+    const optimized = await this.measureCurrentLatency();
+    const improvement = ((original - optimized) / original) * 100;
+
+    return {
+      originalLatency: original,
+      optimizedLatency: optimized,
+      improvement
+    };
+  }
+
+  private identifyBottlenecks(metrics: any): Bottleneck[] {
+    const bottlenecks: Bottleneck[] = [];
+
+    // Token usage bottleneck
+    if (metrics.tokenUsage.avgTokensPerRequest > 3000) {
+      bottlenecks.push({
+        component: 'TokenUsage',
+        metric: 'avgTokensPerRequest',
+        currentValue: metrics.tokenUsage.avgTokensPerRequest,
+        threshold: 3000,
+        impact: 'high'
+      });
+    }
+
+    // Response time bottleneck
+    if (metrics.avgResponseTime > 2000) {
+      bottlenecks.push({
+        component: 'ResponseTime',
+        metric: 'avgResponseTime',
+        currentValue: metrics.avgResponseTime,
+        threshold: 2000,
+        impact: 'medium'
+      });
+    }
+
+    // Memory usage bottleneck
+    if (metrics.memoryUsage.peak > 500) {
+      bottlenecks.push({
+        component: 'Memory',
+        metric: 'peakMemoryUsage',
+        currentValue: metrics.memoryUsage.peak,
+        threshold: 500,
+        impact: 'low'
+      });
+    }
+
+    return bottlenecks;
+  }
+
+  private findOptimizationOpportunities(metrics: any): OptimizationOpportunity[] {
+    const opportunities: OptimizationOpportunity[] = [];
+
+    // Context optimization opportunity
+    if (metrics.tokenUsage.compressionRatio < 0.7) {
+      opportunities.push({
+        area: 'Context Compression',
+        description: 'Implement aggressive context compression',
+        expectedImprovement: 30,
+        effort: 'medium',
+        priority: 1
+      });
+    }
+
+    // Caching opportunity
+    if (metrics.cacheHitRate < 0.5) {
+      opportunities.push({
+        area: 'Caching',
+        description: 'Improve cache hit rate',
+        expectedImprovement: 40,
+        effort: 'low',
+        priority: 2
+      });
+    }
+
+    // Parallel processing opportunity
+    if (metrics.parallelizationRate < 0.6) {
+      opportunities.push({
+        area: 'Parallel Processing',
+        description: 'Increase parallel subtask execution',
+        expectedImprovement: 25,
+        effort: 'high',
+        priority: 3
+      });
+    }
+
+    return opportunities;
+  }
+
+  private calculateResourceUtilization(metrics: any): any {
+    return {
+      cpu: metrics.cpuUsage || 45,
+      memory: metrics.memoryUsage.current || 256,
+      tokenBudget: (metrics.tokenUsage.avgTokensPerRequest / 4000) * 100,
+      throughput: metrics.throughput || 10
+    };
+  }
+
+  private async measureCurrentLatency(): Promise<number> {
+    // Simulate latency measurement
+    return 150 + Math.random() * 50;
+  }
+
+  private async applyLatencyOptimizations(): Promise<void> {
+    // Simulate optimization application
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+class MetricsCollector {
+  async collectAllMetrics(): Promise<any> {
+    return {
+      avgResponseTime: 1800,
+      tokenUsage: {
+        avgTokensPerRequest: 2500,
+        compressionRatio: 0.65
+      },
+      memoryUsage: {
+        current: 256,
+        peak: 480
+      },
+      cacheHitRate: 0.45,
+      parallelizationRate: 0.55,
+      throughput: 12
+    };
+  }
+}
+
+class CacheManager {
+  configure(): { strategy: string; maxSize: number; ttl: number } {
+    return {
+      strategy: 'lru',
+      maxSize: 1000,
+      ttl: 3600
+    };
+  }
+}
+
+class TokenOptimizer {
+  optimize(context: any, maxTokens: number): {
+    optimizedTokens: number;
+    compressionRatio: number;
+    preservedKeys: string[];
+  } {
+    const originalSize = JSON.stringify(context).length;
+    const preservedKeys = ['metadata'];
+
+    // Simulate optimization
+    const optimizedSize = Math.min(originalSize * 0.6, maxTokens * 4);
+
+    return {
+      optimizedTokens: Math.floor(optimizedSize / 4),
+      compressionRatio: optimizedSize / originalSize,
+      preservedKeys
+    };
+  }
+}
+```
+
+### タスク6.4: エラーハンドリング強化の実装
+
+#### 実装: src/error-handling/error-framework.ts
+
+```typescript
+import type { ErrorInfo } from '../types';
+
+export class ErrorHandlingFramework {
+  private errorRecovery: ErrorRecovery;
+  private fallbackStrategies: FallbackStrategies;
+  private errorReporter: ErrorReporter;
+
+  constructor() {
+    this.errorRecovery = new ErrorRecovery();
+    this.fallbackStrategies = new FallbackStrategies();
+    this.errorReporter = new ErrorReporter();
+  }
+
+  async handleOrchestrationError(error: Error): Promise<{
+    recovered: boolean;
+    strategy: string;
+    result?: any;
+  }> {
+    // Log error
+    await this.errorReporter.reportError({
+      message: error.message,
+      stack: error.stack,
+      timestamp: new Date(),
+      component: 'orchestration'
+    });
+
+    // Attempt recovery
+    const recoveryResult = await this.errorRecovery.attemptRecovery(error);
+
+    if (recoveryResult.success) {
+      return {
+        recovered: true,
+        strategy: recoveryResult.strategy,
+        result: recoveryResult.result
+      };
+    }
+
+    // Apply fallback
+    const fallbackResult = await this.implementFallback({
+      error,
+      attempts: recoveryResult.attempts,
+      context: {}
+    });
+
+    return {
+      recovered: fallbackResult.success,
+      strategy: fallbackResult.strategy,
+      result: fallbackResult.result
+    };
+  }
+
+  async implementFallback(context: {
+    error: Error;
+    attempts: number;
+    context: any;
+  }): Promise<{
+    success: boolean;
+    strategy: string;
+    result?: any;
+  }> {
+    return this.fallbackStrategies.apply(context);
+  }
+
+  reportError(error: ErrorInfo): void {
+    this.errorReporter.reportError(error);
+  }
+}
+
+class ErrorRecovery {
+  async attemptRecovery(error: Error): Promise<{
+    success: boolean;
+    strategy: string;
+    attempts: number;
+    result?: any;
+  }> {
+    // Token limit error - optimize context
+    if (error.message.includes('token limit')) {
+      return {
+        success: true,
+        strategy: 'context_optimization',
+        attempts: 1,
+        result: { optimized: true }
+      };
+    }
+
+    // Rate limit error - retry with backoff
+    if (error.message.includes('rate limit')) {
+      await this.delay(1000);
+      return {
+        success: true,
+        strategy: 'exponential_backoff',
+        attempts: 1,
+        result: { retried: true }
+      };
+    }
+
+    // Mode not found - fallback to default
+    if (error.message.includes('Mode not found')) {
+      return {
+        success: true,
+        strategy: 'default_mode_fallback',
+        attempts: 1,
+        result: { mode: 'code' }
+      };
+    }
+
+    return {
+      success: false,
+      strategy: 'none',
+      attempts: 1
+    };
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}
+
+class FallbackStrategies {
+  apply(context: any): {
+    success: boolean;
+    strategy: string;
+    result?: any;
+  } {
+    // Simple task fallback
+    if (context.error.message.includes('complex')) {
+      return {
+        success: true,
+        strategy: 'simplify_task',
+        result: { simplified: true }
+      };
+    }
+
+    // Generic fallback
+    return {
+      success: true,
+      strategy: 'graceful_degradation',
+      result: { degraded: true }
+    };
+  }
+}
+
+class ErrorReporter {
+  reportError(error: any): void {
+    console.error('Error reported:', error);
+    // In production, this would send to monitoring service
+  }
+}
+```
+
+## コミット計画
+
+### コミット1: 統合テスト型定義
+```bash
+git add src/testing/integration-types.ts
+git commit -m "feat(testing): add integration test type definitions"
+```
+
+### コミット2: E2Eテストランナー
+```bash
+git add src/testing/e2e-test-runner.ts test/testing/e2e-test-runner.test.ts
+git commit -m "feat(testing): implement E2E test runner with scenarios"
+```
+
+### コミット3: パフォーマンス最適化
+```bash
+git add src/optimization/performance-optimizer.ts test/optimization/performance-optimizer.test.ts
+git commit -m "feat(optimization): implement performance optimization framework"
+```
+
+### コミット4: エラーハンドリング
+```bash
+git add src/error-handling/error-framework.ts test/error-handling/error-framework.test.ts
+git commit -m "feat(error-handling): implement comprehensive error handling"
+```
+
+### コミット5: 統合とドキュメント
+```bash
+git add test/integration/full-system.test.ts docs/orchestration-guide.md
+git commit -m "feat(integration): add full system tests and documentation"
+```
+
+## ディレクトリ構造
+
+```
+src/
+├── testing/
+│   ├── integration-types.ts      # テスト型定義
+│   ├── e2e-test-runner.ts        # E2Eテストランナー
+│   └── performance-test-runner.ts # パフォーマンステスト
+├── optimization/
+│   ├── performance-optimizer.ts   # パフォーマンス最適化
+│   ├── cache-manager.ts          # キャッシュ管理
+│   └── token-optimizer.ts        # トークン最適化
+└── error-handling/
+    ├── error-framework.ts        # エラーハンドリング
+    ├── recovery-strategies.ts    # リカバリー戦略
+    └── error-reporter.ts         # エラーレポート
+
+test/
+├── testing/
+│   ├── e2e-test-runner.test.ts
+│   └── performance-test-runner.test.ts
+├── optimization/
+│   └── performance-optimizer.test.ts
+├── error-handling/
+│   └── error-framework.test.ts
+└── integration/
+    └── full-system.test.ts
+
+docs/
+├── orchestration-guide.md        # ユーザーガイド
+├── api-reference.md              # APIリファレンス
+└── performance-tuning.md         # パフォーマンスチューニング
+```
+
+## 統合テスト
+
+```typescript
+// test/integration/full-system.test.ts
+import { describe, test, expect } from 'bun:test';
+import { IntegrationTestSuite } from '../../src/testing/integration-test-suite';
+
+describe('Full System Integration', () => {
+  test('should run complete integration test suite', async () => {
+    const suite = new IntegrationTestSuite();
+    const report = await suite.runAllTests();
+
+    // E2E Tests
+    expect(report.e2eResults.scenarios.length).toBeGreaterThan(5);
+    expect(report.summary.passed / report.summary.totalTests).toBeGreaterThan(0.95);
+
+    // Performance Tests
+    expect(report.performanceResults.avgResponseTime).toBeLessThan(2000);
+    expect(report.performanceResults.tokenUsage.avgTokensPerRequest).toBeLessThan(3000);
+
+    // Load Tests
+    expect(report.loadTestResults.errorRate).toBeLessThan(0.01);
+    expect(report.loadTestResults.avgLatency).toBeLessThan(500);
+
+    // Recommendations
+    expect(report.recommendations).toBeDefined();
+    expect(report.recommendations.length).toBeGreaterThan(0);
+  }, 60000); // 60 second timeout for full suite
+
+  test('should handle concurrent orchestration requests', async () => {
+    const concurrentRequests = 10;
+    const promises = [];
+
+    for (let i = 0; i < concurrentRequests; i++) {
+      promises.push(
+        simulateOrchestrationRequest(`Task ${i}: Implement feature ${i}`)
+      );
+    }
+
+    const results = await Promise.all(promises);
+    const successRate = results.filter(r => r.success).length / results.length;
+
+    expect(successRate).toBeGreaterThan(0.95);
+  });
+
+  test('should maintain performance under load', async () => {
+    const loadTest = new LoadTestRunner();
+    const result = await loadTest.run({
+      duration: 30, // seconds
+      concurrentUsers: 50,
+      scenario: 'mixed_workload'
+    });
+
+    expect(result.avgResponseTime).toBeLessThan(3000);
+    expect(result.errorRate).toBeLessThan(0.02);
+    expect(result.throughput).toBeGreaterThan(5); // requests per second
+  });
+});
+
+async function simulateOrchestrationRequest(task: string): Promise<any> {
+  // Simulate orchestration request
+  return { success: true, task };
+}
+```
+
+## パフォーマンスベンチマーク
+
+```typescript
+// scripts/benchmark.ts
+import { PerformanceBenchmark } from '../src/testing/performance-benchmark';
+
+async function runBenchmarks() {
+  const benchmark = new PerformanceBenchmark();
+
+  console.log('Running orchestration benchmarks...\n');
+
+  // Token optimization benchmark
+  const tokenBench = await benchmark.runTokenOptimizationBenchmark();
+  console.log('Token Optimization:');
+  console.log(`  Original: ${tokenBench.originalTokens} tokens`);
+  console.log(`  Optimized: ${tokenBench.optimizedTokens} tokens`);
+  console.log(`  Reduction: ${tokenBench.reductionPercentage}%\n`);
+
+  // Mode switching benchmark
+  const modeBench = await benchmark.runModeSwitchingBenchmark();
+  console.log('Mode Switching:');
+  console.log(`  Avg switch time: ${modeBench.avgSwitchTime}ms`);
+  console.log(`  Context preserved: ${modeBench.contextPreservationRate * 100}%\n`);
+
+  // Subtask execution benchmark
+  const subtaskBench = await benchmark.runSubtaskExecutionBenchmark();
+  console.log('Subtask Execution:');
+  console.log(`  Parallel speedup: ${subtaskBench.parallelSpeedup}x`);
+  console.log(`  Avg subtask time: ${subtaskBench.avgSubtaskTime}ms`);
+}
+
+runBenchmarks().catch(console.error);
+```
+
+## 実行手順
+
+### 実行フロー
+```bash
+# 1. phase4-mcp-extension から作業ブランチを作成
+git checkout phase4-mcp-extension
+git pull origin phase4-mcp-extension # 念のため最新化
+git checkout -b phase5-integration-testing phase4-mcp-extension
+
+# 2. AI実装（Claude Code、Cursor等）
+# TDDに従ってテストファーストで実装 (プロジェクトルートで行う)
+
+# 3. プリコミットチェック
+bun test && bun run format:check && bun run typecheck
+
+# 4. コミット
+git add .
+git commit -m "feat(integration-testing): implement integration testing" # コミットメッセージは適宜変更
+
+# 5. プッシュしてPR作成
+git push origin phase5-integration-testing
+
+# 6. GitHubでPR作成・レビュー・マージ
+#    PRのターゲットブランチは phase4-mcp-extension とする
+
+# 7. クリーンアップ (PRマージ後)
+git checkout phase4-mcp-extension
+git pull origin phase4-mcp-extension # リモートの変更を取り込み最新化
+git branch -d phase5-integration-testing # ローカルの作業ブランチを削除
+# git push origin --delete phase5-integration-testing # (任意) リモートの作業ブランチも削除する場合
+```
+
+### 詳細ステップ（TDD）
+```bash
+# 1. phase4-mcp-extension から作業ブランチ作成
+git checkout phase4-mcp-extension
+git pull origin phase4-mcp-extension # 念のため最新化
+git checkout -b phase5-integration-testing phase4-mcp-extension
+
+# プロジェクトルートで作業を進める
+
+# (テストファイル作成、テスト実行、実装、スクリプト実行などはドキュメントの各フェーズに従う)
+# ... (省略) ...
+
+# X. プリコミットチェック (実装完了後)
+bun test && bun run format:check && bun run typecheck
+
+# Y. コミット
+git add .
+git commit -m "feat(integration-testing): implement integration testing" # コミットメッセージは適宜変更
+
+# Z. 統合 (PR経由でのマージ)
+#    上記「実行フロー」のステップ5以降に従ってPRを作成し、マージする
+git push origin phase5-integration-testing
+# GitHub上で phase4-mcp-extension をターゲットブランチとしてPRを作成・レビュー・マージ
+# マージ後、ローカルブランチをクリーンアップ
+git checkout phase4-mcp-extension
+git pull origin phase4-mcp-extension
+git branch -d phase5-integration-testing
+```
+
+## 依存関係
+
+このフェーズは全ての前フェーズ完了後に実装してください：
+- フェーズ1-5: 全機能の実装完了
+
+## 次のステップ
+
+1. 本番環境でのモニタリング設定
+2. パフォーマンスダッシュボードの作成
+3. 継続的な最適化プロセスの確立
+
+**💡 重要な点**: 統合テストと最適化により、システム全体の品質と信頼性を確保し、本番環境での安定稼働を実現することが重要です。

--- a/predev-docs/09-phase5-integration-testing-design.md
+++ b/predev-docs/09-phase5-integration-testing-design.md
@@ -5,6 +5,7 @@
 統合テストと最適化フェーズでは、実装された全コンポーネントの統合テスト、パフォーマンス最適化、エラーハンドリング強化、およびドキュメント作成を行います。システム全体の品質保証と本番環境での安定稼働を目指します。
 
 **📌 参考実装**: RooCode（RooCline）のオーケストレーション実装を参考にしてください：
+
 - GitHub: https://github.com/RooCodeInc/Roo-Code
 - UIthub: https://uithub.com/RooCodeInc/Roo-Code
 - DeepWiki: https://deepwiki.com/RooCodeInc/Roo-Code
@@ -102,7 +103,7 @@ export interface TestScenario {
   name: string;
   description: string;
   steps: TestStep[];
-  result: 'passed' | 'failed' | 'skipped';
+  result: "passed" | "failed" | "skipped";
   duration: number;
   errors?: string[];
 }
@@ -149,14 +150,14 @@ export interface Bottleneck {
   metric: string;
   currentValue: number;
   threshold: number;
-  impact: 'high' | 'medium' | 'low';
+  impact: "high" | "medium" | "low";
 }
 
 export interface OptimizationOpportunity {
   area: string;
   description: string;
   expectedImprovement: number;
-  effort: 'low' | 'medium' | 'high';
+  effort: "low" | "medium" | "high";
   priority: number;
 }
 ```
@@ -169,62 +170,62 @@ E2E統合テストスイートは、システム全体の動作をユーザー�
 
 ```typescript
 // test/testing/e2e-test-runner.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { E2ETestRunner } from '../../src/testing/e2e-test-runner';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { E2ETestRunner } from "../../src/testing/e2e-test-runner";
 
-describe('E2ETestRunner', () => {
+describe("E2ETestRunner", () => {
   let runner: E2ETestRunner;
 
   beforeEach(() => {
     runner = new E2ETestRunner();
   });
 
-  test('should run simple task orchestration scenario', async () => {
+  test("should run simple task orchestration scenario", async () => {
     const scenario = {
-      name: 'Simple Task Orchestration',
-      description: 'Test basic task analysis and execution',
+      name: "Simple Task Orchestration",
+      description: "Test basic task analysis and execution",
       steps: [
         {
-          action: 'Analyze simple task',
-          input: 'Fix typo in README',
-          expectedMode: 'code',
-          expectedComplexity: 'low'
-        }
-      ]
+          action: "Analyze simple task",
+          input: "Fix typo in README",
+          expectedMode: "code",
+          expectedComplexity: "low",
+        },
+      ],
     };
 
     const result = await runner.runScenario(scenario);
 
-    expect(result.result).toBe('passed');
+    expect(result.result).toBe("passed");
     expect(result.steps[0].passed).toBe(true);
   });
 
-  test('should run complex orchestration scenario', async () => {
+  test("should run complex orchestration scenario", async () => {
     const scenario = {
-      name: 'Complex Task Orchestration',
-      description: 'Test complex task decomposition and multi-mode execution',
+      name: "Complex Task Orchestration",
+      description: "Test complex task decomposition and multi-mode execution",
       steps: [
         {
-          action: 'Analyze complex task',
-          input: 'Build complete authentication system',
-          expectedMode: 'orchestrator',
-          expectedSubtasks: 4
+          action: "Analyze complex task",
+          input: "Build complete authentication system",
+          expectedMode: "orchestrator",
+          expectedSubtasks: 4,
         },
         {
-          action: 'Execute subtasks',
+          action: "Execute subtasks",
           expectParallelExecution: true,
-          expectedModes: ['architect', 'code', 'debug']
-        }
-      ]
+          expectedModes: ["architect", "code", "debug"],
+        },
+      ],
     };
 
     const result = await runner.runScenario(scenario);
 
-    expect(result.result).toBe('passed');
+    expect(result.result).toBe("passed");
     expect(result.duration).toBeGreaterThan(0);
   });
 
-  test('should test mode switching workflow', async () => {
+  test("should test mode switching workflow", async () => {
     const result = await runner.runModeSwitchingTest();
 
     expect(result.passed).toBe(true);
@@ -232,17 +233,17 @@ describe('E2ETestRunner', () => {
     expect(result.contextPreserved).toBe(true);
   });
 
-  test('should test error recovery', async () => {
+  test("should test error recovery", async () => {
     const scenario = {
-      name: 'Error Recovery Test',
-      description: 'Test error handling and recovery',
+      name: "Error Recovery Test",
+      description: "Test error handling and recovery",
       steps: [
         {
-          action: 'Trigger error',
-          errorType: 'TokenLimitExceeded',
-          expectedRecovery: 'context_optimization'
-        }
-      ]
+          action: "Trigger error",
+          errorType: "TokenLimitExceeded",
+          expectedRecovery: "context_optimization",
+        },
+      ],
     };
 
     const result = await runner.runScenario(scenario);
@@ -256,9 +257,13 @@ describe('E2ETestRunner', () => {
 #### 実装: src/testing/e2e-test-runner.ts
 
 ```typescript
-import { MCPOrchestrationServer } from '../mcp/orchestration-server';
-import { OrchestrationEntrypoint } from '../entrypoints/orchestrate';
-import type { TestScenario, E2ETestResults, TestStep } from './integration-types';
+import { MCPOrchestrationServer } from "../mcp/orchestration-server";
+import { OrchestrationEntrypoint } from "../entrypoints/orchestrate";
+import type {
+  TestScenario,
+  E2ETestResults,
+  TestStep,
+} from "./integration-types";
 
 export class E2ETestRunner {
   private mcpServer: MCPOrchestrationServer;
@@ -284,14 +289,14 @@ export class E2ETestRunner {
     return {
       scenarios: results,
       coverage,
-      criticalPaths
+      criticalPaths,
     };
   }
 
   async runScenario(scenario: any): Promise<TestScenario> {
     const startTime = Date.now();
     const steps: TestStep[] = [];
-    let result: 'passed' | 'failed' | 'skipped' = 'passed';
+    let result: "passed" | "failed" | "skipped" = "passed";
     const errors: string[] = [];
 
     try {
@@ -300,12 +305,12 @@ export class E2ETestRunner {
         steps.push(stepResult);
 
         if (!stepResult.passed) {
-          result = 'failed';
+          result = "failed";
           break;
         }
       }
     } catch (error) {
-      result = 'failed';
+      result = "failed";
       errors.push(error.message);
     }
 
@@ -315,7 +320,7 @@ export class E2ETestRunner {
       steps,
       result,
       duration: Date.now() - startTime,
-      errors: errors.length > 0 ? errors : undefined
+      errors: errors.length > 0 ? errors : undefined,
     };
   }
 
@@ -329,12 +334,12 @@ export class E2ETestRunner {
 
     try {
       // Test mode switches
-      const modes = ['architect', 'code', 'debug', 'ask'];
+      const modes = ["architect", "code", "debug", "ask"];
 
       for (const mode of modes) {
-        const result = await this.mcpServer.handleToolCall('switch_mode', {
+        const result = await this.mcpServer.handleToolCall("switch_mode", {
           mode,
-          preserveContext: true
+          preserveContext: true,
         });
 
         if (result.mode.slug === mode) {
@@ -349,13 +354,13 @@ export class E2ETestRunner {
       return {
         passed: modeSwitches === modes.length,
         modeSwitches,
-        contextPreserved
+        contextPreserved,
       };
     } catch (error) {
       return {
         passed: false,
         modeSwitches,
-        contextPreserved: false
+        contextPreserved: false,
       };
     }
   }
@@ -367,45 +372,54 @@ export class E2ETestRunner {
 
     try {
       switch (action) {
-        case 'Analyze simple task':
-        case 'Analyze complex task':
-          const analysis = await this.mcpServer.handleToolCall('analyze_task', {
-            task: step.input
+        case "Analyze simple task":
+        case "Analyze complex task":
+          const analysis = await this.mcpServer.handleToolCall("analyze_task", {
+            task: step.input,
           });
 
-          if (step.expectedMode && analysis.requiredModes[0] !== step.expectedMode) {
+          if (
+            step.expectedMode &&
+            analysis.requiredModes[0] !== step.expectedMode
+          ) {
             passed = false;
             actual = `Mode: ${analysis.requiredModes[0]}`;
           }
 
           if (step.expectedComplexity) {
-            const complexityLevel = analysis.complexity < 3 ? 'low' : 'high';
+            const complexityLevel = analysis.complexity < 3 ? "low" : "high";
             if (complexityLevel !== step.expectedComplexity) {
               passed = false;
               actual = `Complexity: ${complexityLevel}`;
             }
           }
 
-          if (step.expectedSubtasks && analysis.estimatedSubtasks < step.expectedSubtasks) {
+          if (
+            step.expectedSubtasks &&
+            analysis.estimatedSubtasks < step.expectedSubtasks
+          ) {
             passed = false;
             actual = `Subtasks: ${analysis.estimatedSubtasks}`;
           }
           break;
 
-        case 'Execute subtasks':
+        case "Execute subtasks":
           // Simulate subtask execution
           passed = true;
-          actual = 'Subtasks executed successfully';
+          actual = "Subtasks executed successfully";
           break;
 
-        case 'Trigger error':
+        case "Trigger error":
           // Simulate error and recovery
-          if (step.errorType === 'TokenLimitExceeded') {
+          if (step.errorType === "TokenLimitExceeded") {
             // Should trigger context optimization
-            const optimized = await this.mcpServer.handleToolCall('optimize_context', {
-              context: { large: 'data'.repeat(1000) },
-              maxTokens: 1000
-            });
+            const optimized = await this.mcpServer.handleToolCall(
+              "optimize_context",
+              {
+                context: { large: "data".repeat(1000) },
+                maxTokens: 1000,
+              },
+            );
 
             passed = optimized.tokensUsed <= 1000;
             actual = `Recovery: ${step.expectedRecovery}`;
@@ -421,59 +435,60 @@ export class E2ETestRunner {
       action,
       expected: this.getExpectedFromStep(step),
       actual,
-      passed
+      passed,
     };
   }
 
   private getExpectedFromStep(step: any): string {
     if (step.expectedMode) return `Mode: ${step.expectedMode}`;
-    if (step.expectedComplexity) return `Complexity: ${step.expectedComplexity}`;
+    if (step.expectedComplexity)
+      return `Complexity: ${step.expectedComplexity}`;
     if (step.expectedSubtasks) return `Subtasks: >= ${step.expectedSubtasks}`;
     if (step.expectedRecovery) return `Recovery: ${step.expectedRecovery}`;
-    return 'Success';
+    return "Success";
   }
 
   private getTestScenarios(): any[] {
     return [
       {
-        name: 'Basic Task Analysis',
-        description: 'Test basic task analysis functionality',
+        name: "Basic Task Analysis",
+        description: "Test basic task analysis functionality",
         steps: [
           {
-            action: 'Analyze simple task',
-            input: 'Update package version',
-            expectedMode: 'code',
-            expectedComplexity: 'low'
-          }
-        ]
+            action: "Analyze simple task",
+            input: "Update package version",
+            expectedMode: "code",
+            expectedComplexity: "low",
+          },
+        ],
       },
       {
-        name: 'Complex Orchestration',
-        description: 'Test complex task orchestration',
+        name: "Complex Orchestration",
+        description: "Test complex task orchestration",
         steps: [
           {
-            action: 'Analyze complex task',
-            input: 'Implement complete e-commerce platform',
-            expectedMode: 'orchestrator',
-            expectedSubtasks: 5
+            action: "Analyze complex task",
+            input: "Implement complete e-commerce platform",
+            expectedMode: "orchestrator",
+            expectedSubtasks: 5,
           },
           {
-            action: 'Execute subtasks',
-            expectParallelExecution: true
-          }
-        ]
+            action: "Execute subtasks",
+            expectParallelExecution: true,
+          },
+        ],
       },
       {
-        name: 'Context Optimization',
-        description: 'Test context optimization under token pressure',
+        name: "Context Optimization",
+        description: "Test context optimization under token pressure",
         steps: [
           {
-            action: 'Trigger error',
-            errorType: 'TokenLimitExceeded',
-            expectedRecovery: 'context_optimization'
-          }
-        ]
-      }
+            action: "Trigger error",
+            errorType: "TokenLimitExceeded",
+            expectedRecovery: "context_optimization",
+          },
+        ],
+      },
     ];
   }
 
@@ -483,22 +498,27 @@ export class E2ETestRunner {
       components: 0.85,
       modes: 1.0,
       tools: 0.9,
-      overall: 0.88
+      overall: 0.88,
     };
   }
 
   private identifyCriticalPaths(results: TestScenario[]): any[] {
     return [
       {
-        name: 'Task Analysis Path',
-        steps: ['Receive task', 'Analyze complexity', 'Determine modes'],
-        coverage: 1.0
+        name: "Task Analysis Path",
+        steps: ["Receive task", "Analyze complexity", "Determine modes"],
+        coverage: 1.0,
       },
       {
-        name: 'Orchestration Path',
-        steps: ['Decompose task', 'Assign modes', 'Execute subtasks', 'Aggregate results'],
-        coverage: 0.9
-      }
+        name: "Orchestration Path",
+        steps: [
+          "Decompose task",
+          "Assign modes",
+          "Execute subtasks",
+          "Aggregate results",
+        ],
+        coverage: 0.9,
+      },
     ];
   }
 }
@@ -510,17 +530,17 @@ export class E2ETestRunner {
 
 ```typescript
 // test/optimization/performance-optimizer.test.ts
-import { describe, test, expect, beforeEach } from 'bun:test';
-import { PerformanceOptimizer } from '../../src/optimization/performance-optimizer';
+import { describe, test, expect, beforeEach } from "bun:test";
+import { PerformanceOptimizer } from "../../src/optimization/performance-optimizer";
 
-describe('PerformanceOptimizer', () => {
+describe("PerformanceOptimizer", () => {
   let optimizer: PerformanceOptimizer;
 
   beforeEach(() => {
     optimizer = new PerformanceOptimizer();
   });
 
-  test('should analyze performance bottlenecks', async () => {
+  test("should analyze performance bottlenecks", async () => {
     const analysis = await optimizer.analyzePerformance();
 
     expect(analysis.bottlenecks).toBeDefined();
@@ -528,32 +548,34 @@ describe('PerformanceOptimizer', () => {
     expect(analysis.resourceUtilization).toBeDefined();
   });
 
-  test('should optimize token usage', async () => {
+  test("should optimize token usage", async () => {
     const context = {
-      largeData: 'x'.repeat(10000),
+      largeData: "x".repeat(10000),
       metadata: { timestamp: new Date() },
-      history: Array(100).fill('command')
+      history: Array(100).fill("command"),
     };
 
     const result = await optimizer.optimizeTokenUsage(context, 2000);
 
     expect(result.optimizedTokens).toBeLessThanOrEqual(2000);
     expect(result.compressionRatio).toBeGreaterThan(0.5);
-    expect(result.preservedKeys).toContain('metadata');
+    expect(result.preservedKeys).toContain("metadata");
   });
 
-  test('should implement effective caching', async () => {
+  test("should implement effective caching", async () => {
     const cacheConfig = await optimizer.implementCaching();
 
-    expect(cacheConfig.strategy).toBe('lru');
+    expect(cacheConfig.strategy).toBe("lru");
     expect(cacheConfig.maxSize).toBeGreaterThan(0);
     expect(cacheConfig.ttl).toBeGreaterThan(0);
   });
 
-  test('should reduce latency through optimization', async () => {
+  test("should reduce latency through optimization", async () => {
     const latencyReport = await optimizer.reduceLatency();
 
-    expect(latencyReport.originalLatency).toBeGreaterThan(latencyReport.optimizedLatency);
+    expect(latencyReport.originalLatency).toBeGreaterThan(
+      latencyReport.optimizedLatency,
+    );
     expect(latencyReport.improvement).toBeGreaterThan(20); // 20% improvement
   });
 });
@@ -566,8 +588,8 @@ import type {
   PerformanceAnalysis,
   Bottleneck,
   OptimizationOpportunity,
-  TokenMetrics
-} from '../testing/integration-types';
+  TokenMetrics,
+} from "../testing/integration-types";
 
 export class PerformanceOptimizer {
   private metricsCollector: MetricsCollector;
@@ -589,13 +611,13 @@ export class PerformanceOptimizer {
     return {
       bottlenecks,
       optimizationOpportunities: opportunities,
-      resourceUtilization
+      resourceUtilization,
     };
   }
 
   async optimizeTokenUsage(
     context: any,
-    maxTokens: number
+    maxTokens: number,
   ): Promise<{
     optimizedTokens: number;
     compressionRatio: number;
@@ -628,7 +650,7 @@ export class PerformanceOptimizer {
     return {
       originalLatency: original,
       optimizedLatency: optimized,
-      improvement
+      improvement,
     };
   }
 
@@ -638,72 +660,74 @@ export class PerformanceOptimizer {
     // Token usage bottleneck
     if (metrics.tokenUsage.avgTokensPerRequest > 3000) {
       bottlenecks.push({
-        component: 'TokenUsage',
-        metric: 'avgTokensPerRequest',
+        component: "TokenUsage",
+        metric: "avgTokensPerRequest",
         currentValue: metrics.tokenUsage.avgTokensPerRequest,
         threshold: 3000,
-        impact: 'high'
+        impact: "high",
       });
     }
 
     // Response time bottleneck
     if (metrics.avgResponseTime > 2000) {
       bottlenecks.push({
-        component: 'ResponseTime',
-        metric: 'avgResponseTime',
+        component: "ResponseTime",
+        metric: "avgResponseTime",
         currentValue: metrics.avgResponseTime,
         threshold: 2000,
-        impact: 'medium'
+        impact: "medium",
       });
     }
 
     // Memory usage bottleneck
     if (metrics.memoryUsage.peak > 500) {
       bottlenecks.push({
-        component: 'Memory',
-        metric: 'peakMemoryUsage',
+        component: "Memory",
+        metric: "peakMemoryUsage",
         currentValue: metrics.memoryUsage.peak,
         threshold: 500,
-        impact: 'low'
+        impact: "low",
       });
     }
 
     return bottlenecks;
   }
 
-  private findOptimizationOpportunities(metrics: any): OptimizationOpportunity[] {
+  private findOptimizationOpportunities(
+    metrics: any,
+  ): OptimizationOpportunity[] {
     const opportunities: OptimizationOpportunity[] = [];
 
     // Context optimization opportunity
     if (metrics.tokenUsage.compressionRatio < 0.7) {
       opportunities.push({
-        area: 'Context Compression',
-        description: 'Implement aggressive context compression',
+        area: "Context Compression",
+        description: "Implement aggressive context compression",
         expectedImprovement: 30,
-        effort: 'medium',
-        priority: 1
+        effort: "medium",
+        priority: 1,
       });
     }
 
     // Caching opportunity
     if (metrics.cacheHitRate < 0.5) {
       opportunities.push({
-        area: 'Caching',
-        description: 'Improve cache hit rate',
+        area: "Caching",
+        description: "Improve cache hit rate",
         expectedImprovement: 40,
-        effort: 'low',
-        priority: 2
+        effort: "low",
+        priority: 2,
       });
     }
 
     // Parallel processing opportunity
     if (metrics.parallelizationRate < 0.6) {
       opportunities.push({
-        area: 'Parallel Processing',
-        description: 'Increase parallel subtask execution',
+        area: "Parallel Processing",
+        description: "Increase parallel subtask execution",
         expectedImprovement: 25,
-        effort: 'high',
-        priority: 3
+        effort: "high",
+        priority: 3,
       });
     }
 
@@ -715,7 +739,7 @@ export class PerformanceOptimizer {
       cpu: metrics.cpuUsage || 45,
       memory: metrics.memoryUsage.current || 256,
       tokenBudget: (metrics.tokenUsage.avgTokensPerRequest / 4000) * 100,
-      throughput: metrics.throughput || 10
+      throughput: metrics.throughput || 10,
     };
   }
 
@@ -726,7 +750,7 @@ export class PerformanceOptimizer {
 
   private async applyLatencyOptimizations(): Promise<void> {
     // Simulate optimization application
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 }
 
@@ -736,15 +760,15 @@ class MetricsCollector {
       avgResponseTime: 1800,
       tokenUsage: {
         avgTokensPerRequest: 2500,
-        compressionRatio: 0.65
+        compressionRatio: 0.65,
       },
       memoryUsage: {
         current: 256,
-        peak: 480
+        peak: 480,
       },
       cacheHitRate: 0.45,
       parallelizationRate: 0.55,
-      throughput: 12
+      throughput: 12,
     };
   }
 }
@@ -752,21 +776,24 @@ class MetricsCollector {
 class CacheManager {
   configure(): { strategy: string; maxSize: number; ttl: number } {
     return {
-      strategy: 'lru',
+      strategy: "lru",
       maxSize: 1000,
-      ttl: 3600
+      ttl: 3600,
     };
   }
 }
 
 class TokenOptimizer {
-  optimize(context: any, maxTokens: number): {
+  optimize(
+    context: any,
+    maxTokens: number,
+  ): {
     optimizedTokens: number;
     compressionRatio: number;
     preservedKeys: string[];
   } {
     const originalSize = JSON.stringify(context).length;
-    const preservedKeys = ['metadata'];
+    const preservedKeys = ["metadata"];
 
     // Simulate optimization
     const optimizedSize = Math.min(originalSize * 0.6, maxTokens * 4);
@@ -774,7 +801,7 @@ class TokenOptimizer {
     return {
       optimizedTokens: Math.floor(optimizedSize / 4),
       compressionRatio: optimizedSize / originalSize,
-      preservedKeys
+      preservedKeys,
     };
   }
 }
@@ -785,7 +812,7 @@ class TokenOptimizer {
 #### 実装: src/error-handling/error-framework.ts
 
 ```typescript
-import type { ErrorInfo } from '../types';
+import type { ErrorInfo } from "../types";
 
 export class ErrorHandlingFramework {
   private errorRecovery: ErrorRecovery;
@@ -808,7 +835,7 @@ export class ErrorHandlingFramework {
       message: error.message,
       stack: error.stack,
       timestamp: new Date(),
-      component: 'orchestration'
+      component: "orchestration",
     });
 
     // Attempt recovery
@@ -818,7 +845,7 @@ export class ErrorHandlingFramework {
       return {
         recovered: true,
         strategy: recoveryResult.strategy,
-        result: recoveryResult.result
+        result: recoveryResult.result,
       };
     }
 
@@ -826,13 +853,13 @@ export class ErrorHandlingFramework {
     const fallbackResult = await this.implementFallback({
       error,
       attempts: recoveryResult.attempts,
-      context: {}
+      context: {},
     });
 
     return {
       recovered: fallbackResult.success,
       strategy: fallbackResult.strategy,
-      result: fallbackResult.result
+      result: fallbackResult.result,
     };
   }
 
@@ -861,45 +888,45 @@ class ErrorRecovery {
     result?: any;
   }> {
     // Token limit error - optimize context
-    if (error.message.includes('token limit')) {
+    if (error.message.includes("token limit")) {
       return {
         success: true,
-        strategy: 'context_optimization',
+        strategy: "context_optimization",
         attempts: 1,
-        result: { optimized: true }
+        result: { optimized: true },
       };
     }
 
     // Rate limit error - retry with backoff
-    if (error.message.includes('rate limit')) {
+    if (error.message.includes("rate limit")) {
       await this.delay(1000);
       return {
         success: true,
-        strategy: 'exponential_backoff',
+        strategy: "exponential_backoff",
         attempts: 1,
-        result: { retried: true }
+        result: { retried: true },
       };
     }
 
     // Mode not found - fallback to default
-    if (error.message.includes('Mode not found')) {
+    if (error.message.includes("Mode not found")) {
       return {
         success: true,
-        strategy: 'default_mode_fallback',
+        strategy: "default_mode_fallback",
         attempts: 1,
-        result: { mode: 'code' }
+        result: { mode: "code" },
       };
     }
 
     return {
       success: false,
-      strategy: 'none',
-      attempts: 1
+      strategy: "none",
+      attempts: 1,
     };
   }
 
   private delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 
@@ -910,26 +937,26 @@ class FallbackStrategies {
     result?: any;
   } {
     // Simple task fallback
-    if (context.error.message.includes('complex')) {
+    if (context.error.message.includes("complex")) {
       return {
         success: true,
-        strategy: 'simplify_task',
-        result: { simplified: true }
+        strategy: "simplify_task",
+        result: { simplified: true },
       };
     }
 
     // Generic fallback
     return {
       success: true,
-      strategy: 'graceful_degradation',
-      result: { degraded: true }
+      strategy: "graceful_degradation",
+      result: { degraded: true },
     };
   }
 }
 
 class ErrorReporter {
   reportError(error: any): void {
-    console.error('Error reported:', error);
+    console.error("Error reported:", error);
     // In production, this would send to monitoring service
   }
 }
@@ -938,30 +965,35 @@ class ErrorReporter {
 ## コミット計画
 
 ### コミット1: 統合テスト型定義
+
 ```bash
 git add src/testing/integration-types.ts
 git commit -m "feat(testing): add integration test type definitions"
 ```
 
 ### コミット2: E2Eテストランナー
+
 ```bash
 git add src/testing/e2e-test-runner.ts test/testing/e2e-test-runner.test.ts
 git commit -m "feat(testing): implement E2E test runner with scenarios"
 ```
 
 ### コミット3: パフォーマンス最適化
+
 ```bash
 git add src/optimization/performance-optimizer.ts test/optimization/performance-optimizer.test.ts
 git commit -m "feat(optimization): implement performance optimization framework"
 ```
 
 ### コミット4: エラーハンドリング
+
 ```bash
 git add src/error-handling/error-framework.ts test/error-handling/error-framework.test.ts
 git commit -m "feat(error-handling): implement comprehensive error handling"
 ```
 
 ### コミット5: 統合とドキュメント
+
 ```bash
 git add test/integration/full-system.test.ts docs/orchestration-guide.md
 git commit -m "feat(integration): add full system tests and documentation"
@@ -1005,21 +1037,25 @@ docs/
 
 ```typescript
 // test/integration/full-system.test.ts
-import { describe, test, expect } from 'bun:test';
-import { IntegrationTestSuite } from '../../src/testing/integration-test-suite';
+import { describe, test, expect } from "bun:test";
+import { IntegrationTestSuite } from "../../src/testing/integration-test-suite";
 
-describe('Full System Integration', () => {
-  test('should run complete integration test suite', async () => {
+describe("Full System Integration", () => {
+  test("should run complete integration test suite", async () => {
     const suite = new IntegrationTestSuite();
     const report = await suite.runAllTests();
 
     // E2E Tests
     expect(report.e2eResults.scenarios.length).toBeGreaterThan(5);
-    expect(report.summary.passed / report.summary.totalTests).toBeGreaterThan(0.95);
+    expect(report.summary.passed / report.summary.totalTests).toBeGreaterThan(
+      0.95,
+    );
 
     // Performance Tests
     expect(report.performanceResults.avgResponseTime).toBeLessThan(2000);
-    expect(report.performanceResults.tokenUsage.avgTokensPerRequest).toBeLessThan(3000);
+    expect(
+      report.performanceResults.tokenUsage.avgTokensPerRequest,
+    ).toBeLessThan(3000);
 
     // Load Tests
     expect(report.loadTestResults.errorRate).toBeLessThan(0.01);
@@ -1030,28 +1066,29 @@ describe('Full System Integration', () => {
     expect(report.recommendations.length).toBeGreaterThan(0);
   }, 60000); // 60 second timeout for full suite
 
-  test('should handle concurrent orchestration requests', async () => {
+  test("should handle concurrent orchestration requests", async () => {
     const concurrentRequests = 10;
     const promises = [];
 
     for (let i = 0; i < concurrentRequests; i++) {
       promises.push(
-        simulateOrchestrationRequest(`Task ${i}: Implement feature ${i}`)
+        simulateOrchestrationRequest(`Task ${i}: Implement feature ${i}`),
       );
     }
 
     const results = await Promise.all(promises);
-    const successRate = results.filter(r => r.success).length / results.length;
+    const successRate =
+      results.filter((r) => r.success).length / results.length;
 
     expect(successRate).toBeGreaterThan(0.95);
   });
 
-  test('should maintain performance under load', async () => {
+  test("should maintain performance under load", async () => {
     const loadTest = new LoadTestRunner();
     const result = await loadTest.run({
       duration: 30, // seconds
       concurrentUsers: 50,
-      scenario: 'mixed_workload'
+      scenario: "mixed_workload",
     });
 
     expect(result.avgResponseTime).toBeLessThan(3000);
@@ -1070,29 +1107,31 @@ async function simulateOrchestrationRequest(task: string): Promise<any> {
 
 ```typescript
 // scripts/benchmark.ts
-import { PerformanceBenchmark } from '../src/testing/performance-benchmark';
+import { PerformanceBenchmark } from "../src/testing/performance-benchmark";
 
 async function runBenchmarks() {
   const benchmark = new PerformanceBenchmark();
 
-  console.log('Running orchestration benchmarks...\n');
+  console.log("Running orchestration benchmarks...\n");
 
   // Token optimization benchmark
   const tokenBench = await benchmark.runTokenOptimizationBenchmark();
-  console.log('Token Optimization:');
+  console.log("Token Optimization:");
   console.log(`  Original: ${tokenBench.originalTokens} tokens`);
   console.log(`  Optimized: ${tokenBench.optimizedTokens} tokens`);
   console.log(`  Reduction: ${tokenBench.reductionPercentage}%\n`);
 
   // Mode switching benchmark
   const modeBench = await benchmark.runModeSwitchingBenchmark();
-  console.log('Mode Switching:');
+  console.log("Mode Switching:");
   console.log(`  Avg switch time: ${modeBench.avgSwitchTime}ms`);
-  console.log(`  Context preserved: ${modeBench.contextPreservationRate * 100}%\n`);
+  console.log(
+    `  Context preserved: ${modeBench.contextPreservationRate * 100}%\n`,
+  );
 
   // Subtask execution benchmark
   const subtaskBench = await benchmark.runSubtaskExecutionBenchmark();
-  console.log('Subtask Execution:');
+  console.log("Subtask Execution:");
   console.log(`  Parallel speedup: ${subtaskBench.parallelSpeedup}x`);
   console.log(`  Avg subtask time: ${subtaskBench.avgSubtaskTime}ms`);
 }
@@ -1103,6 +1142,7 @@ runBenchmarks().catch(console.error);
 ## 実行手順
 
 ### 実行フロー
+
 ```bash
 # 1. phase4-mcp-extension から作業ブランチを作成
 git checkout phase4-mcp-extension
@@ -1133,6 +1173,7 @@ git branch -d phase5-integration-testing # ローカルの作業ブランチを�
 ```
 
 ### 詳細ステップ（TDD）
+
 ```bash
 # 1. phase4-mcp-extension から作業ブランチ作成
 git checkout phase4-mcp-extension
@@ -1164,6 +1205,7 @@ git branch -d phase5-integration-testing
 ## 依存関係
 
 このフェーズは全ての前フェーズ完了後に実装してください：
+
 - フェーズ1-5: 全機能の実装完了
 
 ## 次のステップ

--- a/predev-docs/claude-code-action-orchestration-plan.md
+++ b/predev-docs/claude-code-action-orchestration-plan.md
@@ -15,6 +15,7 @@
 ### 0.1 アクション参照の更新
 
 #### タスク0.1.1: アクション参照の置換
+
 - **ファイル**:
   - `README.md`
   - `examples/*.yml`
@@ -30,6 +31,7 @@ uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
 ```
 
 ### タグ命名の理由
+
 - **orchestrator-alpha**:
   - オーケストレーション機能の実装を明確に示す
   - アルファ版として実験的な段階であることを表明
@@ -40,6 +42,7 @@ uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
 ### 1.1 組み込みモードシステムの実装
 
 #### タスク1.1.1: モード定義の作成
+
 - **ファイル**: `src/modes/types.ts`
 - **内容**: モードインターフェースの定義
 
@@ -55,11 +58,13 @@ interface Mode {
 ```
 
 #### タスク1.1.2: 組み込みモードの実装
+
 - **ファイル**: `src/modes/built-in-modes.ts`
 - **内容**: Code, Architect, Debug, Ask, Orchestratorモードの定義
 - **テスト**: `test/modes/built-in-modes.test.ts`
 
 #### タスク1.1.3: モード管理システム
+
 - **ファイル**: `src/modes/mode-manager.ts`
 - **内容**: 組み込みモードの取得機能
 - **テスト**: `test/modes/mode-manager.test.ts`
@@ -67,6 +72,7 @@ interface Mode {
 ### 1.2 タスクシステムの実装
 
 #### タスク1.2.1: タスク定義の作成
+
 - **ファイル**: `src/tasks/types.ts`
 - **内容**: タスクインターフェースの定義
 
@@ -77,7 +83,7 @@ interface Task {
   message: string;
   parentTaskId?: string;
   context: TaskContext;
-  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  status: "pending" | "in_progress" | "completed" | "failed";
   result?: TaskResult;
   createdAt: Date;
   updatedAt: Date;
@@ -85,6 +91,7 @@ interface Task {
 ```
 
 #### タスク1.2.2: タスクマネージャーの実装
+
 - **ファイル**: `src/tasks/task-manager.ts`
 - **内容**: タスクの作成、管理、実行制御。コンストラクタはオプションでデフォルトコンテキスト値（例：`defaultMaxTokens`）を受け付け、`executeTask` はタスクIDと実行関数 (`executionFn`) を引数に取り、タスクの状態遷移と結果の記録を行う。`updateTaskResult`, `getAllTasks`, `getTasksByStatus` などのメソッドも含む。
 - **テスト**: `test/tasks/task-manager.test.ts`
@@ -94,11 +101,13 @@ interface Task {
 ### 2.1 タスク分析エンジン
 
 #### タスク2.1.1: タスク複雑度分析
+
 - **ファイル**: `src/orchestration/task-analyzer.ts`
 - **内容**: タスクの複雑度を分析し、分割が必要かを判定
 - **テスト**: `test/orchestration/task-analyzer.test.ts`
 
 #### タスク2.1.2: サブタスク生成
+
 - **ファイル**: `src/orchestration/subtask-generator.ts`
 - **内容**: 複雑なタスクを適切なサブタスクに分解
 - **テスト**: `test/orchestration/subtask-generator.test.ts`
@@ -106,11 +115,13 @@ interface Task {
 ### 2.2 コンテキスト最適化
 
 #### タスク2.2.1: コンテキスト優先度管理
+
 - **ファイル**: `src/orchestration/context-optimizer.ts`
 - **内容**: モードごとの情報優先度に基づくコンテキスト最適化
 - **テスト**: `test/orchestration/context-optimizer.test.ts`
 
 #### タスク2.2.2: 動的コンテキスト生成
+
 - **ファイル**: `src/orchestration/dynamic-context.ts`
 - **内容**: サブタスクの進行状況に応じたコンテキスト生成
 - **テスト**: `test/orchestration/dynamic-context.test.ts`
@@ -120,21 +131,25 @@ interface Task {
 ### 3.1 プロンプト生成の拡張
 
 #### タスク3.1.1: プロンプト拡張型定義の作成
+
 - **ファイル**: `src/create-prompt/types.ts`
 - **内容**: プロンプト拡張関連の型定義（`PromptTemplate`, `PromptConstraints`, `QualityScore` など）
 - **テスト**: (型定義ファイルのため、直接的なテストファイルはなし。関連する実装のテストで検証)
 
 #### タスク3.1.2: モード別プロンプト生成エンジンの実装
+
 - **ファイル**: `src/create-prompt/mode-prompt-generator.ts`
 - **内容**: モードに応じたプロンプト生成機能の実装
 - **テスト**: `test/create-prompt/mode-prompt-generator.test.ts`
 
 #### タスク3.1.3: サブタスクプロンプト生成エンジンの実装
+
 - **ファイル**: `src/create-prompt/subtask-prompt-generator.ts`
 - **内容**: サブタスク用の最適化されたプロンプト生成
 - **テスト**: `test/create-prompt/subtask-prompt-generator.test.ts`
 
 #### タスク3.1.4: プロンプト拡張統合クラスの実装
+
 - **ファイル**: `src/create-prompt/prompt-extension.ts`
 - **内容**: モード別およびサブタスク別のプロンプト生成を統合し、プロンプト最適化機能を提供するクラス
 - **テスト**: `test/create-prompt/prompt-extension.test.ts`
@@ -142,11 +157,13 @@ interface Task {
 ### 3.2 GitHub Actionsワークフローの拡張
 
 #### タスク3.2.1: オーケストレーター対応
+
 - **ファイル**: `src/entrypoints/orchestrate.ts`
 - **内容**: オーケストレーション機能のエントリーポイント
 - **テスト**: `test/entrypoints/orchestrate.test.ts`
 
 #### タスク3.2.2: サブタスク実行管理
+
 - **ファイル**: `src/github/operations/subtask-execution.ts`
 - **内容**: サブタスクの並列・順次実行制御
 - **テスト**: `test/github/operations/subtask-execution.test.ts`
@@ -156,11 +173,13 @@ interface Task {
 ### 4.1 新しいMCPツール
 
 #### タスク4.1.1: new_taskツールの実装
+
 - **ファイル**: `src/mcp/tools/new-task.ts`
 - **内容**: サブタスク作成用のMCPツール
 - **テスト**: `test/mcp/tools/new-task.test.ts`
 
 #### タスク4.1.2: switch_modeツールの実装
+
 - **ファイル**: `src/mcp/tools/switch-mode.ts`
 - **内容**: モード切り替え用のMCPツール
 - **テスト**: `test/mcp/tools/switch-mode.test.ts`
@@ -170,16 +189,19 @@ interface Task {
 ### 5.1 エンドツーエンドテスト
 
 #### タスク5.1.1: オーケストレーションE2Eテスト
+
 - **ファイル**: `test/e2e/orchestration.test.ts`
 - **内容**: 完全なオーケストレーションフローのテスト
 
 #### タスク5.1.2: パフォーマンステスト
+
 - **ファイル**: `test/performance/orchestration-perf.test.ts`
 - **内容**: コンテキスト最適化の効果測定
 
 ### 5.2 ドキュメンテーション
 
 #### タスク5.2.1: 利用ガイドの作成
+
 - **ファイル**: `docs/orchestration-guide.md`
 - **内容**: オーケストレーション機能の使い方
 
@@ -193,11 +215,13 @@ interface Task {
 ## 成功指標
 
 1. **機能面**
+
    - 複雑なタスクの自動分割が可能
    - サブタスクごとに最適化されたコンテキストの生成
    - モード間の円滑な切り替え
 
 2. **パフォーマンス面**
+
    - コンテキストサイズの30%以上削減
    - AIの応答精度の向上
    - トークン使用量の最適化
@@ -221,11 +245,13 @@ interface Task {
 ## リスクと対策
 
 1. **技術的リスク**
+
    - Claude APIの制限への対応
    - GitHub Actions実行時間の制限
    - 対策: 適切なタイムアウト設定とエラーハンドリング
 
 2. **互換性リスク**
+
    - 既存の claude-code-action との互換性
    - 対策: 段階的な移行パスの提供
 
@@ -452,24 +478,29 @@ classDiagram
 ### クラス設計の詳細説明
 
 #### 1. Mode System（モードシステム）
+
 - **Mode Interface**: モードの基本構造を定義
 - **ModeManager**: 組み込みモードを管理・提供
 
 #### 2. Task System（タスクシステム）
+
 - **Task Interface**: タスクの基本構造（ID、モード、コンテキスト、ステータス等）
 - **TaskManager**: タスクのライフサイクル全体を管理
 - **AutoOrchestrator**: タスクの分解とサブタスクへの委譲を制御
 
 #### 3. Task Analysis（タスク分析）
+
 - **TaskAnalyzer**: タスクの複雑度を分析し、オーケストレーションの必要性を判断
 - **SubtaskGenerator**: 複雑なタスクを適切なサブタスクに分解
 - **SubTask**: サブタスクの表現（依存関係、優先度を含む）
 
 #### 4. Context Optimization（コンテキスト最適化）
+
 - **ContextOptimizer**: 各モードに最適化されたコンテキストを生成
 - **PriorityCalculator**: モード別の情報優先度を計算
 
 #### 5. Integration（既存システムとの統合）
+
 - **OrchestrationEntrypoint**: GitHub Actionsのエントリーポイント
 - **PromptExtension**: モード別・サブタスク別のプロンプト生成と最適化（`design.md`で詳細定義）
 - **MCPOrchestrationTools**: Claude がサブタスクを作成するための新しいMCPツール
@@ -488,4 +519,4 @@ classDiagram
 
 ---
 
-*注: この計画は初期版であり、実装の進行に応じて適宜更新される予定です。*
+_注: この計画は初期版であり、実装の進行に応じて適宜更新される予定です。_

--- a/predev-docs/claude-code-action-orchestration-plan.md
+++ b/predev-docs/claude-code-action-orchestration-plan.md
@@ -1,0 +1,491 @@
+# Claude Code Action オーケストレーション機能実装計画
+
+## 概要
+
+本ドキュメントは、RooCline（Roo Code）のオーケストレーション機能をClaude Code Actionに実装するための詳細な計画書です。テスト駆動開発（TDD）の方法論に従って実装を進めます。
+
+## 実装目標
+
+1. **タスクの分割と最適化**: 複雑なタスクを適切なサブタスクに分解し、各サブタスクに最適化されたコンテキストを提供
+2. **組み込みモードシステム**: タスクの性質に応じて異なるモード（Code, Architect, Debug, Ask, Orchestrator）を使い分け
+3. **効率的なコンテキスト管理**: 各サブタスクに必要最小限の情報のみを渡すことで、AIの精度向上とコスト削減を実現
+
+## フェーズ0: フォーク対応
+
+### 0.1 アクション参照の更新
+
+#### タスク0.1.1: アクション参照の置換
+- **ファイル**:
+  - `README.md`
+  - `examples/*.yml`
+- **内容**: `anthropics/claude-code-action@beta` を `MasashiFukuzawa/claude-code-action@orchestrator-alpha` に置換
+- **理由**: フォークしたリポジトリでオーケストレーション機能を実装するため
+
+```yaml
+# 変更前
+uses: anthropics/claude-code-action@beta
+
+# 変更後
+uses: MasashiFukuzawa/claude-code-action@orchestrator-alpha
+```
+
+### タグ命名の理由
+- **orchestrator-alpha**:
+  - オーケストレーション機能の実装を明確に示す
+  - アルファ版として実験的な段階であることを表明
+  - 将来的に `orchestrator-beta`、`orchestrator-stable` へ進化可能
+
+## フェーズ1: 基盤構築
+
+### 1.1 組み込みモードシステムの実装
+
+#### タスク1.1.1: モード定義の作成
+- **ファイル**: `src/modes/types.ts`
+- **内容**: モードインターフェースの定義
+
+```typescript
+interface Mode {
+  slug: string;
+  name: string;
+  roleDefinition: string;
+  groups: string[];
+  customInstructions?: string;
+  defaultLLMProvider?: string;
+}
+```
+
+#### タスク1.1.2: 組み込みモードの実装
+- **ファイル**: `src/modes/built-in-modes.ts`
+- **内容**: Code, Architect, Debug, Ask, Orchestratorモードの定義
+- **テスト**: `test/modes/built-in-modes.test.ts`
+
+#### タスク1.1.3: モード管理システム
+- **ファイル**: `src/modes/mode-manager.ts`
+- **内容**: 組み込みモードの取得機能
+- **テスト**: `test/modes/mode-manager.test.ts`
+
+### 1.2 タスクシステムの実装
+
+#### タスク1.2.1: タスク定義の作成
+- **ファイル**: `src/tasks/types.ts`
+- **内容**: タスクインターフェースの定義
+
+```typescript
+interface Task {
+  id: string;
+  mode: string;
+  message: string;
+  parentTaskId?: string;
+  context: TaskContext;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  result?: TaskResult;
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+#### タスク1.2.2: タスクマネージャーの実装
+- **ファイル**: `src/tasks/task-manager.ts`
+- **内容**: タスクの作成、管理、実行制御。コンストラクタはオプションでデフォルトコンテキスト値（例：`defaultMaxTokens`）を受け付け、`executeTask` はタスクIDと実行関数 (`executionFn`) を引数に取り、タスクの状態遷移と結果の記録を行う。`updateTaskResult`, `getAllTasks`, `getTasksByStatus` などのメソッドも含む。
+- **テスト**: `test/tasks/task-manager.test.ts`
+
+## フェーズ2: オーケストレーション機能
+
+### 2.1 タスク分析エンジン
+
+#### タスク2.1.1: タスク複雑度分析
+- **ファイル**: `src/orchestration/task-analyzer.ts`
+- **内容**: タスクの複雑度を分析し、分割が必要かを判定
+- **テスト**: `test/orchestration/task-analyzer.test.ts`
+
+#### タスク2.1.2: サブタスク生成
+- **ファイル**: `src/orchestration/subtask-generator.ts`
+- **内容**: 複雑なタスクを適切なサブタスクに分解
+- **テスト**: `test/orchestration/subtask-generator.test.ts`
+
+### 2.2 コンテキスト最適化
+
+#### タスク2.2.1: コンテキスト優先度管理
+- **ファイル**: `src/orchestration/context-optimizer.ts`
+- **内容**: モードごとの情報優先度に基づくコンテキスト最適化
+- **テスト**: `test/orchestration/context-optimizer.test.ts`
+
+#### タスク2.2.2: 動的コンテキスト生成
+- **ファイル**: `src/orchestration/dynamic-context.ts`
+- **内容**: サブタスクの進行状況に応じたコンテキスト生成
+- **テスト**: `test/orchestration/dynamic-context.test.ts`
+
+## フェーズ3: 統合とGitHub Actions対応
+
+### 3.1 プロンプト生成の拡張
+
+#### タスク3.1.1: プロンプト拡張型定義の作成
+- **ファイル**: `src/create-prompt/types.ts`
+- **内容**: プロンプト拡張関連の型定義（`PromptTemplate`, `PromptConstraints`, `QualityScore` など）
+- **テスト**: (型定義ファイルのため、直接的なテストファイルはなし。関連する実装のテストで検証)
+
+#### タスク3.1.2: モード別プロンプト生成エンジンの実装
+- **ファイル**: `src/create-prompt/mode-prompt-generator.ts`
+- **内容**: モードに応じたプロンプト生成機能の実装
+- **テスト**: `test/create-prompt/mode-prompt-generator.test.ts`
+
+#### タスク3.1.3: サブタスクプロンプト生成エンジンの実装
+- **ファイル**: `src/create-prompt/subtask-prompt-generator.ts`
+- **内容**: サブタスク用の最適化されたプロンプト生成
+- **テスト**: `test/create-prompt/subtask-prompt-generator.test.ts`
+
+#### タスク3.1.4: プロンプト拡張統合クラスの実装
+- **ファイル**: `src/create-prompt/prompt-extension.ts`
+- **内容**: モード別およびサブタスク別のプロンプト生成を統合し、プロンプト最適化機能を提供するクラス
+- **テスト**: `test/create-prompt/prompt-extension.test.ts`
+
+### 3.2 GitHub Actionsワークフローの拡張
+
+#### タスク3.2.1: オーケストレーター対応
+- **ファイル**: `src/entrypoints/orchestrate.ts`
+- **内容**: オーケストレーション機能のエントリーポイント
+- **テスト**: `test/entrypoints/orchestrate.test.ts`
+
+#### タスク3.2.2: サブタスク実行管理
+- **ファイル**: `src/github/operations/subtask-execution.ts`
+- **内容**: サブタスクの並列・順次実行制御
+- **テスト**: `test/github/operations/subtask-execution.test.ts`
+
+## フェーズ4: MCPサーバー拡張
+
+### 4.1 新しいMCPツール
+
+#### タスク4.1.1: new_taskツールの実装
+- **ファイル**: `src/mcp/tools/new-task.ts`
+- **内容**: サブタスク作成用のMCPツール
+- **テスト**: `test/mcp/tools/new-task.test.ts`
+
+#### タスク4.1.2: switch_modeツールの実装
+- **ファイル**: `src/mcp/tools/switch-mode.ts`
+- **内容**: モード切り替え用のMCPツール
+- **テスト**: `test/mcp/tools/switch-mode.test.ts`
+
+## フェーズ5: 統合テストと最適化
+
+### 5.1 エンドツーエンドテスト
+
+#### タスク5.1.1: オーケストレーションE2Eテスト
+- **ファイル**: `test/e2e/orchestration.test.ts`
+- **内容**: 完全なオーケストレーションフローのテスト
+
+#### タスク5.1.2: パフォーマンステスト
+- **ファイル**: `test/performance/orchestration-perf.test.ts`
+- **内容**: コンテキスト最適化の効果測定
+
+### 5.2 ドキュメンテーション
+
+#### タスク5.2.1: 利用ガイドの作成
+- **ファイル**: `docs/orchestration-guide.md`
+- **内容**: オーケストレーション機能の使い方
+
+## 実装優先順位
+
+1. **最優先**: フェーズ0（フォーク対応）
+2. **高優先度**: フェーズ1とフェーズ2（基本的なオーケストレーション機能）
+3. **中優先度**: フェーズ3（GitHub Actions統合）
+4. **低優先度**: フェーズ4とフェーズ5（MCP拡張と統合テスト）
+
+## 成功指標
+
+1. **機能面**
+   - 複雑なタスクの自動分割が可能
+   - サブタスクごとに最適化されたコンテキストの生成
+   - モード間の円滑な切り替え
+
+2. **パフォーマンス面**
+   - コンテキストサイズの30%以上削減
+   - AIの応答精度の向上
+   - トークン使用量の最適化
+
+3. **開発面**
+   - 全機能に対する単体テストカバレッジ100%
+   - 統合テストによる主要シナリオの検証
+   - 明確なドキュメントとサンプルコード
+
+## 実装スケジュール（推定）
+
+- フェーズ0: 1日
+- フェーズ1: 2週間
+- フェーズ2: 2週間
+- フェーズ3: 1週間
+- フェーズ4: 1週間
+- フェーズ5: 1週間
+
+合計: 約7週間
+
+## リスクと対策
+
+1. **技術的リスク**
+   - Claude APIの制限への対応
+   - GitHub Actions実行時間の制限
+   - 対策: 適切なタイムアウト設定とエラーハンドリング
+
+2. **互換性リスク**
+   - 既存の claude-code-action との互換性
+   - 対策: 段階的な移行パスの提供
+
+3. **パフォーマンスリスク**
+   - サブタスク数が多い場合の処理時間
+   - 対策: 並列実行とキャッシング機構の実装
+
+## アーキテクチャ設計（クラス図）
+
+### オーケストレーション機能のクラス構成
+
+#### 1. モードシステム（Mode System）
+
+```mermaid
+classDiagram
+    class Mode {
+        <<interface>>
+        +slug: string
+        +name: string
+        +roleDefinition: string
+        +groups: string[]
+        +customInstructions?: string
+        +defaultLLMProvider?: string
+    }
+
+    class ModeManager {
+        -modes: Map<string, Mode>
+        +getModeBySlug(slug: string): Mode
+        +getAllModes(): Mode[]
+        +getDefaultMode(): Mode
+    }
+
+    class BuiltInModes {
+        <<enumeration>>
+        CODE
+        ARCHITECT
+        DEBUG
+        ASK
+        ORCHESTRATOR
+    }
+
+    ModeManager --> Mode : manages
+    BuiltInModes ..> Mode : implements
+
+    note for ModeManager "組み込みモードの管理と提供"
+```
+
+#### 2. タスクシステム（Task System）
+
+```mermaid
+classDiagram
+    class Task {
+        <<interface>>
+        +id: string
+        +mode: string
+        +message: string
+        +parentTaskId?: string
+        +context: TaskContext
+        +status: 'pending' | 'in_progress' | 'completed' | 'failed';
+        +result?: TaskResult;
+        +createdAt: Date
+        +updatedAt: Date
+    }
+
+    class TaskContext {
+        <<interface>>
+        +previousResults: string[]
+        +globalContext: Record<string, any>
+        +modeSpecificContext: Record<string, any>
+        +maxTokens: number
+    }
+
+    class TaskManager {
+        -tasks: Map<string, Task>
+        +constructor(options?: TaskManagerOptions)
+        +createTask(params: CreateTaskParams): Task
+        +getTask(id: string): Task
+        +updateTaskStatus(id: string, status: TaskStatus): void
+        +updateTaskResult(id: string, result: TaskResult): void
+        +executeTask(id: string, executionFn: Function): Promise<TaskResult>
+        +getSubTasks(parentId: string): Task[]
+        +getAllTasks(): Task[]
+        +getTasksByStatus(status: TaskStatus): Task[]
+    }
+
+    class AutoOrchestrator {
+        -taskManager: TaskManager
+        -taskAnalyzer: TaskAnalyzer
+        -contextOptimizer: ContextOptimizer
+        -modeManager: ModeManager
+        -executionManager: SubtaskExecutionManager
+        +orchestrateTask(taskDescription: string): Promise<OrchestrationResult>
+        +executeSubTasks(analysis: TaskAnalysis): Promise<TaskResult[]>
+        +handleBoomerangTask(request: BoomerangRequest): Promise<TaskResult>
+    }
+
+    Task --> TaskContext : contains
+    TaskManager --> Task : manages
+    AutoOrchestrator --> TaskManager : uses
+    AutoOrchestrator o-- SubtaskExecutionManager : aggregates
+
+    note for AutoOrchestrator "オーケストレーションの中核<br>タスク分解とモード委譲を制御"
+    note for TaskManager "タスクのライフサイクル管理"
+```
+
+#### 3. タスク分析システム（Task Analysis System）
+
+```mermaid
+classDiagram
+    class TaskAnalyzer {
+        +analyzeTask(description: string): TaskAnalysis
+        +calculateComplexity(task: string): number
+        +determineRequiredModes(task: string): string[]
+        +shouldOrchestrate(analysis: TaskAnalysis): boolean
+    }
+
+    class SubtaskGenerator {
+        +generateSubtasks(analysis: TaskAnalysis): SubTask[]
+        +prioritizeSubtasks(subtasks: SubTask[]): SubTask[]
+        +identifyDependencies(subtasks: SubTask[]): DependencyGraph
+    }
+
+    class SubTask {
+        +id: string
+        +description: string
+        +mode: string
+        +priority: number
+        +dependencies: string[]
+        +estimatedComplexity: number
+        +estimatedDuration?: number
+    }
+
+    class TaskAnalysis {
+        <<interface>>
+        +complexity: number
+        +complexityFactors: ComplexityFactor[]
+        +requiredModes: string[]
+        +requiresOrchestration: boolean
+        +estimatedSubtasks: number
+        +suggestedApproach: string
+    }
+
+    TaskAnalyzer --> TaskAnalysis : produces
+    TaskAnalyzer --> SubtaskGenerator : works with
+    SubtaskGenerator --> SubTask : generates
+
+    note for TaskAnalyzer "タスクの複雑度を分析<br>オーケストレーションの必要性を判断"
+    note for SubtaskGenerator "複雑なタスクを<br>適切なサブタスクに分解"
+```
+
+#### 4. コンテキスト最適化システム（Context Optimization System）
+
+```mermaid
+classDiagram
+    class ContextOptimizer {
+        -priorityCalculator: PriorityCalculator
+        +createContextForSubTask(params: ContextParams): TaskContext
+        +extractRelevantInfo(previousResults: string[], mode: string): any
+        +optimizeContext(context: any, maxTokens: number): any
+    }
+
+    class PriorityCalculator {
+        -modePriorities: Map<string, ModePriorities>
+        +calculatePriority(info: any, mode: string): number
+        +getModePriorities(mode: string): ModePriorities
+    }
+
+    class ModePriorities {
+        +design_decision: number
+        +technical_detail: number
+        +dependency_info: number
+        +file_change: number
+        +error_info: number
+    }
+
+    ContextOptimizer --> PriorityCalculator : uses
+    PriorityCalculator --> ModePriorities : uses
+
+    note for ContextOptimizer "コンテキストサイズを30-50%削減<br>モードに基づいて情報を優先順位付けし、トークン最適化も行う"
+```
+
+#### 5. 統合レイヤー（Integration Layer）
+
+```mermaid
+classDiagram
+    class OrchestrationEntrypoint {
+        -githubContext: GitHubContext
+        -taskManager: TaskManager
+        -promptExtension: PromptExtension
+        +prepare(): Promise<void>
+        +execute(): Promise<void>
+        +updateComment(result: OrchestrationResult): Promise<void>
+    }
+
+    class PromptExtension {
+        +createPromptForMode(context: any, mode: Mode): PromptGenerationResult
+        +createPromptForSubtask(subtask: SubTask, context: TaskContext): PromptGenerationResult
+        +optimizePrompt(prompt: string, constraints: PromptConstraints): string
+    }
+
+    class MCPOrchestrationTools {
+        +new_task: MCPTool
+        +switch_mode: MCPTool
+        +get_task_status: MCPTool
+        +boomerang_task: MCPTool
+    }
+
+    class GitHubContext {
+        <<existing>>
+        +eventType: string
+        +repository: Repository
+        +issue?: Issue
+        +pullRequest?: PullRequest
+    }
+
+    OrchestrationEntrypoint --> GitHubContext : uses
+    OrchestrationEntrypoint --> PromptExtension : uses
+    MCPOrchestrationTools --> OrchestrationEntrypoint : interacts
+
+    note for MCPOrchestrationTools "新しいMCPツール<br>Claudeがサブタスクを作成可能に"
+    note for PromptExtension "モード別・サブタスク別プロンプト生成と最適化を行う (design.mdで定義)"
+```
+
+### クラス設計の詳細説明
+
+#### 1. Mode System（モードシステム）
+- **Mode Interface**: モードの基本構造を定義
+- **ModeManager**: 組み込みモードを管理・提供
+
+#### 2. Task System（タスクシステム）
+- **Task Interface**: タスクの基本構造（ID、モード、コンテキスト、ステータス等）
+- **TaskManager**: タスクのライフサイクル全体を管理
+- **AutoOrchestrator**: タスクの分解とサブタスクへの委譲を制御
+
+#### 3. Task Analysis（タスク分析）
+- **TaskAnalyzer**: タスクの複雑度を分析し、オーケストレーションの必要性を判断
+- **SubtaskGenerator**: 複雑なタスクを適切なサブタスクに分解
+- **SubTask**: サブタスクの表現（依存関係、優先度を含む）
+
+#### 4. Context Optimization（コンテキスト最適化）
+- **ContextOptimizer**: 各モードに最適化されたコンテキストを生成
+- **PriorityCalculator**: モード別の情報優先度を計算
+
+#### 5. Integration（既存システムとの統合）
+- **OrchestrationEntrypoint**: GitHub Actionsのエントリーポイント
+- **PromptExtension**: モード別・サブタスク別のプロンプト生成と最適化（`design.md`で詳細定義）
+- **MCPOrchestrationTools**: Claude がサブタスクを作成するための新しいMCPツール
+
+### 設計の特徴
+
+1. **既存コードへの影響を最小化**: 新機能を独立したモジュールとして実装
+2. **テスタビリティ**: 各クラスが単一責任の原則に従い、単体テストが容易
+3. **パフォーマンス**: コンテキスト最適化により、トークン使用量を30-50%削減（これはコンテキスト最適化フェーズの目標）
+
+## 次のステップ
+
+1. このプランのレビューと承認
+2. フェーズ1の詳細設計
+3. TDDに従った実装開始
+
+---
+
+*注: この計画は初期版であり、実装の進行に応じて適宜更新される予定です。*

--- a/predev-docs/roocline-orchestration-explained.md
+++ b/predev-docs/roocline-orchestration-explained.md
@@ -7,11 +7,13 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ## 核心概念：なぜオーケストレーションが必要か？
 
 ### 従来の問題点
+
 1. **クソデカコンテキスト問題**: 全ての情報をAIに渡すと、重要な情報が埋もれてしまう
 2. **数撃ちゃ当たる戦略の限界**: 並列で複数の試行を行うとコストが膨大になる
 3. **専門性の欠如**: 全てのタスクを同じ設定で処理すると、各タスクに最適な結果が得られない
 
 ### オーケストレーションによる解決
+
 - **タスクの分解**: 大きな問題を管理可能な小さな部分に分割
 - **専門モードの活用**: 各サブタスクに最適な専門モードを選択
 - **コンテキストの最適化**: 各タスクに必要最小限の情報のみを提供
@@ -19,6 +21,7 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ## モードシステムの詳細
 
 ### 1. Code Mode（コードモード）
+
 ```yaml
 役割: 実際のコーディング作業を担当
 アクセス可能なツール:
@@ -31,6 +34,7 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ```
 
 ### 2. Architect Mode（アーキテクトモード）
+
 ```yaml
 役割: システム設計と技術的意思決定
 アクセス可能なツール: Code Modeと同様
@@ -41,6 +45,7 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ```
 
 ### 3. Debug Mode（デバッグモード）
+
 ```yaml
 役割: エラーの診断と修正
 特徴:
@@ -50,6 +55,7 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ```
 
 ### 4. Ask Mode（質問モード）
+
 ```yaml
 役割: 情報収集と明確化
 特徴:
@@ -59,6 +65,7 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ```
 
 ### 5. Orchestrator Mode（オーケストレーターモード）🪃
+
 ```yaml
 役割: 戦略的なワークフロー調整
 機能:
@@ -71,12 +78,14 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ## オーケストレーションの動作フロー
 
 ### 1. タスク受信と分析
+
 ```xml
 <!-- ユーザーからのタスク -->
 「新しいユーザー認証システムを実装してください」
 ```
 
 ### 2. Orchestratorによる分解
+
 ```xml
 <orchestration>
   <analysis>
@@ -106,6 +115,7 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ```
 
 ### 3. new_task ツールによる委譲
+
 ```xml
 <new_task>
   <mode>architect</mode>
@@ -132,51 +142,50 @@ RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オ�
 ## コンテキスト最適化の仕組み
 
 ### モード別優先度設定
+
 ```typescript
 const MODE_PRIORITIES = {
   architect: {
-    design_decision: 1.5,      // 最優先
+    design_decision: 1.5, // 最優先
     technical_detail: 1.3,
     dependency_info: 1.2,
-    file_change: 0.8,         // 低優先度
-    error_info: 0.7
+    file_change: 0.8, // 低優先度
+    error_info: 0.7,
   },
   code: {
-    file_change: 1.5,         // 最優先
+    file_change: 1.5, // 最優先
     technical_detail: 1.3,
     error_info: 1.2,
     design_decision: 0.9,
-    dependency_info: 0.8
+    dependency_info: 0.8,
   },
   debug: {
-    error_info: 1.5,          // 最優先
+    error_info: 1.5, // 最優先
     stack_trace: 1.4,
     recent_changes: 1.3,
     test_results: 1.2,
-    design_decision: 0.7
-  }
+    design_decision: 0.7,
+  },
 };
 ```
 
 ### 動的コンテキスト生成
+
 ```typescript
 // サブタスク用のコンテキスト生成例
 function createContextForSubTask(
   previousResults: string[],
   taskDescription: string,
   mode: string,
-  maxTokens: number
+  maxTokens: number,
 ) {
   // 1. 前のタスクの結果から必要な情報を抽出
-  const relevantPreviousInfo = extractRelevantInfo(
-    previousResults,
-    mode
-  );
+  const relevantPreviousInfo = extractRelevantInfo(previousResults, mode);
 
   // 2. モード固有の情報を優先度順に収集
   const modeSpecificContext = gatherModeSpecificInfo(
     mode,
-    MODE_PRIORITIES[mode]
+    MODE_PRIORITIES[mode],
   );
 
   // 3. トークン制限内で最適化
@@ -184,7 +193,7 @@ function createContextForSubTask(
     relevantPreviousInfo,
     modeSpecificContext,
     taskDescription,
-    maxTokens
+    maxTokens,
   );
 }
 ```
@@ -192,17 +201,19 @@ function createContextForSubTask(
 ## ブーメランタスク機能
 
 ### 概念
+
 「ブーメランタスク」は、あるモードが自身では処理できないタスクを検出し、適切なモードに「投げる」機能です。処理が完了すると、結果が元のモードに「戻ってくる」ことからこの名前が付けられています。
 
 ### 実装例
+
 ```typescript
 // Codeモードでの実行中
 if (taskRequiresArchitecturalDecision(currentTask)) {
   // Architectモードにブーメラン
   const architectResult = await boomerangTask({
-    targetMode: 'architect',
-    task: 'このデータベース設計の選択について判断してください',
-    context: currentContext
+    targetMode: "architect",
+    task: "このデータベース設計の選択について判断してください",
+    context: currentContext,
   });
 
   // 結果を使って実装を継続
@@ -213,6 +224,7 @@ if (taskRequiresArchitecturalDecision(currentTask)) {
 ## カスタムモードの実装
 
 ### .actionmodes ファイル形式
+
 ```yaml
 # プロジェクトルートの .actionmodes ファイル
 custom_modes:
@@ -238,21 +250,25 @@ custom_modes:
 ## 実装上の利点
 
 ### 1. 精度の向上
+
 - 各タスクに特化したプロンプトとコンテキスト
 - 不要な情報によるノイズの削減
 - 専門モードによる深い分析
 
 ### 2. コスト効率
+
 - トークン使用量の最適化（30-50%削減）
 - 必要な情報のみを処理
 - 再試行の削減
 
 ### 3. スケーラビリティ
+
 - 複雑なプロジェクトへの対応
 - チーム固有のワークフローサポート
 - カスタムモードによる拡張性
 
 ### 4. デバッグとメンテナンス
+
 - 各サブタスクの明確な責任範囲
 - 問題の特定が容易
 - 段階的な改善が可能
@@ -583,21 +599,26 @@ classDiagram
 ### claude-code-actionとの比較
 
 #### 共通点
+
 1. **モードシステム**: 両者ともモードの概念を採用
 2. **タスク管理**: タスクの作成と実行管理
 3. **コンテキスト最適化**: トークン使用量の最適化
 
 #### RooClineの特徴（claude-code-actionでは省略された部分）
+
 1. **VSCode統合**
+
    - `ClineProvider`によるWebviewProviderの実装
    - VSCode拡張機能としての深い統合
    - Webview UIとの双方向通信
 
 2. **階層的タスク管理**
+
    - タスクスタックによる親子関係の管理
    - ネストされたタスクの実行サポート
 
 3. **プロバイダー設定管理**
+
    - モードごとのAPI設定の永続化
    - 動的なプロバイダー切り替え
 
@@ -606,12 +627,15 @@ classDiagram
    - 進捗状況の視覚的フィードバック
 
 #### claude-code-actionでの簡略化
+
 1. **GitHub Actions特化**
+
    - VSCode依存の削除
    - GitHub APIとの直接統合
    - コメントベースのUI
 
 2. **シンプルなタスク管理**
+
    - フラットなタスク構造
    - GitHub Actionsのワークフローに最適化
 
@@ -624,6 +648,7 @@ classDiagram
 RooClineは**VSCode拡張機能**として設計されており、リッチなUIとリアルタイムの対話を提供します。一方、claude-code-actionは**GitHub Actions環境**で動作することを前提とし、よりシンプルで自動化に適した設計となっています。
 
 この違いにより、claude-code-actionでは：
+
 - Webview関連のコンポーネントを削除
 - GitHub APIとの統合を強化
 - MCPツールによるオーケストレーションを採用

--- a/predev-docs/roocline-orchestration-explained.md
+++ b/predev-docs/roocline-orchestration-explained.md
@@ -1,0 +1,644 @@
+# RooCline (Roo Code) のオーケストレーション機能解説
+
+## 概要
+
+RooCline（現在は Roo Code）は、AI支援開発ツールにおいて「オーケストレーション」という革新的なアプローチを採用しています。この機能は、複雑なタスクを効率的に処理するために、タスクの分解、適切なモードへの委譲、そしてコンテキストの最適化を自動的に行います。
+
+## 核心概念：なぜオーケストレーションが必要か？
+
+### 従来の問題点
+1. **クソデカコンテキスト問題**: 全ての情報をAIに渡すと、重要な情報が埋もれてしまう
+2. **数撃ちゃ当たる戦略の限界**: 並列で複数の試行を行うとコストが膨大になる
+3. **専門性の欠如**: 全てのタスクを同じ設定で処理すると、各タスクに最適な結果が得られない
+
+### オーケストレーションによる解決
+- **タスクの分解**: 大きな問題を管理可能な小さな部分に分割
+- **専門モードの活用**: 各サブタスクに最適な専門モードを選択
+- **コンテキストの最適化**: 各タスクに必要最小限の情報のみを提供
+
+## モードシステムの詳細
+
+### 1. Code Mode（コードモード）
+```yaml
+役割: 実際のコーディング作業を担当
+アクセス可能なツール:
+  - read（ファイル読み取り）
+  - edit（ファイル編集）
+  - browser（ブラウザ操作）
+  - command（コマンド実行）
+  - mcp（Model Context Protocol）
+特徴: コード変更に焦点を当て、技術的詳細とエラー情報を優先
+```
+
+### 2. Architect Mode（アーキテクトモード）
+```yaml
+役割: システム設計と技術的意思決定
+アクセス可能なツール: Code Modeと同様
+特徴:
+  - 設計決定を最優先
+  - 技術的詳細と依存関係情報を重視
+  - 実装前の計画立案に特化
+```
+
+### 3. Debug Mode（デバッグモード）
+```yaml
+役割: エラーの診断と修正
+特徴:
+  - エラー情報とスタックトレースを優先
+  - 問題の根本原因分析に特化
+  - 修正提案の生成
+```
+
+### 4. Ask Mode（質問モード）
+```yaml
+役割: 情報収集と明確化
+特徴:
+  - ユーザーとの対話を重視
+  - 不明確な要件の明確化
+  - 追加情報の収集
+```
+
+### 5. Orchestrator Mode（オーケストレーターモード）🪃
+```yaml
+役割: 戦略的なワークフロー調整
+機能:
+  - 複雑なタスクの分析
+  - サブタスクへの分解
+  - 適切なモードへの委譲
+  - 進捗の追跡と調整
+```
+
+## オーケストレーションの動作フロー
+
+### 1. タスク受信と分析
+```xml
+<!-- ユーザーからのタスク -->
+「新しいユーザー認証システムを実装してください」
+```
+
+### 2. Orchestratorによる分解
+```xml
+<orchestration>
+  <analysis>
+    - タスクの複雑度: 高
+    - 必要な専門性: 設計、実装、テスト
+    - 推定サブタスク数: 5
+  </analysis>
+
+  <subtasks>
+    <subtask id="1" mode="architect">
+      認証システムのアーキテクチャ設計
+    </subtask>
+    <subtask id="2" mode="code">
+      認証モデルとデータベーススキーマの実装
+    </subtask>
+    <subtask id="3" mode="code">
+      認証APIエンドポイントの実装
+    </subtask>
+    <subtask id="4" mode="code">
+      フロントエンド認証UIの実装
+    </subtask>
+    <subtask id="5" mode="debug">
+      統合テストとバグ修正
+    </subtask>
+  </subtasks>
+</orchestration>
+```
+
+### 3. new_task ツールによる委譲
+```xml
+<new_task>
+  <mode>architect</mode>
+  <message>
+    ユーザー認証システムのアーキテクチャを設計してください。
+
+    要件:
+    - JWT基盤の認証
+    - リフレッシュトークンのサポート
+    - ロールベースのアクセス制御
+
+    制約:
+    - 既存のExpressアプリケーションとの統合
+    - PostgreSQLデータベースの使用
+
+    成果物:
+    - アーキテクチャ図
+    - 技術スタックの選定
+    - 実装計画
+  </message>
+</new_task>
+```
+
+## コンテキスト最適化の仕組み
+
+### モード別優先度設定
+```typescript
+const MODE_PRIORITIES = {
+  architect: {
+    design_decision: 1.5,      // 最優先
+    technical_detail: 1.3,
+    dependency_info: 1.2,
+    file_change: 0.8,         // 低優先度
+    error_info: 0.7
+  },
+  code: {
+    file_change: 1.5,         // 最優先
+    technical_detail: 1.3,
+    error_info: 1.2,
+    design_decision: 0.9,
+    dependency_info: 0.8
+  },
+  debug: {
+    error_info: 1.5,          // 最優先
+    stack_trace: 1.4,
+    recent_changes: 1.3,
+    test_results: 1.2,
+    design_decision: 0.7
+  }
+};
+```
+
+### 動的コンテキスト生成
+```typescript
+// サブタスク用のコンテキスト生成例
+function createContextForSubTask(
+  previousResults: string[],
+  taskDescription: string,
+  mode: string,
+  maxTokens: number
+) {
+  // 1. 前のタスクの結果から必要な情報を抽出
+  const relevantPreviousInfo = extractRelevantInfo(
+    previousResults,
+    mode
+  );
+
+  // 2. モード固有の情報を優先度順に収集
+  const modeSpecificContext = gatherModeSpecificInfo(
+    mode,
+    MODE_PRIORITIES[mode]
+  );
+
+  // 3. トークン制限内で最適化
+  return optimizeContext(
+    relevantPreviousInfo,
+    modeSpecificContext,
+    taskDescription,
+    maxTokens
+  );
+}
+```
+
+## ブーメランタスク機能
+
+### 概念
+「ブーメランタスク」は、あるモードが自身では処理できないタスクを検出し、適切なモードに「投げる」機能です。処理が完了すると、結果が元のモードに「戻ってくる」ことからこの名前が付けられています。
+
+### 実装例
+```typescript
+// Codeモードでの実行中
+if (taskRequiresArchitecturalDecision(currentTask)) {
+  // Architectモードにブーメラン
+  const architectResult = await boomerangTask({
+    targetMode: 'architect',
+    task: 'このデータベース設計の選択について判断してください',
+    context: currentContext
+  });
+
+  // 結果を使って実装を継続
+  continueImplementation(architectResult);
+}
+```
+
+## カスタムモードの実装
+
+### .actionmodes ファイル形式
+```yaml
+# プロジェクトルートの .actionmodes ファイル
+custom_modes:
+  - slug: "api-designer"
+    name: "🌐 API Designer"
+    role_definition: "RESTful APIとGraphQLスキーマの設計専門家"
+    groups: ["read", "edit", "architect"]
+    custom_instructions: |
+      - OpenAPI 3.0仕様に準拠
+      - GraphQLベストプラクティスの適用
+      - バージョニング戦略の考慮
+
+  - slug: "security-auditor"
+    name: "🔒 Security Auditor"
+    role_definition: "セキュリティ脆弱性の検出と修正提案"
+    groups: ["read", "analyze", "report"]
+    custom_instructions: |
+      - OWASP Top 10の確認
+      - 依存関係の脆弱性スキャン
+      - セキュリティベストプラクティスの適用
+```
+
+## 実装上の利点
+
+### 1. 精度の向上
+- 各タスクに特化したプロンプトとコンテキスト
+- 不要な情報によるノイズの削減
+- 専門モードによる深い分析
+
+### 2. コスト効率
+- トークン使用量の最適化（30-50%削減）
+- 必要な情報のみを処理
+- 再試行の削減
+
+### 3. スケーラビリティ
+- 複雑なプロジェクトへの対応
+- チーム固有のワークフローサポート
+- カスタムモードによる拡張性
+
+### 4. デバッグとメンテナンス
+- 各サブタスクの明確な責任範囲
+- 問題の特定が容易
+- 段階的な改善が可能
+
+## オーケストレーション機能の詳細フロー（シーケンス図）
+
+### 基本的なオーケストレーションフロー
+
+```mermaid
+sequenceDiagram
+    participant User as ユーザー
+    participant System as RooCline System
+    participant Orchestrator as Orchestrator Mode
+    participant Architect as Architect Mode
+    participant Code as Code Mode
+    participant Debug as Debug Mode
+    participant Context as Context Manager
+
+    User->>System: 複雑なタスクを依頼
+    Note over User,System: "ユーザー認証システムを実装してください"
+
+    System->>Orchestrator: タスクを転送
+    activate Orchestrator
+
+    Orchestrator->>Orchestrator: タスク複雑度を分析
+    Note over Orchestrator: 複雑度: 高<br/>サブタスク数: 5
+
+    Orchestrator->>Context: 初期コンテキストを準備
+    Context-->>Orchestrator: グローバルコンテキスト
+
+    %% サブタスク1: アーキテクチャ設計
+    Orchestrator->>Architect: new_task: アーキテクチャ設計
+    activate Architect
+    Orchestrator->>Context: Architectモード用コンテキスト生成
+    Context-->>Architect: 最適化されたコンテキスト
+    Note over Context,Architect: design_decision: 1.5<br/>technical_detail: 1.3
+
+    Architect->>Architect: 設計作業実行
+    Architect-->>Orchestrator: 設計結果を返却
+    deactivate Architect
+
+    %% サブタスク2-4: 実装
+    Orchestrator->>Code: new_task: DBスキーマ実装
+    activate Code
+    Orchestrator->>Context: 前のタスク結果を含むコンテキスト生成
+    Context-->>Code: 最適化されたコンテキスト
+    Note over Context,Code: file_change: 1.5<br/>前の設計結果を含む
+
+    Code->>Code: 実装作業実行
+    Code-->>Orchestrator: 実装結果を返却
+    deactivate Code
+
+    Note over Orchestrator: 同様にAPI実装、UI実装も処理
+
+    %% サブタスク5: デバッグ
+    Orchestrator->>Debug: new_task: 統合テストとバグ修正
+    activate Debug
+    Orchestrator->>Context: 全実装結果を含むコンテキスト生成
+    Context-->>Debug: 最適化されたコンテキスト
+    Note over Context,Debug: error_info: 1.5<br/>test_results: 1.2
+
+    Debug->>Debug: テスト実行とバグ修正
+    Debug-->>Orchestrator: デバッグ結果を返却
+    deactivate Debug
+
+    Orchestrator->>Orchestrator: 全サブタスク結果を統合
+    Orchestrator-->>System: 統合結果を返却
+    deactivate Orchestrator
+
+    System-->>User: タスク完了報告
+```
+
+### ブーメランタスク機能のフロー
+
+```mermaid
+sequenceDiagram
+    participant Code as Code Mode
+    participant Orchestrator as Orchestrator
+    participant Architect as Architect Mode
+    participant Ask as Ask Mode
+    participant Context as Context Manager
+
+    Note over Code: 実装中に設計判断が必要
+
+    Code->>Code: taskRequiresArchitecturalDecision()
+    Note over Code: true
+
+    Code->>Orchestrator: ブーメランタスク要求
+    Note over Code,Orchestrator: "DBインデックス戦略の決定が必要"
+
+    activate Orchestrator
+    Orchestrator->>Context: ブーメラン用コンテキスト生成
+    Context-->>Orchestrator: 現在の実装状況を含むコンテキスト
+
+    Orchestrator->>Architect: new_task: 設計判断要求
+    activate Architect
+
+    Architect->>Architect: 設計判断を実行
+
+    alt 追加情報が必要な場合
+        Architect->>Orchestrator: ブーメランタスク要求
+        Note over Architect,Orchestrator: "パフォーマンス要件の確認が必要"
+
+        Orchestrator->>Ask: new_task: ユーザーへの質問
+        activate Ask
+        Ask->>Ask: ユーザーとの対話準備
+        Ask-->>Orchestrator: 質問結果
+        deactivate Ask
+
+        Orchestrator-->>Architect: 追加情報を提供
+    end
+
+    Architect-->>Orchestrator: 設計判断結果
+    deactivate Architect
+
+    Orchestrator-->>Code: ブーメラン結果を返却
+    deactivate Orchestrator
+
+    Code->>Code: continueImplementation()
+    Note over Code: 設計判断に基づいて実装を継続
+```
+
+### コンテキスト最適化の詳細フロー
+
+```mermaid
+sequenceDiagram
+    participant Orchestrator as Orchestrator
+    participant Context as Context Manager
+    participant Priority as Priority Calculator
+    participant Optimizer as Token Optimizer
+    participant Mode as Target Mode
+
+    Orchestrator->>Context: createContextForSubTask()
+    activate Context
+
+    Context->>Context: 前のタスク結果を取得
+    Note over Context: previousResults[]
+
+    Context->>Priority: モード別優先度を取得
+    activate Priority
+    Priority-->>Context: MODE_PRIORITIES[mode]
+    Note over Priority,Context: architect: {design_decision: 1.5, ...}
+    deactivate Priority
+
+    Context->>Context: extractRelevantInfo()
+    Note over Context: モードに関連する情報のみ抽出
+
+    Context->>Context: gatherModeSpecificInfo()
+    Note over Context: 優先度順に情報を収集
+
+    Context->>Optimizer: optimizeContext()
+    activate Optimizer
+    Note over Optimizer: トークン制限: 8000
+
+    Optimizer->>Optimizer: 優先度スコアを計算
+    Optimizer->>Optimizer: 低優先度情報を削除
+    Optimizer->>Optimizer: 重複情報を統合
+
+    Optimizer-->>Context: 最適化されたコンテキスト
+    deactivate Optimizer
+
+    Context-->>Orchestrator: 最終コンテキスト
+    deactivate Context
+
+    Orchestrator->>Mode: 最適化されたコンテキストでタスク実行
+```
+
+### カスタムモードの読み込みと実行フロー
+
+```mermaid
+sequenceDiagram
+    participant System as RooCline System
+    participant Loader as Custom Mode Loader
+    participant Validator as Mode Validator
+    participant Registry as Mode Registry
+    participant Orchestrator as Orchestrator
+    participant Custom as Custom Mode
+
+    System->>Loader: loadCustomModes()
+    activate Loader
+
+    Loader->>Loader: .actionmodesファイルを読み込み
+    Note over Loader: プロジェクトルートから検索
+
+    loop 各カスタムモード定義
+        Loader->>Validator: validateModeDefinition()
+        activate Validator
+
+        Validator->>Validator: スキーマ検証
+        Validator->>Validator: 必須フィールド確認
+        Validator->>Validator: ツールグループ検証
+
+        alt 検証成功
+            Validator-->>Loader: OK
+            Loader->>Registry: registerMode(customMode)
+            Registry-->>Loader: 登録完了
+        else 検証失敗
+            Validator-->>Loader: エラー詳細
+            Note over Loader: エラーログ出力、スキップ
+        end
+        deactivate Validator
+    end
+
+    Loader-->>System: カスタムモード読み込み完了
+    deactivate Loader
+
+    Note over System: ユーザータスク受信時
+
+    System->>Orchestrator: タスク処理開始
+    Orchestrator->>Registry: getAvailableModes()
+    Registry-->>Orchestrator: 組み込み + カスタムモード
+
+    Orchestrator->>Custom: new_task: カスタムモードでの実行
+    activate Custom
+    Custom->>Custom: カスタム指示に従って実行
+    Custom-->>Orchestrator: 実行結果
+    deactivate Custom
+```
+
+## RooCline（Roo Code）の実際のアーキテクチャ
+
+### クラス構成の概要
+
+RooClineの実際の実装は、以下の主要コンポーネントで構成されています：
+
+```mermaid
+classDiagram
+    %% Core Provider
+    class ClineProvider {
+        -taskStack: Task[]
+        -customModesManager: CustomModesManager
+        -providerSettingsManager: ProviderSettingsManager
+        -contextProxy: ContextProxy
+        +initClineWithTask(prompt: string): Task
+        +getCurrentCline(): Task
+        +handleModeSwitch(mode: string): void
+        +postMessageToWebview(message: ExtensionMessage): void
+        +setWebviewMessageListener(webview: Webview): void
+    }
+
+    %% Task Management
+    class Task {
+        -taskId: string
+        -instanceId: string
+        -apiConversationHistory: Message[]
+        -clineMessages: ClineMessage[]
+        -parentTask?: Task
+        -childTasks: Task[]
+        +getSystemPrompt(): string
+        +trackTokenUsage(): void
+        +addToHistory(message: Message): void
+    }
+
+    %% Mode System
+    class Mode {
+        <<interface>>
+        +slug: string
+        +name: string
+        +roleDefinition: string
+        +customInstructions?: string
+        +groups: string[]
+    }
+
+    class CustomModesManager {
+        -customModes: Map<string, Mode>
+        +loadCustomModes(): void
+        +getCustomMode(slug: string): Mode
+    }
+
+    class ProviderSettingsManager {
+        -settings: Map<string, ProviderSettings>
+        +getSettingsForMode(mode: string): ProviderSettings
+        +updateSettings(mode: string, settings: ProviderSettings): void
+    }
+
+    %% Context Management
+    class ContextProxy {
+        -globalState: vscode.ExtensionContext
+        +get(key: string): any
+        +update(key: string, value: any): void
+    }
+
+    class SlidingWindow {
+        <<module>>
+        +condenseMessages(messages: Message[]): Message[]
+        +calculateTokenCount(messages: Message[]): number
+    }
+
+    %% API Integration
+    class RooCodeAPI {
+        +startNewTask(mode: string, message: string): Promise<void>
+        +resumeTask(taskId: string): Promise<void>
+        +cancelCurrentTask(): Promise<void>
+        +sendMessage(message: string): Promise<void>
+    }
+
+    %% System Prompt
+    class SystemPromptGenerator {
+        <<function>>
+        +SYSTEM_PROMPT(options: SystemPromptOptions): string
+    }
+
+    %% Webview Communication
+    class WebviewMessageHandler {
+        <<function>>
+        +handle(message: WebviewMessage): Promise<void>
+    }
+
+    %% Relationships
+    ClineProvider --> Task : manages stack
+    ClineProvider --> CustomModesManager : uses
+    ClineProvider --> ProviderSettingsManager : uses
+    ClineProvider --> ContextProxy : uses
+    ClineProvider --> WebviewMessageHandler : delegates to
+
+    Task --> SystemPromptGenerator : uses
+    Task --> SlidingWindow : uses for context
+
+    CustomModesManager --> Mode : manages
+
+    RooCodeAPI --> ClineProvider : interacts with
+    RooCodeAPI --> Task : creates/manages
+
+    WebviewMessageHandler --> ClineProvider : updates
+    WebviewMessageHandler --> Task : controls
+```
+
+### claude-code-actionとの比較
+
+#### 共通点
+1. **モードシステム**: 両者ともモードの概念を採用
+2. **タスク管理**: タスクの作成と実行管理
+3. **コンテキスト最適化**: トークン使用量の最適化
+
+#### RooClineの特徴（claude-code-actionでは省略された部分）
+1. **VSCode統合**
+   - `ClineProvider`によるWebviewProviderの実装
+   - VSCode拡張機能としての深い統合
+   - Webview UIとの双方向通信
+
+2. **階層的タスク管理**
+   - タスクスタックによる親子関係の管理
+   - ネストされたタスクの実行サポート
+
+3. **プロバイダー設定管理**
+   - モードごとのAPI設定の永続化
+   - 動的なプロバイダー切り替え
+
+4. **リアルタイムUI連携**
+   - WebviewMessageHandlerによる即時応答
+   - 進捗状況の視覚的フィードバック
+
+#### claude-code-actionでの簡略化
+1. **GitHub Actions特化**
+   - VSCode依存の削除
+   - GitHub APIとの直接統合
+   - コメントベースのUI
+
+2. **シンプルなタスク管理**
+   - フラットなタスク構造
+   - GitHub Actionsのワークフローに最適化
+
+3. **MCPツール中心**
+   - new_task、switch_modeなどのMCPツール
+   - GitHub Actions環境での動作に特化
+
+### アーキテクチャの違い
+
+RooClineは**VSCode拡張機能**として設計されており、リッチなUIとリアルタイムの対話を提供します。一方、claude-code-actionは**GitHub Actions環境**で動作することを前提とし、よりシンプルで自動化に適した設計となっています。
+
+この違いにより、claude-code-actionでは：
+- Webview関連のコンポーネントを削除
+- GitHub APIとの統合を強化
+- MCPツールによるオーケストレーションを採用
+- コメントベースのシンプルなUI
+
+これらの変更により、GitHub Actions環境でも効果的なオーケストレーション機能を実現できるよう設計されています。
+
+## まとめ
+
+RooClineのオーケストレーション機能は、単なるタスク分割以上の価値を提供します。それは、AIが人間のように「適材適所」で問題を解決する能力を実現し、より効率的で正確な開発支援を可能にします。この機能により、「数撃ちゃ当たる」アプローチから「狙って確実に成功する」アプローチへの転換が実現されています。
+
+上記のシーケンス図により、オーケストレーション機能の動作フローがより明確に理解できるようになりました。特に重要なのは：
+
+1. **タスクの階層的な分解と委譲**: Orchestratorが中心となってサブタスクを適切なモードに振り分ける
+2. **コンテキストの動的最適化**: 各モードに必要な情報のみを優先度に基づいて提供
+3. **ブーメランタスクによる柔軟な協調**: モード間で必要に応じて動的にタスクを委譲
+
+claude-code-actionへの実装では、RooClineの核心的な価値を維持しながら、GitHub Actions環境に最適化された形でこれらの機能を提供することを目指しています。

--- a/scripts/update-fork-references.ts
+++ b/scripts/update-fork-references.ts
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+const OLD_REFERENCE = "anthropics/claude-code-action@beta";
+const NEW_REFERENCE = "MasashiFukuzawa/claude-code-action@orchestrator-alpha";
+
+function updateFile(filePath: string): boolean {
+  const content = readFileSync(filePath, "utf-8");
+  if (content.includes(OLD_REFERENCE)) {
+    const updatedContent = content.replace(
+      new RegExp(OLD_REFERENCE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+      NEW_REFERENCE,
+    );
+    writeFileSync(filePath, updatedContent);
+    console.log(`✅ Updated: ${filePath}`);
+    return true;
+  }
+  return false;
+}
+
+async function main() {
+  // Get example files
+  const exampleFiles = readdirSync("examples")
+    .filter((file) => file.endsWith(".yml"))
+    .map((file) => join("examples", file));
+
+  const files = ["README.md", ...exampleFiles];
+
+  let updatedCount = 0;
+  for (const file of files) {
+    if (updateFile(file)) {
+      updatedCount++;
+    }
+  }
+
+  console.log(`\n✨ Updated ${updatedCount} files`);
+}
+
+main().catch(console.error);

--- a/test/fork-update.test.ts
+++ b/test/fork-update.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Fork Update Validation", () => {
+  const rootDir = join(__dirname, "..");
+
+  test("README.md should reference forked action", () => {
+    const readme = readFileSync(join(rootDir, "README.md"), "utf-8");
+    expect(readme).not.toContain("anthropics/claude-code-action@beta");
+    expect(readme).toContain(
+      "MasashiFukuzawa/claude-code-action@orchestrator-alpha",
+    );
+  });
+
+  test("all example files should reference forked action", () => {
+    const exampleFiles = [
+      "claude.yml",
+      "claude-auto-review.yml",
+      "claude-pr-path-specific.yml",
+      "claude-review-from-author.yml",
+    ];
+
+    exampleFiles.forEach((file) => {
+      const content = readFileSync(join(rootDir, "examples", file), "utf-8");
+      expect(content).not.toContain("anthropics/claude-code-action@beta");
+      expect(content).toContain(
+        "MasashiFukuzawa/claude-code-action@orchestrator-alpha",
+      );
+    });
+  });
+
+  test("should maintain YAML structure integrity", () => {
+    const exampleFiles = [
+      "claude.yml",
+      "claude-auto-review.yml",
+      "claude-pr-path-specific.yml",
+      "claude-review-from-author.yml",
+    ];
+
+    exampleFiles.forEach((file) => {
+      const content = readFileSync(join(rootDir, "examples", file), "utf-8");
+      // YAMLの基本構造が保たれていることを確認
+      expect(content).toMatch(/^name:/m);
+      expect(content).toMatch(/^\s+uses:/m);
+      expect(content).toMatch(/^\s+with:/m);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Update action references from `anthropics/claude-code-action@beta` to `MasashiFukuzawa/claude-code-action@orchestrator-alpha`
- Add tests for fork reference validation
- Add update script for automated reference replacement

## Changes
- Modified README.md and all example workflow files to use the forked action reference
- Added test/fork-update.test.ts to ensure all references are updated correctly
- Added scripts/update-fork-references.ts for automated reference updates
- Formatted predev-docs markdown files

## Test plan
- [x] Run `bun test` - All tests pass
- [x] Run `bun run format:check` - All formatting checks pass
- [x] Run `bun run typecheck` - Type checking passes
- [x] Verify all action references have been updated by running:
  ```bash
  grep -r "anthropics/claude-code-action" .
  ```

🤖 Generated with [Claude Code](https://claude.ai/code)