### PR TITLE
feat: add TaskAnalyzer skeleton

### DIFF
--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -1,0 +1,26 @@
+export type SuggestedSubtask = {
+  mode: string;
+  description: string;
+};
+
+export type ComplexityAnalysis = {
+  isComplex: boolean;
+  confidence: number;
+  reason: string;
+  suggestedSubtasks: SuggestedSubtask[];
+};
+
+export class TaskAnalyzer {
+  constructor() {
+    // TODO: initialize patterns and configuration
+  }
+
+  analyze(_task: string): ComplexityAnalysis {
+    return {
+      isComplex: false,
+      confidence: 0,
+      reason: "Analyzer not implemented",
+      suggestedSubtasks: [],
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold `TaskAnalyzer` class under `src/orchestrator`
- add stub `analyze()` method returning a fixed result

## Testing
- `bun run typecheck`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683f734630bc832bae53b8310eb23e36