### PR TITLE
Add Japanese language detection to TaskAnalyzer

### DIFF
--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -8,6 +8,7 @@ export type ComplexityAnalysis = {
   confidence: number;
   reason: string;
   suggestedSubtasks: SuggestedSubtask[];
+  isJapanese: boolean;
 };
 
 export class TaskAnalyzer {
@@ -15,12 +16,20 @@ export class TaskAnalyzer {
     // TODO: initialize patterns and configuration
   }
 
-  analyze(_task: string): ComplexityAnalysis {
+  private detectJapanese(task: string): boolean {
+    const japaneseRegex = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9faf]/;
+    return japaneseRegex.test(task);
+  }
+
+  analyze(task: string): ComplexityAnalysis {
+    const isJapanese = this.detectJapanese(task);
+
     return {
       isComplex: false,
       confidence: 0,
       reason: "Analyzer not implemented",
       suggestedSubtasks: [],
+      isJapanese,
     };
   }
 }

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -10,6 +10,13 @@ describe("TaskAnalyzer.analyze", () => {
       confidence: 0,
       reason: "Analyzer not implemented",
       suggestedSubtasks: [],
+      isJapanese: false,
     });
+  });
+
+  it("detects Japanese text", () => {
+    const analyzer = new TaskAnalyzer();
+    const result = analyzer.analyze("日本語のタスクを実行してください");
+    expect(result.isJapanese).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- implement `detectJapanese` helper in TaskAnalyzer
- return language detection result from `analyze`
- update tests to assert detection of Japanese tasks

## Testing
- `bun test test/task-analyzer.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683f80dbe94c832b826ad5432490b6d6