### PR TITLE
feat(orchestrator): add Japanese detection functionality

### DIFF
--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -32,4 +32,13 @@ export class TaskAnalyzer {
     // Empty implementation - will be implemented incrementally
     return false;
   }
+
+  /**
+   * Public wrapper for testing detectJapanese (temporary)
+   * @param text - Text to analyze
+   * @returns True if Japanese characters are detected
+   */
+  public testDetectJapanese(text: string): boolean {
+    return this.detectJapanese(text);
+  }
 }

--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -28,9 +28,13 @@ export class TaskAnalyzer {
    * @param text - Text to analyze
    * @returns True if Japanese characters are detected
    */
-  private detectJapanese(_text: string): boolean {
-    // Empty implementation - will be implemented incrementally
-    return false;
+  private detectJapanese(text: string): boolean {
+    // Regular expression to match Japanese characters
+    // \u3040-\u309F: Hiragana
+    // \u30A0-\u30FF: Katakana
+    // \u4E00-\u9FAF: Kanji
+    const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/;
+    return japanesePattern.test(text);
   }
 
   /**

--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -22,4 +22,14 @@ export class TaskAnalyzer {
       suggestedSubtasks: [],
     };
   }
+
+  /**
+   * Detect if the given text contains Japanese characters
+   * @param text - Text to analyze
+   * @returns True if Japanese characters are detected
+   */
+  private detectJapanese(_text: string): boolean {
+    // Empty implementation - will be implemented incrementally
+    return false;
+  }
 }

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -18,4 +18,25 @@ describe("TaskAnalyzer", () => {
       suggestedSubtasks: [],
     });
   });
+
+  describe("Japanese detection", () => {
+    test("should detect Japanese characters", () => {
+      const analyzer = new TaskAnalyzer();
+      
+      // These should return true when implemented
+      expect(analyzer.testDetectJapanese("こんにちは")).toBe(true);
+      expect(analyzer.testDetectJapanese("テスト")).toBe(true);
+      expect(analyzer.testDetectJapanese("実装してください")).toBe(true);
+      expect(analyzer.testDetectJapanese("Hello 世界")).toBe(true);
+    });
+
+    test("should not detect Japanese in English text", () => {
+      const analyzer = new TaskAnalyzer();
+      
+      // These should return false
+      expect(analyzer.testDetectJapanese("Hello world")).toBe(false);
+      expect(analyzer.testDetectJapanese("implement feature")).toBe(false);
+      expect(analyzer.testDetectJapanese("123 test")).toBe(false);
+    });
+  });
 });

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -22,7 +22,7 @@ describe("TaskAnalyzer", () => {
   describe("Japanese detection", () => {
     test("should detect Japanese characters", () => {
       const analyzer = new TaskAnalyzer();
-      
+
       // These should return true when implemented
       expect(analyzer.testDetectJapanese("こんにちは")).toBe(true);
       expect(analyzer.testDetectJapanese("テスト")).toBe(true);
@@ -32,7 +32,7 @@ describe("TaskAnalyzer", () => {
 
     test("should not detect Japanese in English text", () => {
       const analyzer = new TaskAnalyzer();
-      
+
       // These should return false
       expect(analyzer.testDetectJapanese("Hello world")).toBe(false);
       expect(analyzer.testDetectJapanese("implement feature")).toBe(false);


### PR DESCRIPTION
## Summary
- Add detectJapanese private method to TaskAnalyzer
- Implement regex-based Japanese character detection (Hiragana, Katakana, Kanji)
- Add comprehensive test coverage for Japanese and English text

## Implementation Details
- Phase 1-4 of orchestrator implementation
- Follows TDD Red → Green cycle
- Detects Japanese characters using Unicode ranges: \\u3040-\\u309F (Hiragana), \\u30A0-\\u30FF (Katakana), \\u4E00-\\u9FAF (Kanji)
- Includes temporary public wrapper for testing private method
- All tests pass (4 total tests including new Japanese detection tests)

🤖 Generated with [Claude Code](https://claude.ai/code)