### PR TITLE
feat: add keyword patterns to TaskAnalyzer

### DIFF
--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -11,11 +11,18 @@ export type ComplexityAnalysis = {
 };
 
 export class TaskAnalyzer {
+  private japanesePatterns: RegExp[];
+  private englishPatterns: RegExp[];
+
   constructor() {
-    // TODO: initialize patterns and configuration
+    this.japanesePatterns = [/実装/, /テスト/, /設計/];
+    this.englishPatterns = [/implement/i, /test/i, /design/i];
   }
 
   analyze(_task: string): ComplexityAnalysis {
+    // Reference patterns to avoid unused property errors
+    void this.japanesePatterns;
+    void this.englishPatterns;
     return {
       isComplex: false,
       confidence: 0,

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -13,3 +13,21 @@ describe("TaskAnalyzer.analyze", () => {
     });
   });
 });
+
+describe("TaskAnalyzer patterns", () => {
+  it("matches Japanese keywords", () => {
+    const analyzer = new TaskAnalyzer() as any;
+    const patterns: RegExp[] = analyzer["japanesePatterns"];
+    expect(patterns.some((p) => p.test("この機能を実装する"))).toBe(true);
+    expect(patterns.some((p) => p.test("テストを追加"))).toBe(true);
+    expect(patterns.some((p) => p.test("設計を検討"))).toBe(true);
+  });
+
+  it("matches English keywords", () => {
+    const analyzer = new TaskAnalyzer() as any;
+    const patterns: RegExp[] = analyzer["englishPatterns"];
+    expect(patterns.some((p) => p.test("implement the feature"))).toBe(true);
+    expect(patterns.some((p) => p.test("write a test"))).toBe(true);
+    expect(patterns.some((p) => p.test("design the system"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- define Japanese and English keyword regexes in TaskAnalyzer
- test pattern matching for both languages

## Testing
- `bun run format`
- `bun run typecheck`
- `bun test`
- `bun test test/task-analyzer.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_683f8107b348832bad338dea967696a4