### PR TITLE
feat(orchestrator): implement task extraction functionality

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -136,6 +136,11 @@ export function shouldUseOrchestrator(_context: ParsedGitHubContext): boolean {
   return true;
 }
 
+export function extractTaskFromComment(_context: ParsedGitHubContext): string {
+  // TODO: Implement task extraction logic
+  return "";
+}
+
 export async function checkTriggerAction(context: ParsedGitHubContext) {
   const containsTrigger = checkContainsTrigger(context);
   core.setOutput("contains_trigger", containsTrigger.toString());

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -140,7 +140,10 @@ export function extractTaskFromComment(context: ParsedGitHubContext): string {
   let commentBody = "";
 
   // Extract comment body based on event type
-  if (isIssueCommentEvent(context) || isPullRequestReviewCommentEvent(context)) {
+  if (
+    isIssueCommentEvent(context) ||
+    isPullRequestReviewCommentEvent(context)
+  ) {
     commentBody = context.payload.comment.body;
   } else if (isPullRequestReviewEvent(context)) {
     commentBody = context.payload.review.body || "";

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -158,7 +158,7 @@ export function extractTaskFromComment(context: ParsedGitHubContext): string {
   const regex = new RegExp(`${escapeRegExp(triggerPhrase)}\\s*(.+)`, "is");
   const match = commentBody.match(regex);
 
-  return match ? match[1].trim() : "";
+  return match && match[1] ? match[1].trim() : "";
 }
 
 export async function checkTriggerAction(context: ParsedGitHubContext) {

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -136,9 +136,26 @@ export function shouldUseOrchestrator(_context: ParsedGitHubContext): boolean {
   return true;
 }
 
-export function extractTaskFromComment(_context: ParsedGitHubContext): string {
-  // TODO: Implement task extraction logic
-  return "";
+export function extractTaskFromComment(context: ParsedGitHubContext): string {
+  let commentBody = "";
+
+  // Extract comment body based on event type
+  if (isIssueCommentEvent(context) || isPullRequestReviewCommentEvent(context)) {
+    commentBody = context.payload.comment.body;
+  } else if (isPullRequestReviewEvent(context)) {
+    commentBody = context.payload.review.body || "";
+  } else if (isIssuesEvent(context)) {
+    commentBody = context.payload.issue.body || "";
+  } else if (isPullRequestEvent(context)) {
+    commentBody = context.payload.pull_request.body || "";
+  }
+
+  // Extract task from comment body
+  const triggerPhrase = context.inputs.triggerPhrase || "@claude";
+  const regex = new RegExp(`${escapeRegExp(triggerPhrase)}\\s*(.+)`, "is");
+  const match = commentBody.match(regex);
+
+  return match ? match[1].trim() : "";
 }
 
 export async function checkTriggerAction(context: ParsedGitHubContext) {

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -452,7 +452,9 @@ describe("extractTaskFromComment", () => {
         issue: { number: 1 },
       } as IssueCommentEvent,
     });
-    expect(extractTaskFromComment(context)).toBe("Fix the bug in the login form");
+    expect(extractTaskFromComment(context)).toBe(
+      "Fix the bug in the login form",
+    );
   });
 
   it("should return empty string for comment without trigger phrase", () => {

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -1,6 +1,7 @@
 import {
   checkContainsTrigger,
   escapeRegExp,
+  extractTaskFromComment,
 } from "../src/github/validation/trigger";
 import { describe, it, expect } from "bun:test";
 import {
@@ -427,5 +428,76 @@ describe("escapeRegExp", () => {
   it("should handle mixed characters", () => {
     expect(escapeRegExp("hello.world")).toBe("hello\\.world");
     expect(escapeRegExp("test[123]")).toBe("test\\[123\\]");
+  });
+});
+
+describe("extractTaskFromComment", () => {
+  it("should extract task from issue comment", () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      eventAction: "created",
+      inputs: {
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        directPrompt: "",
+        allowedTools: "",
+        disallowedTools: "",
+        customInstructions: "",
+      },
+      payload: {
+        action: "created",
+        comment: {
+          body: "@claude Fix the bug in the login form",
+        },
+        issue: { number: 1 },
+      } as IssueCommentEvent,
+    });
+    expect(extractTaskFromComment(context)).toBe("Fix the bug in the login form");
+  });
+
+  it("should return empty string for comment without trigger phrase", () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      eventAction: "created",
+      inputs: {
+        triggerPhrase: "@claude",
+        assigneeTrigger: "",
+        directPrompt: "",
+        allowedTools: "",
+        disallowedTools: "",
+        customInstructions: "",
+      },
+      payload: {
+        action: "created",
+        comment: {
+          body: "This is a regular comment",
+        },
+        issue: { number: 1 },
+      } as IssueCommentEvent,
+    });
+    expect(extractTaskFromComment(context)).toBe("");
+  });
+
+  it("should handle custom trigger phrase", () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      eventAction: "created",
+      inputs: {
+        triggerPhrase: "/claude",
+        assigneeTrigger: "",
+        directPrompt: "",
+        allowedTools: "",
+        disallowedTools: "",
+        customInstructions: "",
+      },
+      payload: {
+        action: "created",
+        comment: {
+          body: "/claude Update the documentation",
+        },
+        issue: { number: 1 },
+      } as IssueCommentEvent,
+    });
+    expect(extractTaskFromComment(context)).toBe("Update the documentation");
   });
 });


### PR DESCRIPTION
## Summary
- extractTaskFromComment関数を実装（@claudeコメントからタスクテキストを抽出）
- イベントタイプ別のコメント本文取得ロジック
- 正規表現によるタスク抽出とテストケース追加

## Test plan
- [x] 型チェック通過
- [x] タスク抽出テスト追加・パス
- [x] 既存テスト全てパス

🤖 Generated with [Claude Code](https://claude.ai/code)