### PR TITLE
feat: add orchestrator type definitions

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -1,0 +1,31 @@
+export type SubtaskMode =
+  | "architect"
+  | "code"
+  | "debug"
+  | "ask"
+  | "orchestrator";
+
+export type Subtask = {
+  id: string;
+  description: string;
+  mode: SubtaskMode;
+  dependencies?: string[];
+};
+
+export type ComplexityIndicators = {
+  multipleActions: boolean;
+  hasDesignKeywords: boolean;
+  hasImplementKeywords: boolean;
+  hasTestKeywords: boolean;
+  hasConditionals: boolean;
+  hasSequentialMarkers: boolean;
+  taskLength: boolean;
+};
+
+export type ComplexityAnalysis = {
+  isComplex: boolean;
+  confidence: number;
+  reason: string;
+  suggestedSubtasks: Subtask[];
+  error?: string;
+};


### PR DESCRIPTION
## Summary
- add `src/orchestrator/` directory
- define basic orchestrator types
- re-export orchestrator types from `index.ts`

## Testing
- `bun run format`
- `bun tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683f73429df8832ba6ccfa8e67e5af32