### PR TITLE
feat(orchestrator): add English pattern definitions

### DIFF
--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -1,10 +1,11 @@
-import type { ComplexityAnalysis, JapanesePatterns } from "./types";
+import type { ComplexityAnalysis, JapanesePatterns, EnglishPatterns } from "./types";
 
 /**
  * TaskAnalyzer class for analyzing task complexity
  */
 export class TaskAnalyzer {
   private _japanesePatterns: JapanesePatterns;
+  private _englishPatterns: EnglishPatterns;
 
   constructor() {
     // Initialize TaskAnalyzer
@@ -48,6 +49,49 @@ export class TaskAnalyzer {
         "コンポーネント",
         "機能",
         "追加",
+      ],
+    };
+
+    this._englishPatterns = {
+      multipleActions: [
+        "and.*and",
+        "also",
+        "additionally",
+        "furthermore",
+        "moreover",
+        "as well as",
+        "along with",
+        ".*and.*",
+      ],
+      conditionals: [
+        "if",
+        "when",
+        "unless",
+        "provided",
+        "assuming",
+        "in case",
+        "should",
+        "depending",
+      ],
+      designKeywords: [
+        "design",
+        "architecture",
+        "structure",
+        "pattern",
+        "framework",
+        "library",
+        "approach",
+        "strategy",
+      ],
+      implementKeywords: [
+        "implement",
+        "code",
+        "function",
+        "method",
+        "class",
+        "component",
+        "feature",
+        "add",
       ],
     };
   }
@@ -96,5 +140,13 @@ export class TaskAnalyzer {
    */
   public getJapanesePatterns(): JapanesePatterns {
     return this._japanesePatterns;
+  }
+
+  /**
+   * Get English patterns (temporary for testing)
+   * @returns English patterns object
+   */
+  public getEnglishPatterns(): EnglishPatterns {
+    return this._englishPatterns;
   }
 }

--- a/src/orchestrator/types.ts
+++ b/src/orchestrator/types.ts
@@ -58,3 +58,20 @@ export interface JapanesePatterns {
   /** Keywords for implementation tasks */
   implementKeywords?: string[];
 }
+
+/**
+ * English patterns for complexity analysis
+ */
+export interface EnglishPatterns {
+  /** Patterns indicating multiple actions */
+  multipleActions?: string[];
+
+  /** Patterns indicating conditional logic */
+  conditionals?: string[];
+
+  /** Keywords for design and architecture tasks */
+  designKeywords?: string[];
+
+  /** Keywords for implementation tasks */
+  implementKeywords?: string[];
+}


### PR DESCRIPTION
## Summary
- Add EnglishPatterns interface for complexity analysis
- Add englishPatterns property to TaskAnalyzer class
- Implement English patterns for multiple actions, conditionals, design keywords, and implementation keywords
- Add getter method for testing English patterns

## Test plan
- Type checking passes
- All existing tests continue to pass
- English patterns are properly initialized in TaskAnalyzer

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>