### PR TITLE
Add TaskAnalyzer stub with test

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./task-analyzer";

--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -1,0 +1,12 @@
+import type { ComplexityAnalysis } from "./types";
+
+export class TaskAnalyzer {
+  analyze(_task: string): ComplexityAnalysis {
+    return {
+      isComplex: false,
+      confidence: 0,
+      reason: "stub",
+      suggestedSubtasks: [],
+    };
+  }
+}

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -1,0 +1,12 @@
+export interface SuggestedSubtask {
+  mode: "architect" | "code" | "debug" | "ask" | "orchestrator";
+  description: string;
+}
+
+export interface ComplexityAnalysis {
+  isComplex: boolean;
+  confidence: number;
+  reason: string;
+  suggestedSubtasks: SuggestedSubtask[];
+  error?: string;
+}

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+
+import { describe, test, expect } from "bun:test";
+import { TaskAnalyzer } from "../src/orchestrator";
+
+describe("TaskAnalyzer", () => {
+  test("analyze returns stubbed result", () => {
+    const analyzer = new TaskAnalyzer();
+    const result = analyzer.analyze("do something");
+    expect(result).toEqual({
+      isComplex: false,
+      confidence: 0,
+      reason: "stub",
+      suggestedSubtasks: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add orchestrator module with TaskAnalyzer stub
- export orchestrator types and class
- test the default `analyze` result

## Testing
- `bun test test/task-analyzer.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683f734855ec832b8ac43c7d4f6df0b0