### PR TITLE
Add TaskAnalyzer unit test

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export { TaskAnalyzer } from "./task-analyzer";

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { TaskAnalyzer } from "../src/orchestrator";
+
+describe("TaskAnalyzer.analyze", () => {
+  it("returns the placeholder analysis result", () => {
+    const analyzer = new TaskAnalyzer();
+    const result = analyzer.analyze("Do something");
+    expect(result).toEqual({
+      isComplex: false,
+      confidence: 0,
+      reason: "Analyzer not implemented",
+      suggestedSubtasks: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add TaskAnalyzer placeholder test
- export TaskAnalyzer from orchestrator index for easier imports

## Testing
- `bun test test/task-analyzer.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_683f76e3eb30832b9dc3f625f193e61c