### PR TITLE
feat(orchestrator): implement subtask generation functionality

### DIFF
--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -126,7 +126,11 @@ export class TaskAnalyzer {
       reasons.push("シンプルなタスクです");
     }
 
-    const suggestedSubtasks = this.generateSubtasks(task, indicators, isComplex);
+    const suggestedSubtasks = this.generateSubtasks(
+      task,
+      indicators,
+      isComplex,
+    );
 
     return {
       isComplex,
@@ -175,7 +179,10 @@ export class TaskAnalyzer {
     }
 
     // Add test subtask if testing is mentioned or if it's a complex implementation
-    if (indicators.hasTestKeywords || (indicators.hasImplementKeywords && isComplex)) {
+    if (
+      indicators.hasTestKeywords ||
+      (indicators.hasImplementKeywords && isComplex)
+    ) {
       subtasks.push({
         mode: "code",
         description: isJapanese ? "テストの作成" : "Test creation",

--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -144,8 +144,8 @@ export class TaskAnalyzer {
    * @returns Array of suggested subtasks
    */
   private generateSubtasks(
-    _task: string,
-    _indicators: ComplexityIndicators,
+    task: string,
+    indicators: ComplexityIndicators,
     isComplex: boolean,
   ): SubTask[] {
     // For simple tasks, return empty array
@@ -153,9 +153,35 @@ export class TaskAnalyzer {
       return [];
     }
 
+    const isJapanese = this.detectJapanese(task);
     const subtasks: SubTask[] = [];
 
-    // TODO: Implement subtask generation logic
+    // Add design/architecture subtask if needed
+    if (indicators.hasDesignKeywords) {
+      subtasks.push({
+        mode: "architect",
+        description: isJapanese
+          ? "設計とアーキテクチャの決定"
+          : "Design and architecture decisions",
+      });
+    }
+
+    // Add implementation subtask if needed
+    if (indicators.hasImplementKeywords) {
+      subtasks.push({
+        mode: "code",
+        description: isJapanese ? "実装" : "Implementation",
+      });
+    }
+
+    // Add test subtask if testing is mentioned or if it's a complex implementation
+    if (indicators.hasTestKeywords || (indicators.hasImplementKeywords && isComplex)) {
+      subtasks.push({
+        mode: "code",
+        description: isJapanese ? "テストの作成" : "Test creation",
+      });
+    }
+
     return subtasks;
   }
 

--- a/src/orchestrator/task-analyzer.ts
+++ b/src/orchestrator/task-analyzer.ts
@@ -3,6 +3,7 @@ import type {
   JapanesePatterns,
   EnglishPatterns,
   ComplexityIndicators,
+  SubTask,
 } from "./types";
 
 /**
@@ -125,12 +126,37 @@ export class TaskAnalyzer {
       reasons.push("シンプルなタスクです");
     }
 
+    const suggestedSubtasks = this.generateSubtasks(task, indicators, isComplex);
+
     return {
       isComplex,
       confidence: Math.max(Math.min(score * 1.5, 1.0), 0.1),
       reason: reasons.join("、"),
-      suggestedSubtasks: [],
+      suggestedSubtasks,
     };
+  }
+
+  /**
+   * Generate subtasks for complex tasks
+   * @param task - Original task description
+   * @param indicators - Complexity indicators
+   * @param isComplex - Whether the task is complex
+   * @returns Array of suggested subtasks
+   */
+  private generateSubtasks(
+    _task: string,
+    _indicators: ComplexityIndicators,
+    isComplex: boolean,
+  ): SubTask[] {
+    // For simple tasks, return empty array
+    if (!isComplex) {
+      return [];
+    }
+
+    const subtasks: SubTask[] = [];
+
+    // TODO: Implement subtask generation logic
+    return subtasks;
   }
 
   /**

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -116,7 +116,20 @@ describe("TaskAnalyzer", () => {
       expect(result.isComplex).toBe(true);
       expect(result.confidence).toBeGreaterThan(0.5);
       expect(result.reason).toContain("複数の操作");
-      expect(result.suggestedSubtasks).toEqual([]);
+      expect(result.suggestedSubtasks).toEqual([
+        {
+          mode: "architect",
+          description: "設計とアーキテクチャの決定",
+        },
+        {
+          mode: "code",
+          description: "実装",
+        },
+        {
+          mode: "code",
+          description: "テストの作成",
+        },
+      ]);
     });
 
     test("should return proper analysis for simple task", () => {

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -149,9 +149,9 @@ describe("TaskAnalyzer", () => {
 
       expect(result.isComplex).toBe(true);
       expect(result.suggestedSubtasks).toHaveLength(3);
-      expect(result.suggestedSubtasks[0].mode).toBe("architect");
-      expect(result.suggestedSubtasks[1].mode).toBe("code");
-      expect(result.suggestedSubtasks[2].mode).toBe("code");
+      expect(result.suggestedSubtasks[0]?.mode).toBe("architect");
+      expect(result.suggestedSubtasks[1]?.mode).toBe("code");
+      expect(result.suggestedSubtasks[2]?.mode).toBe("code");
     });
 
     test("should generate English subtasks for English input", () => {

--- a/test/task-analyzer.test.ts
+++ b/test/task-analyzer.test.ts
@@ -141,4 +141,44 @@ describe("TaskAnalyzer", () => {
       expect(result.reason).toContain("シンプル");
     });
   });
+
+  describe("Subtask generation", () => {
+    test("should generate subtasks for design and implementation", () => {
+      const analyzer = new TaskAnalyzer();
+      const result = analyzer.analyze("設計してから実装してください");
+
+      expect(result.isComplex).toBe(true);
+      expect(result.suggestedSubtasks).toHaveLength(3);
+      expect(result.suggestedSubtasks[0].mode).toBe("architect");
+      expect(result.suggestedSubtasks[1].mode).toBe("code");
+      expect(result.suggestedSubtasks[2].mode).toBe("code");
+    });
+
+    test("should generate English subtasks for English input", () => {
+      const analyzer = new TaskAnalyzer();
+      const result = analyzer.analyze("design and implement the feature");
+
+      expect(result.isComplex).toBe(true);
+      expect(result.suggestedSubtasks).toContainEqual({
+        mode: "architect",
+        description: "Design and architecture decisions",
+      });
+      expect(result.suggestedSubtasks).toContainEqual({
+        mode: "code",
+        description: "Implementation",
+      });
+      expect(result.suggestedSubtasks).toContainEqual({
+        mode: "code",
+        description: "Test creation",
+      });
+    });
+
+    test("should return empty subtasks for simple tasks", () => {
+      const analyzer = new TaskAnalyzer();
+      const result = analyzer.analyze("fix typo");
+
+      expect(result.isComplex).toBe(false);
+      expect(result.suggestedSubtasks).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
# Phase 1-9: Subtask generation functionality

## Summary
- Add `generateSubtasks` method to TaskAnalyzer class
- Implement conditional subtask generation based on complexity indicators
- Support both Japanese and English subtask descriptions
- Add comprehensive test coverage for subtask generation

## Implementation Details

### ✅ Subtask Generation Logic
- **Design subtasks**: Generated when `hasDesignKeywords` is true
- **Implementation subtasks**: Generated when `hasImplementKeywords` is true  
- **Test subtasks**: Generated when `hasTestKeywords` is true OR for complex implementation tasks

### ✅ Language Support
- **Japanese tasks**: Generate Japanese subtask descriptions
- **English tasks**: Generate English subtask descriptions
- Automatic language detection using existing `detectJapanese` method

### ✅ Test Coverage
- Test subtask generation for complex Japanese tasks
- Test subtask generation for complex English tasks
- Test empty subtasks for simple tasks
- Test specific mode assignments (architect, code)

## Files Changed
- `src/orchestrator/task-analyzer.ts`: Added `generateSubtasks` method
- `test/task-analyzer.test.ts`: Added comprehensive subtask generation tests

## Testing
All tests pass ✅
- 13 TaskAnalyzer tests including 3 new subtask generation tests
- 211 total tests across the project

🤖 Generated with [Claude Code](https://claude.ai/code)